### PR TITLE
attempted fix for tuple-related errors in test_random.py, #75

### DIFF
--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -37,8 +37,8 @@ def test_uniform_rand():
     """
     u = galsim.UniformDeviate(testseed)
     testResult = (u(), u(), u())
-    np.testing.assert_almost_equal(testResult, uResult, precision, 
-                                   err_msg='Wrong uniform random number sequence generated')
+    np.testing.assert_array_almost_equal(np.array(testResult), np.array(uResult), precision, 
+                                         err_msg='Wrong uniform random number sequence generated')
 
 def test_uniform_rand_reset():
     """Testing ability to reset uniform random number generator and reproduce sequence.
@@ -49,8 +49,8 @@ def test_uniform_rand_reset():
     testResult2 = (u(), u(), u())
 # note this one is still equal, not almost_equal, because we should be able to achieve complete
 # equality for the same seed and the same exact system
-    np.testing.assert_equal(testResult1, testResult2,
-                            err_msg='Cannot reset generator with same seed to reproduce a sequence')
+    np.testing.assert_array_equal(np.array(testResult1), np.array(testResult2),
+                               err_msg='Cannot reset generator (same seed) to reproduce sequence')
 
 def test_gaussian_rand():
     """Test Gaussian random number generator for expected result given the above seed.
@@ -58,8 +58,8 @@ def test_gaussian_rand():
     u = galsim.UniformDeviate(testseed)
     g = galsim.GaussianDeviate(u, mean=gMean, sigma=gSigma)
     testResult = (g(), g(), g())
-    np.testing.assert_almost_equal(testResult, gResult, precision,
-                                   err_msg='Wrong Gaussian random number sequence generated')
+    np.testing.assert_array_almost_equal(np.array(testResult), np.array(gResult), precision,
+                                         err_msg='Wrong Gaussian random number sequence generated')
 
 def test_binomial_rand():
     """Test binomial random number generator for expected result given the above seed.
@@ -67,8 +67,8 @@ def test_binomial_rand():
     u = galsim.UniformDeviate(testseed)
     b = galsim.BinomialDeviate(u, N=bN, p=bp)
     testResult = (b(), b(), b())
-    np.testing.assert_almost_equal(testResult, bResult, precision,
-                                   err_msg='Wrong binomial random number sequence generated')
+    np.testing.assert_array_almost_equal(np.array(testResult), np.array(bResult), precision,
+                                         err_msg='Wrong binomial random number sequence generated')
 
 def test_poisson_rand():
     """Test Poisson random number generator for expected result given the above seed.
@@ -76,5 +76,5 @@ def test_poisson_rand():
     u = galsim.UniformDeviate(testseed)
     p = galsim.PoissonDeviate(u, mean=pMean)
     testResult = (p(), p(), p())
-    np.testing.assert_almost_equal(testResult, pResult, precision, 
-                                   err_msg='Wrong Poisson random number sequence generated')
+    np.testing.assert_array_almost_equal(np.array(testResult), np.array(pResult), precision, 
+                                         err_msg='Wrong Poisson random number sequence generated')


### PR DESCRIPTION
Mike was getting an error message in test_random.py that seems to come up in Python 2.6 (but not 2.7) because some of the numpy.testing functions don't like to take tuples as arguments.  For backwards compatibility, I changed the code to make these into arrays, and changed assert_almost_equal to assert_array_almost_equal.

This doesn't break anything for me, and he confirmed that it fixes the problem for him.
