### PR TITLE
#42 PyFITS in SCons

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -267,6 +267,10 @@ Macports is another popular Mac package management project with similar function
 
 sudo port install boost +python27
 
+Note: You will still need to install numpy and pyfits manually, since the fink installations
+use /sw/bin/python2.6 (or similar) rather than the normal command line python, which is normally 
+/usr/bin/python.  
+
 
 b) The Enthought Python Distribution (EPD) is a single-install package that provides Python, Numpy,
 and SCons, along with many other useful Python modules in a well-maintined single framework.  It 

--- a/SConstruct
+++ b/SConstruct
@@ -663,11 +663,12 @@ int main()
         context.Result(0)
         print 'Failed to import numpy.'
         print 'Things to try:'
-        print '1) Check that the command line python (with which you probably installed numpy):'
+        print '1) Check that the python with which you installed numpy,'
+        print '   probably the command line python:'
         print '   ',
         sys.stdout.flush()
         subprocess.call('which python',shell=True)
-        print '  is the same as the one used by SCons:'
+        print '   is the same as the one used by SCons:'
         print '  ',sys.executable
         print '   If not, then you probably need to reinstall numpy with %s.' % sys.executable
         print '   And remember to use that when running python for use with GalSim.'
@@ -699,11 +700,12 @@ def CheckPyFITS(context):
         context.Result(0)
         print 'Failed to import PyFITS.'
         print 'Things to try:'
-        print '1) Check that the command line python (with which you probably installed PyFITS):'
+        print '1) Check that the python with which you installed PyFITS,'
+        print '   probably the command line python:'
         print '   ',
         sys.stdout.flush()
         subprocess.call('which python',shell=True)
-        print '  is the same as the one used by SCons:'
+        print '   is the same as the one used by SCons:'
         print '  ',sys.executable
         print '   If not, then you probably need to reinstall PyFITS with %s.' % sys.executable
         print '   And remember to use that when running python for use with GalSim.'


### PR DESCRIPTION
We've added PyFITS as a dependency at the SCons level, and scons now checks that 

```
import pyfits
```

works in Python, in the same way as it does for `import numpy`.  Mike tidied up the error message a little bit, and made necessary mods to the INSTALL doc.
