### PR TITLE
Doxy-fied the integ package (#47)

### DIFF
--- a/include/galsim/integ/Int.h
+++ b/include/galsim/integ/Int.h
@@ -1,3 +1,128 @@
+
+/** 
+ * @file Int.h
+ *
+ * @brief A set of functions for doing integrals of functions which can be evaluated at 
+ *        arbitrary integrands.  
+ *        Uses an adaptive Gauss-Kronrod-Patterson algorithm.
+ *
+ *
+ * Basic Usage:
+ * 
+ *     First, define a function object, which should derive from 
+ *     std::unary_function<double,double>.  For example, to integrate a
+ *     Gaussian, use something along the lines of this:
+ * 
+ *     class Gauss :
+ *         public std::unary_function<double,double>
+ *     {   
+ *     public :
+ *     
+ *         Gauss(double _mu, double _sig) :   
+ *             mu(_mu), sig(_sig), sigsq(_sig*_sig) {}
+ *     
+ *         double operator()(double x) const
+ *         {
+ *             const double SQRTTWOPI = 2.50662827463;
+ *             return exp(-pow(x-mu,2)/2./sigsq)/SQRTTWOPI/sig;
+ *         }
+ *     
+ *       private :
+ *           double mu,sig,sigsq;
+ *     };
+ * 
+ * 
+ *     Then to perform an integral, over the range (min ... max) you would write:
+ * 
+ *     double integ1 = integ::int1d(Gauss(mu,sigma),min,max);
+ * 
+ *     e.g. integ::int1d(Gauss(0.,1.),0.,1.)
+ * 
+ *     should yield a value of 0.68.
+ * 
+ *     If either min or max are > 1.e10 or < -1.e10, then these values are taken to be
+ *     infinity / -infinity, rather than the actual value.  
+ *     So to integrate from 0 to infinity:
+ * 
+ *     double integ2 = integ::int1d(Gauss(0.,2.),0.,1.e100);
+ * 
+ *     which should yield a value of 0.5.  Or, you can also use the variable integ::MOCK_INF, 
+ *     which might be clearer.
+ * 
+ *     There are two final arguments, which we've omitted so far, that can be used to specify
+ *     the precision required.  First the relative error, then the absolute error.
+ *     The defaults are 1.e-6 and 1.e-15 respectively, which are generally fine for most
+ *     purposes, but you can specify different values if you prefer.
+ * 
+ *     The absolute error only comes into play for results which are close to 
+ *     0 to prevent requiring an error of 0 for integrals which evaluate to 0 
+ *     or very close to it.
+ * 
+ * 
+ * 
+ * Advanced Usage:
+ *
+ *     Sometimes it is useful to provide more information into how to split up a region
+ *     when the GKP algorithm fails to converge on the whole region.  To do this,
+ *     we need to start by making an IntRegion object.  e.g. the above integ1 integral
+ *     could use:
+ *
+ *     integ::IntRegion reg1(0.,1.);
+ *
+ *     And the above call could instead be called as:
+ *
+ *     int1d(Gauss(0.,1.), reg1);
+ *
+ *     For that integral, there is nothing weird going on, so the default works fine.
+ *     But when an integration fails to converge with the usual GKP algorithm,
+ *     it splits the region into 2 (or more) and tries again with each sub-region.
+ *     The default is to just bisect the region (or something similarly smart for
+ *     infinite regions), but if you know of a good place to split the region,
+ *     you can tell it using the method addSplit(x).
+ *     For example, if your integral has a singularity at 1/3, then it would help the 
+ *     program a lot to split there, so you can add a split point:
+ *
+ *     reg1.addSplit(1./3.);
+ *
+ *     Zeros of the integrand can also be good choices for splitting.
+ *
+ *     In addition to the integral being returned from int1d, int2d, or int3d as
+ *     the return value, the value is also stored in the region itself. 
+ *     You can access it using:
+ *
+ *     reg.getArea();
+ *
+ *     There is also an estimate of the error in the value:
+ *
+ *     reg.getErr();
+ *
+ *     (It is intended to be an overestimate of the actual error, 
+ *     but it doesn't always get it completely right.)
+ *
+ *
+ *
+ * Two- and Three-Dimensional Integrals:
+ *
+ *     These are slightly more complicated.  The easiest case is when the
+ *     bounds of the integral are a rectangle or 3d box.  In this case,
+ *     you can still use the regular IntRegion.  The only new thing then
+ *     is the definition of the function.  For example, to integrate 
+ *     int(3x^2 + xy + y , x=0..1, y=0..1):
+ *
+ *     struct Integrand :
+ *         public std::binary_function<double,double,double>
+ *     {
+ *         double operator()(double x, double y) const { return x*(3.*x + y) + y; }
+ *     };
+ *
+ *     integ::IntRegion<double> reg3(0.,1.);
+ *     double integ3 = int2d(Integrand(),reg3,reg3);
+ *
+ *     (Which should give 1.75 as the result.)
+ *
+ */
+
+
 #ifndef INT_H
 #define INT_H
 
@@ -16,128 +141,15 @@
 
 #include "MoreFunctional.h"
 #include "IntGKPData10.h"
-
-// Basic Usage:
-//
-// First, define a function object, which should derive from 
-// std::unary_function<double,double>.  For example, to integrate a
-// Gaussian, use something along the lines of this:
-//
-// class Gauss :
-//     public std::unary_function<double,double>
-// {   
-// public :
-// 
-//     Gauss(double _mu, double _sig) :   
-//         mu(_mu), sig(_sig), sigsq(_sig*_sig) {}
-// 
-//     double operator()(double x) const
-//     {
-//         const double SQRTTWOPI = 2.50662827463;
-//         return exp(-pow(x-mu,2)/2./sigsq)/SQRTTWOPI/sig;
-//     }
-// 
-//   private :
-//       double mu,sig,sigsq;
-// };
-//
-//
-// Then to perform an integral, over the range (min ... max) you would write:
-//
-// double integ1 = integ::int1d(Gauss(mu,sigma),min,max);
-//
-// e.g. integ::int1d(Gauss(0.,1.),0.,1.)
-//
-// should yield a value of 0.68.
-//
-// If either min or max are > 1.e10 or < -1.e10, then these values are taken to be
-// infinity / -infinity, rather than the actual value.  
-// So to integrate from 0 to infinity:
-//
-// double integ2 = integ::int1d(Gauss(0.,2.),0.,1.e100);
-//
-// which should yield a value of 0.5.  Or, you can also use the variable integ::MOCK_INF, 
-// which might be clearer.
-//
-// There are two final arguments, which we've omitted so far, that can be used to specify
-// the precision required.  First the relative error, then the absolute error.
-// The defaults are 1.e-6 and 1.e-15 respectively, which are generally fine for most
-// purposes, but you can specify different values if you prefer.
-//
-// The absolute error only comes into play for results which are close to 
-// 0 to prevent requiring an error of 0 for integrals which evaluate to 0 
-// or very close to it.
-//
-//
-//
-// Advanced Usage:
-//
-// Sometimes it is useful to provide more information into how to split up a region
-// when the GKP algorithm fails to converge on the whole region.  To do this,
-// we need to start by making an IntRegion object.  e.g. the above integ1 integral
-// could use:
-//
-// integ::IntRegion reg1(0.,1.);
-//
-// And the above call could instead be called as:
-//
-// int1d(Gauss(0.,1.), reg1);
-//
-// For that integral, there is nothing weird going on, so the default works fine.
-// But when an integration fails to converge with the usual GKP algorithm,
-// it splits the region into 2 (or more) and tries again with each sub-region.
-// The default is to just bisect the region (or something similarly smart for
-// infinite regions), but if you know of a good place to split the region,
-// you can tell it using the method addSplit(x).
-// For example, if your integral has a singularity at 1/3, then it would help the 
-// program a lot to split there, so you can add a split point:
-//
-// reg1.addSplit(1./3.);
-//
-// Zeros of the integrand can also be good choices for splitting.
-//
-// In addition to the integral being returned from int1d, int2d, or int3d as
-// the return value, the value is also stored in the region itself. 
-// You can access it using:
-//
-// reg.Area();
-//
-// There is also an estimate of the error in the value:
-//
-// reg.Err();
-//
-// (It is intended to be an overestimate of the actual error, 
-// but it doesn't always get it completely right.)
-//
-//
-// 
-// Two- and Three-Dimensional Integrals:
-//
-// These are slightly more complicated.  The easiest case is when the
-// bounds of the integral are a rectangle or 3d box.  In this case,
-// you can still use the regular IntRegion.  The only new thing then
-// is the definition of the function.  For example, to integrate 
-// int(3x^2 + xy + y , x=0..1, y=0..1):
-//
-// struct Integrand :
-//     public std::binary_function<double,double,double>
-// {
-//     double operator()(double x, double y) const { return x*(3.*x + y) + y; }
-// };
-//
-// integ::IntRegion<double> reg3(0.,1.);
-// double integ3 = int2d(Integrand(),reg3,reg3);
-//
-// (Which should give 1.75 as the result.)
-// 
-//
-//
-
 namespace galsim {
 namespace integ {
 
-    const double MOCK_INF = 1.e10;
+    const double MOCK_INF = 1.e100;  ///< May be used to indicate infinity in integration regions.
+    const double DEFRELERR = 1.e-6;  ///< The default target relative error if not specified.
+    const double DEFABSERR = 1.e-15; ///< The default target absolute error if not specified.
 
+
+    /// An exception type thrown if the integrator encounters a problem.
     struct IntFailure : public std::runtime_error
     {
         IntFailure(const std::string& s) : 
@@ -155,35 +167,60 @@ namespace integ {
 #define integ_dbg3 if (tempreg.dbgout) (*tempreg.dbgout)
 #endif
 
-    template <class T> 
-    inline T norm(const T& x) { return x*x; }
-    using std::norm;
-    template <class T> 
-    inline T real(const T& x) { return x; }
-    using std::real;
-
-    //#define COUNTFEVAL 
-    // If defined, then count the number of function evaluations
-
 #ifdef COUNTFEVAL
-    int nfeval = 0;
+    int nfeval = 0;  ///< If COUNTFEVAL is defined, this counts the number of function evaluations
 #endif
 
+    /**
+     * @brief A type that encapsulates everything known about the integral in a region.
+     *
+     * The constructor of IntRegion takes the minimum and maximum values for the region,
+     * along with an optional ostream for outputing diagnostic information.
+     *
+     * After the integration is done, the IntRegion will also hold the estimate of the 
+     * integral's value over the region, along with an estimate of the error.
+     */
     template <class T> 
     struct IntRegion 
     {
 
     public:
-        IntRegion(const T _a, const T _b, std::ostream* _dbgout=0) :
+        /**
+         * @brief Constructor taking the bounds of the region and (optionally) 
+         *        an ostream for outputing diagnostic information.
+         *
+         * Note that normally a < b.  However, a > b is also valid.
+         * If a > b, then the integral will be from right to left, which is just
+         * the negative of the integral from b to a.
+         */
+        IntRegion(
+            const T _a,  ///< The left end of the region
+            const T _b,  ///< The right end of the region
+            std::ostream* _dbgout=0  ///< An optional ostream for diagnostic info
+        ) :
             a(_a), b(_b), error(0.), area(0), dbgout(_dbgout) {}
+
+
+        /// op< sorts by the error estimate
         bool operator<(const IntRegion<T>& r2) const 
         { return error < r2.error; }
+
+        /// op> sorts by the error estimate
         bool operator>(const IntRegion<T>& r2) const 
         { return error > r2.error; }
-        void SubDivide(std::vector<IntRegion<T> >* children) 
+
+        /** 
+         * @brief Subdivide a region according to the current split points or biset
+         *
+         * If there are no split points set yet, then this will bisect the region.
+         * However, you may also set split points using addSplit(x). 
+         * This is worth doing if you know about any discontinuities, zeros or poles 
+         * in the function you are integrating.
+         */
+        void subDivide(std::vector<IntRegion<T> >* children) 
         {
             assert(children->size() == 0);
-            if (splitpoints.size() == 0) Bisect();
+            if (splitpoints.size() == 0) bisect();
             if (splitpoints.size() > 1) 
                 std::sort(splitpoints.begin(),splitpoints.end());
 
@@ -205,15 +242,35 @@ namespace integ {
             }
             children->push_back(IntRegion<T>(splitpoints.back(),b,dbgout));
         }
-        void Bisect() { splitpoints.push_back((a+b)/2.); }
-        void AddSplit(const T x) { splitpoints.push_back(x); }
-        size_t NSplit() const { return splitpoints.size(); }
 
-        const T& Left() const { return a; }
-        const T& Right() const { return b; }
-        const T& Err() const { return error; }
-        const T& Area() const { return area; }
-        void SetArea(const T& a, const T& e) { area = a; error = e; }
+        /// Set a split point at the bisection
+        void bisect() { splitpoints.push_back((a+b)/2.); }
+
+        /**
+         * @brief Add a split point to the current list to be used by the next subDivide call
+         *
+         * This is worth doing if you know about any discontinuities, zeros or poles 
+         * in the function you are integrating.
+         */
+        void addSplit(const T x) { splitpoints.push_back(x); }
+
+        /// Get the number of split points currently set.
+        size_t getNSplit() const { return splitpoints.size(); }
+
+        /// Get the left end of the region
+        const T& left() const { return a; }
+
+        /// Get the right end of the region
+        const T& right() const { return b; }
+
+        /// Get the current error estimate
+        const T& getErr() const { return error; }
+
+        /// Get the current estimate of the integral over the region
+        const T& getArea() const { return area; }
+
+        /// Set a new estimate of the area and error
+        void setArea(const T& a, const T& e) { area = a; error = e; }
 
     private:
         T a,b,error,area;
@@ -223,54 +280,62 @@ namespace integ {
         std::ostream* dbgout;
     };
 
+    /// Rescale the error if int |f| dx or int |f-mean| dx are too large
     template <class T> 
-    inline T Epsilon() 
-    { return std::numeric_limits<T>::epsilon(); }
-    template <class T> 
-    inline T MinRep() 
-    { return std::numeric_limits<T>::min(); }
-
-    template <class T> 
-    inline T rescale_error (T err, const T& resabs, const T& resasc)
+    inline T rescaleError(
+        T err, ///< The current estimate of the error
+        const T& int_abs,     ///< An estimate of int |f| dx
+        const T& int_absdiff ///< An estimate of int |f-mean| dx
+    )
     {
-        if (resasc != 0. && err != 0.) {
-            const T scale = (200. * err / resasc);
-            if (scale < 1.) err = resasc * scale * sqrt(scale) ;
-            else err = resasc ;
+        const int eps = std::numeric_limits<T>::epsilon();
+        const int minrep = std::numeric_limits<T>::min();
+
+        if (int_absdiff != 0. && err != 0.) {
+            const T scale = (200. * err / int_absdiff);
+            if (scale < 1.) err = int_absdiff * scale * sqrt(scale) ;
+            else err = int_absdiff ;
         }
-        if (resabs > MinRep<T>() / (50. * Epsilon<T>())) {
-            const T min_err = 50. * Epsilon<T>() * resabs;
+        if (int_abs > minrep / (50. * eps)) {
+            const T min_err = 50. * eps * int_abs;
             if (min_err > err) err = min_err;
         }
         return err;
     }
 
+    /**
+     * @brief Non-adaptive GKP integration
+     *
+     * A non-adaptive integration of the function f over the region reg.
+     *
+     * The algorithm computes first a Gaussian quadrature value
+     * then successive Kronrod/Patterson extensions to this result.
+     * The functions terminates when the difference between successive
+     * approximations (rescaled according to rescaleError) is less than 
+     * either abserr or relerr * I, where I is the latest estimate of the 
+     * integral.
+     *
+     * The order of the Gauss/Kronron/Patterson scheme is determined
+     * by which file is included above.  Currently schemes starting 
+     * with order 1 and order 10 are calculated.  There seems to be 
+     * little practical difference in the integration times using 
+     * the two schemes, so I haven't bothered to calculate any more.
+     */
     template <class UF> 
-    inline bool IntGKPNA(
-        const UF& func, IntRegion<typename UF::result_type>& reg,
-        const typename UF::result_type epsrel, 
-        const typename UF::result_type epsabs,
-        std::map<typename UF::result_type,
-        typename UF::result_type>* fxmap=0)
+    inline bool intGKPNA(
+        const UF& func, ///< The function to integrate
+        IntRegion<typename UF::result_type>& reg, ///< The region with the bounds
+        const typename UF::result_type relerr,  ///< The target relative error
+        const typename UF::result_type abserr,  ///< The target absolute error
+        std::map<typename UF::result_type,typename UF::result_type>* fxmap=0 ///< Known results
+    )
     {
-        // A non-adaptive integration of the function f over the region reg.
-        // The algorithm computes first a Gaussian quadrature value
-        // then successive Kronrod/Patterson extensions to this result.
-        // The functions terminates when the difference between successive
-        // approximations (rescaled according to rescale_error) is less than 
-        // either epsabs or epsrel * I, where I is the latest estimate of the 
-        // integral.
-        // The order of the Gauss/Kronron/Patterson scheme is determined
-        // by which file is included above.  Currently schemes starting 
-        // with order 1 and order 10 are calculated.  There seems to be 
-        // little practical difference in the integration times using 
-        // the two schemes, so I haven't bothered to calculate any more.
         typedef typename UF::result_type T;
-        const T a = reg.Left();
-        const T b = reg.Right();
+        const T a = reg.left();
+        const T b = reg.right();
 
         const T half_length =  0.5 * (b - a);
-        const T abs_half_length = fabs (half_length);
+        const T abs_half_length = std::abs(half_length);
         const T center = 0.5 * (b + a);
         const T f_center = func(center);
 #ifdef COUNTFEVAL
@@ -301,20 +366,20 @@ namespace integ {
         integ_dbg2<<"level 0 rule: area = "<<area1<<std::endl;
 
         T err=0; 
-        bool calcabsasc = true;
-        T resabs=0., resasc=0.;
+        bool calc_int_abs = true;
+        T int_abs=0., int_absdiff=0.;
         for (int level=1; level<NGKPLEVELS; level++) {
             assert(gkp_wa<T>(level).size() == fv1.size());
             assert(gkp_wa<T>(level).size() == fv2.size());
             assert(gkp_wb<T>(level).size() == gkp_x<T>(level).size()+1);
             T area2 = gkp_wb<T>(level).back() * f_center;
-            // resabs = approximation to integral of abs(f)
-            if (calcabsasc) resabs = fabs(area2);
+            // int_abs = approximation to integral of abs(f)
+            if (calc_int_abs) int_abs = std::abs(area2);
             for (size_t k=0; k<fv1.size(); k++) {
                 area2 += gkp_wa<T>(level)[k] * (fv1[k]+fv2[k]);
-                if (calcabsasc) 
-                    resabs += gkp_wa<T>(level)[k] *
-                        (fabs(fv1[k]) + fabs(fv2[k]));
+                if (calc_int_abs) 
+                    int_abs += gkp_wa<T>(level)[k] *
+                        (std::abs(fv1[k]) + std::abs(fv2[k]));
             }
             for (size_t k=0; k<gkp_x<T>(level).size(); k++) {
                 const T abscissa = half_length * gkp_x<T>(level)[k];
@@ -322,8 +387,8 @@ namespace integ {
                 const T fval2 = func(center + abscissa);
                 const T fval = fval1 + fval2;
                 area2 += gkp_wb<T>(level)[k] * fval;
-                if (calcabsasc) 
-                    resabs += gkp_wb<T>(level)[k] * (fabs(fval1) + fabs(fval2));
+                if (calc_int_abs) 
+                    int_abs += gkp_wb<T>(level)[k] * (std::abs(fval1) + std::abs(fval2));
                 fv1.push_back(fval1);
                 fv2.push_back(fval2);
                 if (fxmap) {
@@ -334,89 +399,102 @@ namespace integ {
 #ifdef COUNTFEVAL
             nfeval+=gkp_x<T>(level).size()*2;
 #endif
-            if (calcabsasc) {
+            if (calc_int_abs) {
                 const T mean = area1*T(0.5);
-                // resasc = approximation to the integral of abs(f-mean) 
-                resasc = gkp_wb<T>(level).back() * fabs(f_center-mean);
+                // int_absdiff = approximation to the integral of abs(f-mean) 
+                int_absdiff = gkp_wb<T>(level).back() * std::abs(f_center-mean);
                 for (size_t k=0; k<gkp_wa<T>(level).size(); k++) {
-                    resasc += gkp_wa<T>(level)[k] * 
-                        (fabs(fv1[k]-mean) + fabs(fv2[k]-mean));
+                    int_absdiff += gkp_wa<T>(level)[k] * 
+                        (std::abs(fv1[k]-mean) + std::abs(fv2[k]-mean));
                 }
                 for (size_t k=0; k<gkp_x<T>(level).size(); k++) {
-                    resasc += gkp_wb<T>(level)[k] * 
-                        (fabs(fv1[k]-mean) + fabs(fv2[k]-mean));
+                    int_absdiff += gkp_wb<T>(level)[k] * 
+                        (std::abs(fv1[k]-mean) + std::abs(fv2[k]-mean));
                 }
-                resasc *= abs_half_length ;
-                resabs *= abs_half_length;
+                int_absdiff *= abs_half_length ;
+                int_abs *= abs_half_length;
             }
             area2 *= half_length;
-            err = rescale_error (fabs(area2-area1), resabs, resasc) ;
-            if (err < resasc) calcabsasc = false;
+            err = rescaleError(std::abs(area2-area1), int_abs, int_absdiff) ;
+            if (err < int_absdiff) calc_int_abs = false;
 
             integ_dbg2<<"at level "<<level<<" area2 = "<<area2;
             integ_dbg2<<" +- "<<err<<std::endl;
 
-            //   test for convergence.
-            if (err < epsabs || err < epsrel * fabs (area2)) {
-                reg.SetArea(area2,err);
+            //  Test for convergence.
+            if (err < abserr || err < relerr * std::abs(area2)) {
+                // Converged.  Return current estimate.
+                reg.setArea(area2,err);
                 return true;
             }
             area1 = area2;
         }
 
-        // failed to converge 
-        reg.SetArea(area1,err);
+        // Failed to converge.  Return with current estimate of area and error
+        reg.setArea(area1,err);
 
         integ_dbg2<<"Failed to reach tolerance with highest-order GKP rule";
 
         return false;
     }
 
+    /**
+     * @brief Adaptive GKP integration
+     *
+     * An adaptive integration algorithm which computes the integral of f
+     * over the region reg.
+     *
+     * First the non-adaptive GKP algorithm is tried.
+     *
+     * If that is not accurate enough (according to the absolute and
+     * relative accuracies, abserr and relerr), the region is split in half, 
+     * and each new region is integrated.
+     *
+     * The routine continues by successively splitting the subregion
+     * which gave the largest absolute error until the integral converges.
+     *
+     * The area and estimated error are returned as reg.getArea() and reg.getErr()
+     *
+     * If desired, *fxmap returns a std::map of x,f(x) values that were calculated
+     * during the integration process.
+     */
     template <class UF> 
-    inline void IntGKP(
+    inline void intGKP(
         const UF& func, IntRegion<typename UF::result_type>& reg,
-        const typename UF::result_type epsrel,
-        const typename UF::result_type epsabs,
+        const typename UF::result_type relerr,
+        const typename UF::result_type abserr,
         std::map<typename UF::result_type,
         typename UF::result_type>* fxmap=0)
     {
-        // An adaptive integration algorithm which computes the integral of f
-        // over the region reg.
-        // First the non-adaptive GKP algorithm is tried.
-        // If that is not accurate enough (according to the absolute and
-        // relative accuracies, epsabs and epsrel),
-        // the region is split in half, and each new region is integrated.
-        // The routine continues by successively splitting the subregion
-        // which gave the largest absolute error until the integral converges.
-        //
-        // The area and estimated error are returned as reg.Area() and reg.Err()
-        // If desired, *retx and *retf return std::vectors of x,f(x) 
-        // respectively
-        // They only include the evaluations in the non-adaptive pass, so they
-        // do not give an accurate estimate of the number of function 
-        // evaluations.
         typedef typename UF::result_type T;
-        integ_dbg2<<"Start IntGKP\n";
+        const int eps = std::numeric_limits<T>::epsilon();
 
-        assert(epsabs >= 0.);
-        assert(epsrel > 0.);
+        integ_dbg2<<"Start intGKP\n";
 
-        // perform the first integration 
-        bool done = IntGKPNA(func, reg, epsrel, epsabs, fxmap);
+        assert(abserr >= 0.);
+        assert(relerr > 0.);
+
+        // Perform the first integration 
+        bool done = intGKPNA(func, reg, relerr, abserr, fxmap);
         if (done) return;
 
         integ_dbg2<<"In adaptive GKP, failed first pass... subdividing\n";
-        integ_dbg2<<"Intial range = "<<reg.Left()<<".."<<reg.Right()<<std::endl;
+        integ_dbg2<<"Intial range = "<<reg.left()<<".."<<reg.right()<<std::endl;
 
         int roundoff_type1 = 0, error_type = 0;
         T roundoff_type2 = 0.;
         size_t iteration = 1;
 
+        // Keep track of all subdivision in a priority_queue.  
+        // The top() is always the largest value, and pop() removes it.
+        // We define < and > for IntRegoins such that the "largest" is the one 
+        // with the largest current error estimate.  This is the next one to be split 
+        // if we need to split further.
         std::priority_queue<IntRegion<T>,std::vector<IntRegion<T> > > allregions;
         allregions.push(reg);
-        T finalarea = reg.Area();
-        T finalerr = reg.Err();
-        T tolerance= std::max(epsabs, epsrel * fabs(finalarea));
+        T finalarea = reg.getArea();
+        T finalerr = reg.getErr();
+        T tolerance= std::max(abserr, relerr * std::abs(finalarea));
         assert(finalerr > tolerance);
 
         while(!error_type && finalerr > tolerance) {
@@ -426,64 +504,64 @@ namespace integ {
             IntRegion<T> parent = allregions.top(); 
             allregions.pop();
             integ_dbg2<<"Subdividing largest error region ";
-            integ_dbg2<<parent.Left()<<".."<<parent.Right()<<std::endl;
-            integ_dbg2<<"parent area = "<<parent.Area();
-            integ_dbg2<<" +- "<<parent.Err()<<std::endl;
+            integ_dbg2<<parent.left()<<".."<<parent.right()<<std::endl;
+            integ_dbg2<<"parent area = "<<parent.getArea();
+            integ_dbg2<<" +- "<<parent.getErr()<<std::endl;
             std::vector<IntRegion<T> > children;
-            parent.SubDivide(&children);
+            parent.subDivide(&children);
             // For "GKP", there are only two, but for GKPOSC, there is one 
             // for each oscillation in region
 
             // Try to do at least 3x better with the children
             T factor = 3*children.size()*finalerr/tolerance;
-            T newepsabs = fabs(parent.Err()/factor);
-            T newepsrel = newepsabs/fabs(parent.Area());
-            integ_dbg2<<"New epsabs,rel = "<<newepsabs<<','<<newepsrel;
+            T newabserr = std::abs(parent.getErr()/factor);
+            T newrelerr = newabserr/std::abs(parent.getArea());
+            integ_dbg2<<"New abserr,rel = "<<newabserr<<','<<newrelerr;
             integ_dbg2<<"  ("<<children.size()<<" children)\n";
 
             T newarea = T(0.0);
             T newerror = 0.0;
             for(size_t i=0;i<children.size();i++) {
                 IntRegion<T>& child = children[i];
-                integ_dbg2<<"Integrating child "<<child.Left();
-                integ_dbg2<<".."<<child.Right()<<std::endl;
+                integ_dbg2<<"Integrating child "<<child.left();
+                integ_dbg2<<".."<<child.right()<<std::endl;
                 bool converged;
-                converged = IntGKPNA(func, child, newepsrel, newepsabs);
+                converged = intGKPNA(func, child, newrelerr, newabserr);
                 integ_dbg2<<"child ("<<i+1<<'/'<<children.size()<<") ";
                 if (converged) {
                     integ_dbg2<<" converged."; 
                 } else {
                     integ_dbg2<<" failed.";
                 }
-                integ_dbg2<<"  Area = "<<child.Area()<<
-                    " +- "<<child.Err()<<std::endl;
+                integ_dbg2<<"  Area = "<<child.getArea()<<
+                    " +- "<<child.getErr()<<std::endl;
 
-                newarea += child.Area();
-                newerror += child.Err();
+                newarea += child.getArea();
+                newerror += child.getErr();
             }
             integ_dbg2<<"Compare: newerr = "<<newerror;
-            integ_dbg2<<" to parent err = "<<parent.Err()<<std::endl;
+            integ_dbg2<<" to parent err = "<<parent.getErr()<<std::endl;
 
-            finalerr += (newerror - parent.Err());
-            finalarea += newarea - parent.Area();
+            finalerr += (newerror - parent.getErr());
+            finalarea += newarea - parent.getArea();
 
-            T delta = parent.Area() - newarea;
-            if (newerror <= parent.Err() && fabs (delta) <=  parent.Err()
-                && newerror >= 0.99 * parent.Err()) {
+            T delta = parent.getArea() - newarea;
+            if (newerror <= parent.getErr() && std::abs(delta) <= parent.getErr()
+                && newerror >= 0.99 * parent.getErr()) {
                 integ_dbg2<<"roundoff type 1: delta/newarea = ";
-                integ_dbg2<<fabs(delta)/fabs(newarea);
+                integ_dbg2<<std::abs(delta)/std::abs(newarea);
                 integ_dbg2<<", newerror/error = "<<
-                    newerror/parent.Err()<<std::endl;
+                    newerror/parent.getErr()<<std::endl;
                 roundoff_type1++;
             }
-            if (iteration >= 10 && newerror > parent.Err() && 
-                fabs(delta) <= newerror-parent.Err()) {
+            if (iteration >= 10 && newerror > parent.getErr() && 
+                std::abs(delta) <= newerror-parent.getErr()) {
                 integ_dbg2<<"roundoff type 2: newerror/error = ";
-                integ_dbg2<<newerror/parent.Err()<<std::endl;
-                roundoff_type2+=std::min(newerror/parent.Err()-1.,T(1.));
+                integ_dbg2<<newerror/parent.getErr()<<std::endl;
+                roundoff_type2+=std::min(newerror/parent.getErr()-1.,T(1.));
             }
 
-            tolerance = std::max(epsabs, epsrel * fabs(finalarea));
+            tolerance = std::max(abserr, relerr * std::abs(finalarea));
             if (finalerr > tolerance) {
                 if (roundoff_type1 >= 200) {
                     error_type = 1;	// round off error 
@@ -493,9 +571,9 @@ namespace integ {
                     error_type = 2;	// round off error 
                     integ_dbg2<<"GKP: Round off error 2\n";
                 }
-                const double parent_size = parent.Right()-parent.Left();
-                const double reg_size = reg.Right()-parent.Left();
-                if (fabs(parent_size / reg_size) < Epsilon<double>()) {
+                const double parent_size = parent.right()-parent.left();
+                const double reg_size = reg.right()-parent.left();
+                if (std::abs(parent_size / reg_size) < eps) {
                     error_type = 3; // found singularity
                     integ_dbg2<<"GKP: Probable singularity\n";
                 }
@@ -508,36 +586,33 @@ namespace integ {
         finalarea=0.; finalerr=0.;
         while (!allregions.empty()) {
             const IntRegion<T>& r=allregions.top();
-            finalarea += r.Area();
-            finalerr += r.Err();
+            finalarea += r.getArea();
+            finalerr += r.getErr();
             allregions.pop();
         }
-        reg.SetArea(finalarea,finalerr);
+        reg.setArea(finalarea,finalerr);
 
         if (error_type == 1) {
             std::ostringstream s;
             s << "Type 1 roundoff's = "<<roundoff_type1;
             s << ", Type 2 = "<<roundoff_type2<<std::endl;
             s << "Roundoff error 1 prevents tolerance from being achieved ";
-            s << "in IntGKP\n";
+            s << "in intGKP\n";
             throw IntFailure(s.str());
         } else if (error_type == 2) {
             std::ostringstream s;
             s << "Type 1 roundoff's = "<<roundoff_type1;
             s << ", Type 2 = "<<roundoff_type2<<std::endl;
             s << "Roundoff error 2 prevents tolerance from being achieved ";
-            s << "in IntGKP\n";
+            s << "in intGKP\n";
             throw IntFailure(s.str());
         } else if (error_type == 3) {
             std::ostringstream s;
             s << "Bad integrand behavior found in the integration interval ";
-            s << "in IntGKP\n";
+            s << "in intGKP\n";
             throw IntFailure(s.str());
         }
     }
-
-    const double DEFRELERR = 1.e-6;
-    const double DEFABSERR = 1.e-15;
 
     template <class UF> 
     struct AuxFunc1 : // f(1/x-1) for int(a..infinity)
@@ -575,71 +650,76 @@ namespace integ {
     inline Aux2(UF uf) 
     { return AuxFunc2<UF>(uf); }
 
+    /// Perform a 1-dimensional integral using an IntRegion
     template <class UF> 
     inline typename UF::result_type int1d(
-        const UF& func, 
-        IntRegion<typename UF::result_type>& reg,
-        const typename UF::result_type& relerr=DEFRELERR,
-        const typename UF::result_type& abserr=DEFABSERR)
+        const UF& func,  ///< The function to be integrated(may be a function object)
+        IntRegion<typename UF::result_type>& reg, ///< The region of the integration
+        const typename UF::result_type& relerr=DEFRELERR, ///< The target relative error
+        const typename UF::result_type& abserr=DEFABSERR  ///< The target absolute error
+    )
     {
         typedef typename UF::result_type T;
 
-        integ_dbg2<<"start int1d: "<<reg.Left()<<".."<<reg.Right()<<std::endl;
+        integ_dbg2<<"start int1d: "<<reg.left()<<".."<<reg.right()<<std::endl;
 
-        if ((reg.Left() <= -MOCK_INF && reg.Right() > 0) ||
-            (reg.Right() >= MOCK_INF && reg.Left() < 0)) { 
-            reg.AddSplit(0);
+        if ((reg.left() <= -MOCK_INF && reg.right() > 0) ||
+            (reg.right() >= MOCK_INF && reg.left() < 0)) { 
+            reg.addSplit(0);
         }
 
-        if (reg.NSplit() > 0) {
+        if (reg.getNSplit() > 0) {
             std::vector<IntRegion<T> > children;
-            reg.SubDivide(&children);
+            reg.subDivide(&children);
             integ_dbg2<<"Subdivided into "<<children.size()<<" children\n";
             T answer=0;
             T err=0;
             for(size_t i=0;i<children.size();i++) {
                 IntRegion<T>& child = children[i];
                 integ_dbg2<<"i = "<<i;
-                integ_dbg2<<": bounds = "<<child.Left()<<
-                    ','<<child.Right()<<std::endl;
+                integ_dbg2<<": bounds = "<<child.left()<<
+                    ','<<child.right()<<std::endl;
                 answer += int1d(func,child,relerr,abserr);
-                err += child.Err();
-                integ_dbg2<<"subint = "<<child.Area()<<
-                    " +- "<<child.Err()<<std::endl;
+                err += child.getErr();
+                integ_dbg2<<"subint = "<<child.getArea()<<
+                    " +- "<<child.getErr()<<std::endl;
             }
-            reg.SetArea(answer,err);
+            reg.setArea(answer,err);
             return answer;
         } else {
-            if (reg.Left() <= -MOCK_INF) {
+            if (reg.left() <= -MOCK_INF) {
                 integ_dbg2<<"left = -infinity, right = "<<
-                    reg.Right()<<std::endl;
-                assert(reg.Right() <= 0.);
-                IntRegion<T> modreg(1./(reg.Right()-1.),0.,reg.dbgout);
-                IntGKP(Aux2<UF>(func),modreg,relerr,abserr);
-                reg.SetArea(modreg.Area(),modreg.Err());
-            } else if (reg.Right() >= MOCK_INF) {
-                integ_dbg2<<"left = "<<reg.Left()<<", right = infinity\n";
-                assert(reg.Left() >= 0.);
-                IntRegion<T> modreg(0.,1./(reg.Left()+1.),reg.dbgout);
-                IntGKP(Aux1<UF>(func),modreg,relerr,abserr);
-                reg.SetArea(modreg.Area(),modreg.Err());
+                    reg.right()<<std::endl;
+                assert(reg.right() <= 0.);
+                IntRegion<T> modreg(1./(reg.right()-1.),0.,reg.dbgout);
+                intGKP(Aux2<UF>(func),modreg,relerr,abserr);
+                reg.setArea(modreg.getArea(),modreg.getErr());
+            } else if (reg.right() >= MOCK_INF) {
+                integ_dbg2<<"left = "<<reg.left()<<", right = infinity\n";
+                assert(reg.left() >= 0.);
+                IntRegion<T> modreg(0.,1./(reg.left()+1.),reg.dbgout);
+                intGKP(Aux1<UF>(func),modreg,relerr,abserr);
+                reg.setArea(modreg.getArea(),modreg.getErr());
             } else {
-                integ_dbg2<<"left = "<<reg.Left();
-                integ_dbg2<<", right = "<<reg.Right()<<std::endl;
-                IntGKP(func,reg,relerr,abserr);
+                integ_dbg2<<"left = "<<reg.left();
+                integ_dbg2<<", right = "<<reg.right()<<std::endl;
+                intGKP(func,reg,relerr,abserr);
             }
-            integ_dbg2<<"done int1d  answer = "<<reg.Area();
-            integ_dbg2<<" +- "<<reg.Err()<<std::endl;
-            return reg.Area();
+            integ_dbg2<<"done int1d  answer = "<<reg.getArea();
+            integ_dbg2<<" +- "<<reg.getErr()<<std::endl;
+            return reg.getArea();
         }
     }
 
+    /// Perform a 1-dimensional integral using simple min/max values for the region
     template <class UF> 
     inline typename UF::result_type int1d(
-        const UF& func, 
-        typename UF::result_type min, typename UF::result_type max,
-        const typename UF::result_type& relerr=DEFRELERR,
-        const typename UF::result_type& abserr=DEFABSERR)
+        const UF& func,  ///< The function to be integrated (may be a function object)
+        typename UF::result_type min, ///< The lower bound of the integration
+        typename UF::result_type max, ///< The upper bound of the integration
+        const typename UF::result_type& relerr=DEFRELERR, ///< The target relative error
+        const typename UF::result_type& abserr=DEFABSERR  ///< The target absolute error
+    )
     {
         IntRegion<typename UF::result_type> reg(min,max);
         return int1d(func,reg,relerr,abserr); 
@@ -647,8 +727,7 @@ namespace integ {
 
     template <class BF, class YREG> 
     class Int2DAuxType : 
-        public std::unary_function<typename BF::first_argument_type,
-        typename BF::result_type> 
+        public std::unary_function<typename BF::first_argument_type,typename BF::result_type> 
     {
     public:
         Int2DAuxType(const BF& _func, const YREG& _yreg,
@@ -664,7 +743,7 @@ namespace integ {
             typename BF::result_type result = 
                 int1d(bind21(func,x),tempreg,relerr,abserr);
             integ_dbg3<<"Evaluated int2dAux at x = "<<x;
-            integ_dbg3<<": f = "<<result<<" +- "<<tempreg.Err()<<std::endl;
+            integ_dbg3<<": f = "<<result<<" +- "<<tempreg.getErr()<<std::endl;
             return result;
         } 
 
@@ -674,26 +753,28 @@ namespace integ {
         typename BF::result_type relerr,abserr;
     };
 
+    /// Perform a 2-dimensional integral
     template <class BF, class YREG> 
     inline typename BF::result_type int2d(
-        const BF& func,
-        IntRegion<typename BF::result_type>& reg,
-        const YREG& yreg, const typename BF::result_type& relerr=DEFRELERR,
-        const typename BF::result_type& abserr=DEFABSERR)
+        const BF& func,  ///< The function to be integrated (may be a function object)
+        IntRegion<typename BF::result_type>& reg,  ///< The region of the inner integral
+        const YREG& yreg, ///< yreg(x) is the region of the outer integral at x
+        const typename BF::result_type& relerr=DEFRELERR, ///< The target relative error
+        const typename BF::result_type& abserr=DEFABSERR  ///< The target absolute error
+    )
     {
         integ_dbg2<<"Starting int2d: range = ";
-        integ_dbg2<<reg.Left()<<".."<<reg.Right()<<std::endl;
+        integ_dbg2<<reg.left()<<".."<<reg.right()<<std::endl;
         Int2DAuxType<BF,YREG> faux(func,yreg,relerr*1.e-3,abserr*1.e-3);
         typename BF::result_type answer = int1d(faux,reg,relerr,abserr);
         integ_dbg2<<"done int2d  answer = "<<answer<<
-            " +- "<<reg.Err()<<std::endl;
+            " +- "<<reg.getErr()<<std::endl;
         return answer;
     }
 
     template <class TF, class YREG, class ZREG> 
     class Int3DAuxType : 
-        public std::unary_function<typename TF::firstof3_argument_type,
-        typename TF::result_type> 
+        public std::unary_function<typename TF::firstof3_argument_type,typename TF::result_type> 
     {
     public:
         Int3DAuxType(const TF& _func, const YREG& _yreg, const ZREG& _zreg, 
@@ -709,7 +790,7 @@ namespace integ {
             typename TF::result_type result = 
                 int2d(bind31(func,x),tempreg,bind21(zreg,x),relerr,abserr);
             integ_dbg3<<"Evaluated int3dAux at x = "<<x;
-            integ_dbg3<<": f = "<<result<<" +- "<<tempreg.Err()<<std::endl;
+            integ_dbg3<<": f = "<<result<<" +- "<<tempreg.getErr()<<std::endl;
             return result;
         }
 
@@ -720,28 +801,32 @@ namespace integ {
         typename TF::result_type relerr,abserr;
     };
 
+    /// Perform a 3-dimensional integral
     template <class TF, class YREG, class ZREG> 
     inline typename TF::result_type int3d(
-        const TF& func,
-        IntRegion<typename TF::result_type>& reg,
-        const YREG& yreg, const ZREG& zreg,
-        const typename TF::result_type& relerr=DEFRELERR,
-        const typename TF::result_type& abserr=DEFABSERR)
+        const TF& func,  ///< The function to be integrated (may be a function object)
+        IntRegion<typename TF::result_type>& reg,  ///< The region of the inner integral
+        const YREG& yreg, ///< yreg(x) is the region of the middle integral at x
+        const ZREG& zreg, ///< zreg(x)(y) is the region of the outer integral at x,y
+        const typename TF::result_type& relerr=DEFRELERR, ///< The target relative error
+        const typename TF::result_type& abserr=DEFABSERR  ///< The target absolute error
+    )
     {
         integ_dbg2<<"Starting int3d: range = ";
-        integ_dbg2<<reg.Left()<<".."<<reg.Right()<<std::endl;
+        integ_dbg2<<reg.left()<<".."<<reg.right()<<std::endl;
         Int3DAuxType<TF,YREG,ZREG> faux(
             func,yreg,zreg,relerr*1.e-3,abserr*1.e-3);
         typename TF::result_type answer = int1d(faux,reg,relerr,abserr);
         integ_dbg2<<"done int3d  answer = "<<answer<<
-            "+- "<<reg.Err()<<std::endl;
+            "+- "<<reg.getErr()<<std::endl;
         return answer;
     }
 
     // Helpers for constant regions for int2d, int3d:
 
     template <class T> 
-    struct ConstantReg1 : public std::unary_function<T, IntRegion<T> >
+    struct ConstantReg1 : 
+        public std::unary_function<T, IntRegion<T> >
     {
         ConstantReg1(T a,T b) : ir(a,b) {}
         ConstantReg1(const IntRegion<T>& r) : ir(r) {}
@@ -750,7 +835,8 @@ namespace integ {
     };
 
     template <class T> 
-    struct ConstantReg2 : public std::binary_function<T, T, IntRegion<T> >
+    struct ConstantReg2 : 
+        public std::binary_function<T, T, IntRegion<T> >
     {
         ConstantReg2(T a,T b) : ir(a,b) {}
         ConstantReg2(const IntRegion<T>& r) : ir(r) {}
@@ -758,6 +844,8 @@ namespace integ {
         IntRegion<T> ir;
     };
 
+    /// Perform a 3-dimensional integral using constant IntRegions for both regions
+    /// (i.e. the integral is over a square)
     template <class BF> 
     inline typename BF::result_type int2d(
         const BF& func,
@@ -772,6 +860,8 @@ namespace integ {
             relerr,abserr); 
     }
 
+    /// Perform a 2-dimensional integral using simple min/max values for borh regions
+    /// (i.e. the integral is over a square)
     template <class BF>
     inline typename BF::result_type int2d(
         const BF& func,
@@ -785,6 +875,8 @@ namespace integ {
         return int2d(func,xreg,yreg,relerr,abserr);
     }
 
+    /// Perform a 3-dimensional integral using constant IntRegions for all regions
+    /// (i.e. the integral is over a cube)
     template <class TF> 
     inline typename TF::result_type int3d(
         const TF& func,
@@ -801,6 +893,8 @@ namespace integ {
             relerr,abserr);
     }
 
+    /// Perform a 3-dimensional integral using simple min/max values for all regions
+    /// (i.e. the integral is over a cube)
     template <class TF>
     inline typename TF::result_type int3d(
         const TF& func,

--- a/include/galsim/integ/IntGKPData10.h
+++ b/include/galsim/integ/IntGKPData10.h
@@ -1,7 +1,13 @@
-// Gauss-Kronrod-Patterson quadrature coefficients for use in
-// quadpack routine qng. These coefficients were calculated with
-// 101 decimal digit arithmetic by L. W. Fullerton, Bell Labs, Nov
-// 1981. 
+/**
+ * @file IntGKPData10.h
+ *
+ * @brief Gauss-Kronrod-Patterson quadrature coefficients using the 
+ *        10-, 20-, 43-, 87- and 175-point rule.
+ *
+ * The coefficients up through the 87-point rule  were calculated with 
+ * 101 decimal digit arithmetic by L. W. Fullerton, Bell Labs, Nov 1981. 
+ * The 175-point rule was calculated by Mike Jarvis using long double precision.
+ */
 
 #include <vector>
 
@@ -10,6 +16,7 @@ namespace integ {
 
     static const int NGKPLEVELS = 5;
 
+    /// The number of evaluation points at each level
     inline int gkp_n(int level) 
     { 
         assert(level >= 0 && level < NGKPLEVELS);
@@ -17,6 +24,19 @@ namespace integ {
         return ngkp[level]; 
     }
 
+    /**
+     * @brief The abscissa points for each level
+     *
+     * For level > 0, it only returns the additional points at which 
+     * to evaluate the function.
+     *
+     * The x values are normalized for an integral from -1 to 1.
+     * So when they are used for an arbitrary range, we typically 
+     * define center and half_length = (b-a)/2.
+     * Then the real evaluations points are center + x*half_length
+     * and center - x*half_length, each of which has the same weight
+     * value (given by gkp_wa or gkp_wb).
+     */
     template <class T> 
     inline const std::vector<T>& gkp_x(int level)
     {
@@ -139,6 +159,9 @@ namespace integ {
         return *x[level];
     }
 
+    /**
+     * @brief The weights at each of the evaluation points from previous levels
+     */
     template <class T> 
     inline const std::vector<T>& gkp_wa(int level)
     {
@@ -248,6 +271,13 @@ namespace integ {
         return *wa[level];
     }
 
+    /**
+     * @brief The weights at each of the evaluation points from the current level
+     *
+     * Note that the last value is for the implicit x=0, which isn't listed in the
+     * list of abscissae.  Hence these all have one extra element than the corresponding
+     * gkp_x vector.
+     */
     template <class T> 
     inline const std::vector<T>& gkp_wb(int level)
     {

--- a/include/galsim/integ/MoreFunctional.h
+++ b/include/galsim/integ/MoreFunctional.h
@@ -1,3 +1,11 @@
+/**
+ * @file MoreFunctional.h
+ *
+ * @brief Some additional functional operators that aren't in the standard library's
+ *        <functional> but should be.
+ */
+
+
 #ifndef MoreFuncH
 #define MoreFuncH
 


### PR DESCRIPTION
I think I've finished putting doxygen comments into the integ package.  While I was at it, I also updated the style somewhat to conform with our camelCase style for functions and such.  It's probably not dogmatically conforming, but I think all the functions that the end user might use conform to our style now.

I wasn't sure how strict we want to be about using @brief and the C-style comments.  For one-liners, it's ok to just use a /// comment for the brief description, right?
