### PR TITLE
#661 - WFIRST module accuracy parameters

### DIFF
--- a/galsim/wfirst/wfirst_psfs.py
+++ b/galsim/wfirst/wfirst_psfs.py
@@ -122,9 +122,11 @@ def getPSF(SCAs=None, approximate_struts=False, n_waves=None, extra_aberrations=
                                    bandpass.
                                    [default: False]
     @param    high_accuracy        If True, make higher-fidelity representations of the PSF in
-                                   Fourier space, to minimize aliasing.  This is more expensive in
-                                   terms of time and RAM, and may not be necessary for many
-                                   applications. [default: False]
+                                   Fourier space, to minimize aliasing (see plots on
+                                   https://github.com/GalSim-developers/GalSim/issues/661 for more
+                                   details).  This setting is more expensive in terms of time and
+                                   RAM, and may not be necessary for many applications.
+                                   [default: False]
     @returns  A dict of ChromaticOpticalPSF or OpticalPSF objects for each SCA.
     """
     # Check which SCAs are to be done using a helper routine in this module.

--- a/galsim/wfirst/wfirst_psfs.py
+++ b/galsim/wfirst/wfirst_psfs.py
@@ -65,6 +65,13 @@ def getPSF(SCAs=None, approximate_struts=False, n_waves=None, extra_aberrations=
     simple, understood wavelength-dependence.  The resulting object can be used to draw into any of
     the WFIRST bandpasses.
 
+    For applications that require very high accuracy in the modeling of the PSF, with very limited
+    aliasing, the `high_accuracy` option can be set to True.  When using this option, the MTF has a
+    value below 1e-4 for all wavenumbers above the band limit when using `approximate_struts=True`,
+    or below 3e-4 when using `approximate_struts=False`.  In contrast, when `high_accuracy=False`
+    (the default), there are some bumps in the MTF above the band limit that reach an amplitude of
+    ~1e-2.
+
     By default, no additional aberrations are included above the basic design.  However, users can
     provide an optional keyword `extra_aberrations` that will be included on top of those that are
     part of the design.  This should be in the same format as for the ChromaticOpticalPSF class,

--- a/galsim/wfirst/wfirst_psfs.py
+++ b/galsim/wfirst/wfirst_psfs.py
@@ -134,7 +134,7 @@ def getPSF(SCAs=None, approximate_struts=False, n_waves=None, extra_aberrations=
     # Deal with some accuracy settings.
     if high_accuracy:
         if approximate_struts:
-            oversampling = 3.0
+            oversampling = 3.5
         else:
             oversampling = 2.0
 

--- a/galsim/wfirst/wfirst_psfs.py
+++ b/galsim/wfirst/wfirst_psfs.py
@@ -37,7 +37,7 @@ zemax_filesuff = '_F01_W04.txt'
 zemax_wavelength = 1293. #nm
 
 def getPSF(SCAs=None, approximate_struts=False, n_waves=None, extra_aberrations=None,
-           wavelength_limits=None, logger=None, wavelength=None):
+           wavelength_limits=None, logger=None, wavelength=None, high_accuracy=False):
     """
     Get the PSF for WFIRST observations.
 
@@ -121,10 +121,35 @@ def getPSF(SCAs=None, approximate_struts=False, n_waves=None, extra_aberrations=
                                    OpticalPSF objects defined at the effective wavelength of that
                                    bandpass.
                                    [default: False]
+    @param    high_accuracy        If True, make higher-fidelity representations of the PSF in
+                                   Fourier space, to minimize aliasing.  This is more expensive in
+                                   terms of time and RAM, and may not be necessary for many
+                                   applications. [default: False]
     @returns  A dict of ChromaticOpticalPSF or OpticalPSF objects for each SCA.
     """
     # Check which SCAs are to be done using a helper routine in this module.
     SCAs = galsim.wfirst._parse_SCAs(SCAs)
+
+    # Deal with some accuracy settings.
+    if high_accuracy:
+        if approximate_struts:
+            oversampling = 3.0
+        else:
+            oversampling = 2.0
+
+            # In this case, we need to pad the edges of the pupil plane image, so we cannot just use
+            # the stored file.
+            tmp_pupil_plane_im = galsim.fits.read(galsim.wfirst.pupil_plane_file)
+            old_bounds = tmp_pupil_plane_im.bounds
+            new_bounds = old_bounds.withBorder((old_bounds.xmax+1-old_bounds.xmin)/2)
+            pupil_plane_im = galsim.Image(bounds=new_bounds)
+            pupil_plane_im[old_bounds] = tmp_pupil_plane_im
+    else:
+        if approximate_struts:
+            oversampling = 1.5
+        else:
+            oversampling = 1.2
+            pupil_plane_im = galsim.wfirst.pupil_plane_file
 
     if wavelength is None:
         if n_waves is not None:
@@ -193,14 +218,15 @@ def getPSF(SCAs=None, approximate_struts=False, n_waves=None, extra_aberrations=
                 PSF = galsim.ChromaticOpticalPSF(
                     lam=zemax_wavelength,
                     diam=galsim.wfirst.diameter, aberrations=use_aberrations,
-                    obscuration=galsim.wfirst.obscuration, nstruts=6)
+                    obscuration=galsim.wfirst.obscuration, nstruts=6,
+                    oversampling=oversampling)
             else:
                 PSF = galsim.ChromaticOpticalPSF(
                     lam=zemax_wavelength,
                     diam=galsim.wfirst.diameter, aberrations=use_aberrations,
                     obscuration=galsim.wfirst.obscuration,
-                    pupil_plane_im=galsim.wfirst.pupil_plane_file,
-                    oversampling=1.2, pad_factor=2.)
+                    pupil_plane_im=pupil_plane_im,
+                    oversampling=oversampling, pad_factor=2.)
             if n_waves is not None:
                 PSF = PSF.interpolate(waves=np.linspace(blue_limit, red_limit, n_waves),
                                       oversample_fac=1.5)
@@ -209,13 +235,14 @@ def getPSF(SCAs=None, approximate_struts=False, n_waves=None, extra_aberrations=
             if approximate_struts:
                 PSF = galsim.OpticalPSF(lam=wavelength_nm, diam=galsim.wfirst.diameter,
                                         aberrations=tmp_aberrations,
-                                        obscuration=galsim.wfirst.obscuration, nstruts=6)
+                                        obscuration=galsim.wfirst.obscuration, nstruts=6,
+                                        oversampling=oversampling)
             else:
                 PSF = galsim.OpticalPSF(lam=wavelength_nm, diam=galsim.wfirst.diameter,
                                         aberrations=tmp_aberrations,
                                         obscuration=galsim.wfirst.obscuration,
-                                        pupil_plane_im=galsim.wfirst.pupil_plane_file,
-                                        oversampling=1.2, pad_factor=2.)
+                                        pupil_plane_im=pupil_plane_im,
+                                        oversampling=oversampling, pad_factor=2.)
 
         PSF_dict[SCA]=PSF
 


### PR DESCRIPTION
This is a short pull request that includes an option to have a higher-fidelity representation of the WFIRST PSFs in Fourier space compared to what you get with the default settings.  See the plots on the issue page for details of how this setting changes the MTF.

I did not put this into the CHANGELOG because this PR will go into the same release as the initial PR for the WFIRST module, so it's basically a slight improvement of one of the new features in this version of GalSim rather than an improvement on a previous version of GalSim.

There is a debatable philosophical point here related to how the WFIRST module is set up:
Unlike OpticalPSF or ChromaticOpticalPSF, the user cannot adjust all the parameters related to the WFIRST optical PSF freely.  Instead, the WFIRST module getPSF() method just has default settings and the new 'high accuracy' settings.  The reason for this choice was that once we are working from the WFIRST pupil plane image, the OpticalPSF kwargs cannot be adjusted freely (i.e., many possible changes to the oversampling or pad factor would result in the routine throwing an exception because the supplied pupil plane image is inadequate in some way).  I think it would take a lot of work to make it possible to adjust the OpticalPSF kwargs completely freely, and I did not feel that it was necessary to do this for an initial version of the WFIRST module.  However, I wanted to flag this design decision, particularly now that we have a 'high accuracy' setting that also isn't adjustable (i.e., it's just a binary choice for default or high accuracy with nothing in between).  Any comments or concerns about this choice?