### PR TITLE
#663

### DIFF
--- a/galsim/wfirst/wfirst_psfs.py
+++ b/galsim/wfirst/wfirst_psfs.py
@@ -279,7 +279,8 @@ def storePSFImages(PSF_dict, filename, bandpass_list=None, clobber=False):
     SCA_index_list = []
     for SCA in PSF_dict.keys():
         PSF = PSF_dict[SCA]
-        if not isinstance(PSF, galsim.ChromaticOpticalPSF):
+        if not isinstance(PSF, galsim.ChromaticOpticalPSF) and \
+                not isinstance(PSF, galsim.InterpolatedChromaticObject):
             raise RuntimeError("Error, PSFs are not ChromaticOpticalPSFs.")
         star = galsim.Gaussian(sigma=1.e-8, flux=1.)
 

--- a/galsim/wfirst/wfirst_psfs.py
+++ b/galsim/wfirst/wfirst_psfs.py
@@ -202,8 +202,8 @@ def getPSF(SCAs=None, approximate_struts=False, n_waves=None, extra_aberrations=
                     pupil_plane_im=galsim.wfirst.pupil_plane_file,
                     oversampling=1.2, pad_factor=2.)
             if n_waves is not None:
-                PSF.setupInterpolation(waves=np.linspace(blue_limit, red_limit, n_waves),
-                                       oversample_fac=1.5)
+                PSF = PSF.interpolate(waves=np.linspace(blue_limit, red_limit, n_waves),
+                                      oversample_fac=1.5)
         else:
             tmp_aberrations = use_aberrations * zemax_wavelength / wavelength_nm
             if approximate_struts:

--- a/tests/test_wfirst.py
+++ b/tests/test_wfirst.py
@@ -417,9 +417,11 @@ def test_wfirst_psfs():
     im_int = im_achrom.copy()
     obj_int = psf_int.evaluateAtWavelength(use_lam)
     im_int = obj_int.drawImage(image=im_int, scale=galsim.wfirst.pixel_scale)
-    # These images should agree *extremely* well.
+    # These images should agree well, but not perfectly.  One of them comes from drawing an image
+    # from an object directly, whereas the other comes from drawing an image of that object, making
+    # it into an InterpolatedImage, then re-drawing it.
     np.testing.assert_array_almost_equal(
-        im_int.array, im_achrom.array, decimal=8,
+        im_int.array, im_achrom.array, decimal=4,
         err_msg='PSF at a given wavelength and interpolated chromatic one evaluated at that '
         'wavelength disagree.')
 

--- a/tests/test_wfirst.py
+++ b/tests/test_wfirst.py
@@ -393,7 +393,7 @@ def test_wfirst_psfs():
     # First, we can draw the achromatic PSF.
     im_achrom = psf_achrom.drawImage(scale=galsim.wfirst.pixel_scale)
     im_chrom = im_achrom.copy()
-    obj_chrom = psf_achrom.evaluateAtWavelength(use_lam)
+    obj_chrom = psf_chrom.evaluateAtWavelength(use_lam)
     im_chrom = obj_chrom.drawImage(image=im_chrom, scale=galsim.wfirst.pixel_scale)
     # Normalization should probably not be right.
     im_chrom *= im_achrom.array.sum()/im_chrom.array.sum()

--- a/tests/test_wfirst.py
+++ b/tests/test_wfirst.py
@@ -402,32 +402,30 @@ def test_wfirst_psfs():
         im_chrom.array, im_achrom.array, decimal=8,
         err_msg='PSF at a given wavelength and chromatic one evaluated at that wavelength disagree.')
 
+    # Make a very limited check that interpolation works: just 2 wavelengths, 1 SCA.
+    # Note that the limits below are the blue and red limits for the Y106 filter.
+    blue_limit = 900. # nm
+    red_limit = 1230. # nm
+    n_waves = 2
+    other_sca = 12
+    wfirst_psfs_int = galsim.wfirst.getPSF(SCAs=[use_sca, other_sca],
+                                           approximate_struts=True, n_waves=2,
+                                           wavelength_limits=(blue_limit, red_limit))
+    psf_int = wfirst_psfs_int[use_sca]
+    # Check that evaluation at the edge wavelength, which we used for previous test, is consistent
+    # with previous results.
+    im_int = im_achrom.copy()
+    obj_int = psf_int.evaluateAtWavelength(use_lam)
+    im_int = obj_int.drawImage(image=im_int, scale=galsim.wfirst.pixel_scale)
+    # These images should agree *extremely* well.
+    np.testing.assert_array_almost_equal(
+        im_int.array, im_achrom.array, decimal=8,
+        err_msg='PSF at a given wavelength and interpolated chromatic one evaluated at that '
+        'wavelength disagree.')
+
     # Below are some more expensive tests that will run only when running test_wfirst.py directly,
     # but not when doing "scons tests"
     if __name__ == "__main__":
-        # Make a very limited check that interpolation works: just 2 wavelengths, 1 SCA.
-        # Note that the limits below are the blue and red limits for the Y106 filter.
-        blue_limit = 900. # nm
-        red_limit = 1230. # nm
-        n_waves = 2
-        other_sca = 12
-        wfirst_psfs_int = galsim.wfirst.getPSF(SCAs=[use_sca, other_sca],
-                                               approximate_struts=True, n_waves=2,
-                                               wavelength_limits=(blue_limit, red_limit))
-        psf_int = wfirst_psfs_int[use_sca]
-        # Check that evaluation at the edge wavelength, which we used for previous test, is consistent
-        # with previous results.
-        im_int = im_achrom.copy()
-        obj_int = psf_int.evaluateAtWavelength(use_lam)
-        im_int = obj_int.drawImage(image=im_int, scale=galsim.wfirst.pixel_scale)
-        # Normalization should probably not be right.
-        im_int *= im_achrom.array.sum()/im_int.array.sum()
-        # But otherwise these images should agree *extremely* well.
-        np.testing.assert_array_almost_equal(
-            im_int.array, im_achrom.array, decimal=8,
-            err_msg='PSF at a given wavelength and interpolated chromatic one evaluated at that '
-            'wavelength disagree.')
-
         # Check that if we store and reload, what we get back is consistent with what we put in.
         test_file = 'tmp_store.fits'
         # Make sure we clear out any old versions


### PR DESCRIPTION
This short and simple PR is fixing a place in the WFIRST module that relied on an older version of some of the chromatic object code, and also modifying the unit tests to: (a) account for some of the recent chromatic changes and (b) run some more of the tests when ```scons tests``` is called instead of reserving them for when ```test_wfirst.py``` is run directly.