### PR TITLE
#77 convolve

### DIFF
--- a/galsim/base.py
+++ b/galsim/base.py
@@ -173,5 +173,4 @@ class GSConvolve(GSObject):
         SBList = []
         for obj in GSObjList:
             SBList.append(obj.SBProfile)
-        SBTuple = tuple(SBList)
-        GSObject.__init__(self, galsim.SBConvolve(SBTuple))
+        GSObject.__init__(self, galsim.SBConvolve(SBList))


### PR DESCRIPTION
I've made a GSConvolve class that can convolve our python base classes (Gaussian, Moffat, etc.).  It takes a tuple of these objects as an argument, which could for example include a galaxy image, an optical PSF, an atmospheric PSF, and a pixel response.

I have tested it using groups of Gaussians, since I know the answer there.

We'd like to have this implemented quickly, so I didn't make unit tests.  Once it gets merged in, I will open an issue for it (assigned to me).  Given my Python-newbie status, comments on the implementation and suggestions for further tests are very welcome.
