### PR TITLE
Test if c++ exceptions are propagated up to python (#317)

### DIFF
--- a/galsim/SConscript
+++ b/galsim/SConscript
@@ -46,17 +46,18 @@ def CheckPyPrefix(target, source, env):
         real_pyprefix = os.path.realpath(pyprefix)
         
     if real_pyprefix not in sys_path:
-        print
-        print 'WARNING: The python installation prefix: %s'%pyprefix
-        print '         is not in the search path for %s.'%python
-        print
-        print '         You should add this directory to your PYTHONPATH environment'
-        print '         variable so python will find the installed galsim modules.'
-        print
-        print '         For example, if you use bash, you should add the line:'
-        print '             export PYTHONPATH=$PYTHONPATH:%s'%pyprefix
-        print '         to your .bashrc or .bash_profile file.'
-        print
+        env['final_messages'].append("""
+WARNING: The python installation prefix: %s
+         is not in the search path for %s.
+
+         You should add this directory to your PYTHONPATH environment
+         variable so python will find the installed galsim modules.
+
+         For example, if you use bash, you should add the line:
+             export PYTHONPATH=$PYTHONPATH:%s
+         to your .bashrc or .bash_profile file.
+"""%(pyprefix,python,pyprefix))
+
 
 env['BUILDERS']['CheckPyPrefix'] = Builder(action = CheckPyPrefix)
 
@@ -68,11 +69,13 @@ if 'install' in COMMAND_LINE_TARGETS:
         installed_py += env.Install(dir=python_install_subdir[i], source=py_files_sub[i])
 
     env.Alias(target='install', source=installed_py)
+    env['all_builds'] += installed_py
 
     check = env.CheckPyPrefix(target='#/check', source=None)
     Depends(check,[installed_py, '#pysrc', '#bin', python_install_dir])
     AlwaysBuild(check)
     env.Alias(target='install', source=check)
+    env['all_builds'] += check
 
 
 if 'uninstall' in COMMAND_LINE_TARGETS:

--- a/pysrc/SConscript
+++ b/pysrc/SConscript
@@ -52,6 +52,7 @@ obj_mod = env1.SharedObject(mod_files)
 
 mod = env1.LoadableModule(os.path.join('#galsim','_galsim'), obj_mod,
                           LDMODULEPREFIX='', LDMODULESUFFIX='.so')
+
 mod_targets = [mod]
 
 # NB: With LoadableModule (rather than SharedLibrary), we don't need the RenameLib stuff on Macs.
@@ -62,6 +63,9 @@ if 'install' in COMMAND_LINE_TARGETS:
 
     installed_mod = env1.Install(dir=python_install_dir, source=mod_targets)
     env1.Alias(target='install', source=installed_mod)
+    env['all_builds'] += installed_mod
+else:
+    env['all_builds'] += mod
 
 if 'uninstall' in COMMAND_LINE_TARGETS:
     # There is no env.Uninstall method, we must build our own

--- a/src/SConscript
+++ b/src/SConscript
@@ -136,7 +136,6 @@ link = env1.Command( link_name , lib , SymLink, LibName=lib_short_name)
 Default(link)
 
 lib_targets = [lib]
-
 Default(lib_targets)
 
 if 'install' in COMMAND_LINE_TARGETS:
@@ -148,6 +147,8 @@ if 'install' in COMMAND_LINE_TARGETS:
         LibName=lib_final_name)
 
     env1.Alias(target='install', source=[installed_lib, installed_link])
+    env['all_builds'] += installed_lib
+    env['all_builds'] += installed_link
 
     #hfiles1 = os.listdir(GetBuildPath('#include'))
     #hfiles = []
@@ -155,6 +156,9 @@ if 'install' in COMMAND_LINE_TARGETS:
         #hfiles += [os.path.join('#include',f)]
     #installed_h = env1.Install(dir=header_install_dir, source=hfiles)
     #env1.Alias(target='install', source=installed_h)
+else:
+    env['all_builds'] += lib
+    env['all_builds'] += link
 
 
 if 'uninstall' in COMMAND_LINE_TARGETS:


### PR DESCRIPTION
Rachel discovered that on her system, c++ exceptions show up in python as "unidentifiable C++ exception" rather than whatever text the exception would normally have.  I believe this is due to an incompatibility between the compiler used for GalSim and the one used for python.  (Rachel's python was compiled with a previous MacOS version, which is likely the problem in this case.) 

I don't think there is any real fix for this, but I added a test in SCons to see if this is happening for the user's build.  If so, a warning is emitted to warn the user that their error texts may not be very explanatory.  

Reiko, I think this happened in #288 for one of your systems.  Could you try this branch for that system to see if you get a reasonable warning message?

Others can try this branch too, but it shouldn't be a significant change for most people.
