### PR TITLE
#670 chromatic caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,12 +28,12 @@ API Changes
   issue, and we can add them back. (#218)
 - Made all returned matrices consistently use numpy.array, rather than
   numpy.matrix.  We had been inconsistent with which type different functions
-  returned, so now all matrices are numpy.arrays.  If you rely on the 
+  returned, so now all matrices are numpy.arrays.  If you rely on the
   numpy.matrix behavior, you should recast with numpy.asmatrix(M). (#218)
-- Deprecated CorrelatedNoise.calculateCovarianceMatrix, since it is not used 
+- Deprecated CorrelatedNoise.calculateCovarianceMatrix, since it is not used
   anywhere, and we think no one really has a need for it. (#630)
 - Officially deprecated the methods and functions that had been described as
-  having been removed or changed to a different name.  In fact, many of them 
+  having been removed or changed to a different name.  In fact, many of them
   had been still valid, but no longer documented.  This was intentional to
   allow people time to change their code.  Now these methods are officially
   deprecated and will emit a warning message if used. (#643)
@@ -49,14 +49,14 @@ New Features
 
 - Made all GalSim objects picklable unless they use fundamentally unpicklable
   things such as lambda expressions.  Also gave objects better str and repr
-  representations (str(obj) should be descriptive, but relatively succinct, 
+  representations (str(obj) should be descriptive, but relatively succinct,
   and repr(obj) should be unambiguous).  Also made __eq__, __ne__, and __hash__
   work better. (#218)
 - Added ability to set the zeropoint of a bandpass on construction.  (Only
   a numeric value; more complicated calculations still need to use the method
   `bandpass.withZeropoint()`.) (#218)
 - Added ability to set the redshift of an SED on construction. (#218)
-- Updated CorrelatedNoise to work with images that have a non-trivial WCS. 
+- Updated CorrelatedNoise to work with images that have a non-trivial WCS.
   (#501)
 - Added new methods of the image class to simulate detector effects:
   inter-pixel capacitance (#555) and image quantization (#558).
@@ -80,7 +80,7 @@ New Features
   rendering process compared to brute force evaluation for chromatic objects
   with basic properties that are wavelength-dependent. (#618)
 - Added new `ChromaticAiry` and `ChromaticOpticalPSF` classes for representing
-  optical PSFs.  These new classes allow the diffraction effects and (in the 
+  optical PSFs.  These new classes allow the diffraction effects and (in the
   latter case) aberrations to be wavelength-dependent. (#618)
 - Enable initializing a DES_PSFEx object using a pyfits HDU directly instead
   of a filename. (#626)
@@ -100,7 +100,7 @@ Bug Fixes and Improvements
 - Fixed a bug in UncorrelatedNoise where the variance was set incorrectly.
   (#630)
 - Changed the implementation of drawing Box and Pixel profiles in real space
-  (i.e. without being convolved by anything) to actually draw the surface 
+  (i.e. without being convolved by anything) to actually draw the surface
   brightness at the center of each pixel.  This is what all other profiles do,
   but had not been what a Box or Pixel did. (#639)
 - Fixed a bug where InterpolatedImage and Box profiles were not correctly
@@ -108,7 +108,8 @@ Bug Fixes and Improvements
 - Fixed a bug in rendering profiles that involve two separate shifts. (#645)
 - Fixed a bug if drawImage was given odd nx, ny parameters, the drawn profile
   was not correctly centered in the image. (#645)
-
+- Added intermediate results cache to `ChromaticObject.drawImage` and
+  `ChromaticConvolution.drawImage`
 
 Updates to config options
 -------------------------
@@ -116,4 +117,3 @@ Updates to config options
 - Added Spergel type. (#616)
 - Added lam, diam, scale_units options to Airy and OpticalPSF types. (#618)
 - Added TopHat type. (#639)
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,9 @@ Bug Fixes and Improvements
 - Fixed a bug if drawImage was given odd nx, ny parameters, the drawn profile
   was not correctly centered in the image. (#645)
 - Added intermediate results cache to `ChromaticObject.drawImage` and
-  `ChromaticConvolution.drawImage`
+  `ChromaticConvolution.drawImage`, which, for some applications, can
+  significantly speed up (anywhere from 10% to 2000%) the rendering of groups
+  of similar (same SED, same Bandpass, same PSF) chromatic profiles.
 
 Updates to config options
 -------------------------

--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -273,11 +273,17 @@ class ChromaticObject(object):
 
         By default, the above two integrators will use the trapezoidal rule for integration.  The
         midpoint rule for integration can be specified instead by passing an integrator that has
-        been initialized with the `rule=galsim.integ.midpt` argument.  Finally, when creating a
+        been initialized with the `rule=galsim.integ.midpt` argument.  When creating a
         ContinuousIntegrator, the number of samples `N` is also an argument.  For example:
 
             >>> integrator = galsim.ContinuousIntegrator(rule=galsim.integ.midpt, N=100)
             >>> image = chromatic_obj.drawImage(bandpass, integrator=integrator)
+
+        Finally, this method uses a cache to avoid recomputing the integral over the product of
+        the bandpass and object SED when possible (i.e., for separable profiles).  Because the
+        cache size is finite, users may find that it is more efficient when drawing many images
+        to group images using the same SEDs and bandpasses together in order to hit the cache more
+        often.
 
         @param bandpass         A Bandpass object representing the filter against which to
                                 integrate.
@@ -1735,6 +1741,13 @@ class ChromaticConvolution(ChromaticObject):
 
         Works by finding sums of profiles which include separable portions, which can then be
         integrated before doing any convolutions, which are pushed to the end.
+
+        This method uses a cache to avoid recomputing 'effective' profiles, which are the 
+        wavelength-integrated products of inseparable profiles, the spectral components of 
+        separable profiles, and the bandpass.  Because the cache size is finite, users may find 
+        that it is more efficient when drawing many images to group images using the same 
+        SEDs, bandpasses, and inseparable profiles (generally PSFs) together in order to hit the 
+        cache more often.
 
         @param bandpass         A Bandpass object representing the filter against which to
                                 integrate.

--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -30,7 +30,7 @@ import copy
 
 import galsim
 
-def get_multiplier(sed, bandpass, wave_list):
+def _get_multiplier(sed, bandpass, wave_list):
     wave_list = np.array(wave_list)
     if len(wave_list) > 0:
         multiplier = np.trapz(sed(wave_list) * bandpass(wave_list), wave_list)
@@ -39,9 +39,9 @@ def get_multiplier(sed, bandpass, wave_list):
                                         bandpass.blue_limit, bandpass.red_limit)
     return multiplier
 
-multiplier_cache = galsim.utilities.LRU_Cache(get_multiplier, maxsize=10)
+_multiplier_cache = galsim.utilities.LRU_Cache(_get_multiplier, maxsize=10)
 
-def get_effective_profile(sep_SED, insep_profs, bandpass,
+def _get_effective_profile(sep_SED, insep_profs, bandpass,
                           iimult, wave_list, wmult, integrator,
                           gsparams):
         # Collapse inseparable profiles into one effective profile
@@ -69,14 +69,10 @@ def get_effective_profile(sep_SED, insep_profs, bandpass,
                     insep_obj, effective_bandpass, wmult=wmult, scale=iiscale,
                     integrator=integrator, method='no_pixel')
 
-        # Image -> InterpolatedImage
-        # It could be useful to cache this result if drawing more than one object with the same
-        # PSF+SED combination.  This naturally happens in a ring test or when fitting the
-        # parameters of a galaxy profile to an image when the PSF is constant.
         effective_prof = galsim.InterpolatedImage(effective_prof_image, gsparams=gsparams)
         return effective_prof
 
-effective_prof_cache = galsim.utilities.LRU_Cache(get_effective_profile, maxsize=10)
+_effective_prof_cache = galsim.utilities.LRU_Cache(_get_effective_profile, maxsize=10)
 
 
 class ChromaticObject(object):
@@ -133,18 +129,21 @@ class ChromaticObject(object):
     #    profile at a particular wavelength.
     # 2) Define a `withScaledFlux` method, which scales the flux at all wavelengths by a fixed
     #    multiplier.
-    # 3) Initialize a `separable` attribute.  This marks whether (`separable = True`) or not
+    # 3) Potentially define their own `__repr__` and `__str__` methods.  Note that the default
+    #    assumes that `.obj` is the only attribute of significance, but this isn't always
+    #    appropriate, (e.g. ChromaticSum, ChromaticConvolution).
+    # 4) Initialize a `separable` attribute.  This marks whether (`separable = True`) or not
     #    (`separable = False`) the given chromatic profile can be factored into a spatial profile
     #    and a spectral profile.  Separable profiles can be drawn quickly by evaluating at a single
     #    wavelength and adjusting the flux via a (fast) 1D integral over the spectral component.
     #    Inseparable profiles, on the other hand, need to be evaluated at multiple wavelengths
     #    in order to draw (slow).
-    # 4) Separable objects must initialize an `SED` attribute, which is a callable object (often a
+    # 5) Separable objects must initialize an `SED` attribute, which is a callable object (often a
     #    `galsim.SED` instance) that returns the _relative_ flux of the profile at a given
     #    wavelength. (The _absolute_ flux is controlled by both the `SED` and the `.flux` attribute
     #    of the underlying chromaticized GSObject(s).  See `galsim.Chromatic` docstring for details
     #    concerning normalization.)
-    # 5) Initialize a `wave_list` attribute, which specifies wavelengths at which the profile (or
+    # 6) Initialize a `wave_list` attribute, which specifies wavelengths at which the profile (or
     #    the SED in the case of separable profiles) will be evaluated when drawing a
     #    ChromaticObject.  The type of `wave_list` should be a numpy array, and may be empty, in
     #    which case either the Bandpass object being drawn against, or the integrator being used
@@ -314,12 +313,7 @@ class ChromaticObject(object):
         wave_list = self._getCombinedWaveList(bandpass)
 
         if self.separable:
-            multiplier = multiplier_cache(self.SED, bandpass, tuple(wave_list))
-            # if len(wave_list) > 0:
-            #     multiplier = np.trapz(self.SED(wave_list) * bandpass(wave_list), wave_list)
-            # else:
-            #     multiplier = galsim.integ.int1d(lambda w: self.SED(w) * bandpass(w),
-            #                                     bandpass.blue_limit, bandpass.red_limit)
+            multiplier = _multiplier_cache(self.SED, bandpass, tuple(wave_list))
             prof0 *= multiplier/self.SED(bandpass.effective_wavelength)
             image = prof0.drawImage(image=image, **kwargs)
             return image
@@ -838,8 +832,8 @@ class InterpolatedChromaticObject(ChromaticObject):
 
         # Finally, now that we have an image scale and size, draw all the images.  Note that
         # `no_pixel` is used (we want the object on its own, without a pixel response).
-        self.ims = [ obj.drawImage(scale=scale, nx=im_size, ny=im_size, method='no_pixel') \
-                         for obj in objs ]
+        self.ims = [ obj.drawImage(scale=scale, nx=im_size, ny=im_size, method='no_pixel')
+                     for obj in objs ]
 
     def __repr__(self):
         s = 'galsim.InterpolatedChromaticObject(%r,%r'%(self.original, self.waves)
@@ -1861,45 +1855,16 @@ class ChromaticConvolution(ChromaticObject):
         # ChromaticObject.drawImage() above.
 
         wmult = kwargs.get('wmult', 1)
-        effective_prof = effective_prof_cache(tuple(sep_SED), tuple(insep_profs), bandpass,
-                                              iimult, tuple(wave_list), wmult, integrator,
-                                              self.gsparams)
-        # # Collapse inseparable profiles into one effective profile
-        # SED = lambda w: reduce(lambda x,y:x*y, [s(w) for s in sep_SED], 1)
-        # insep_obj = galsim.Convolve(insep_profs, gsparams=self.gsparams)
-        # # Find scale at which to draw effective profile
-        # iiscale = insep_obj.evaluateAtWavelength(bandpass.effective_wavelength).nyquistScale()
-        # if iimult is not None:
-        #     iiscale /= iimult
-        # # Create the effective bandpass.
-        # wave_list = np.union1d(wave_list, bandpass.wave_list)
-        # wave_list = wave_list[wave_list >= bandpass.blue_limit]
-        # wave_list = wave_list[wave_list <= bandpass.red_limit]
-        # effective_bandpass = galsim.Bandpass(
-        #     galsim.LookupTable(wave_list, bandpass(wave_list) * SED(wave_list),
-        #                        interpolant='linear'))
-        # # If there's only one inseparable profile, let it draw itself.
-        # if len(insep_profs) == 1:
-        #     effective_prof_image = insep_profs[0].drawImage(
-        #         effective_bandpass, wmult=wmult, scale=iiscale, integrator=integrator,
-        #         method='no_pixel')
-        # # Otherwise, use superclass ChromaticObject to draw convolution of inseparable profiles.
-        # else:
-        #     effective_prof_image = ChromaticObject.drawImage(
-        #             insep_obj, effective_bandpass, wmult=wmult, scale=iiscale,
-        #             integrator=integrator, method='no_pixel')
-
-        # # Image -> InterpolatedImage
-        # # It could be useful to cache this result if drawing more than one object with the same
-        # # PSF+SED combination.  This naturally happens in a ring test or when fitting the
-        # # parameters of a galaxy profile to an image when the PSF is constant.
-        # effective_prof = galsim.InterpolatedImage(effective_prof_image, gsparams=self.gsparams)
+        # Collapse inseparable profiles into one effective profile
+        effective_prof = _effective_prof_cache(tuple(sep_SED), tuple(insep_profs), bandpass,
+                                               iimult, tuple(wave_list), wmult, integrator,
+                                               self.gsparams)
 
         # append effective profile to separable profiles (which should all be GSObjects)
         sep_profs.append(effective_prof)
         # finally, convolve and draw.
         final_prof = galsim.Convolve(sep_profs, gsparams=self.gsparams)
-        return final_prof.drawImage(image=image,**kwargs)
+        return final_prof.drawImage(image=image, **kwargs)
 
 
 class ChromaticDeconvolution(ChromaticObject):

--- a/tests/test_chromatic.py
+++ b/tests/test_chromatic.py
@@ -533,7 +533,7 @@ def test_chromatic_flux():
         err_msg="Drawn ChromaticConvolve flux (interpolated) doesn't match analytic prediction")
     # As an aside, check for appropriate tests of 'integrator' argument.
     try:
-        np.testing.assert_raises(TypeError, final_int.drawImage, bandpass, 
+        np.testing.assert_raises(TypeError, final_int.drawImage, bandpass,
                                  integrator='midp') # minor misspelling
         np.testing.assert_raises(TypeError, final_int.drawImage, bandpass,
                                  integrator=galsim.integ.midpt)
@@ -741,7 +741,7 @@ def test_ChromaticObject_expand():
     np.testing.assert_almost_equal(myy / (sigma/pixel_scale)**2, 1.0, decimal=4)
     np.testing.assert_almost_equal(mxy / (sigma/pixel_scale)**2, 0, decimal=4)
 
-    # First a very simple case with no actual wavelength dependence, but using the 
+    # First a very simple case with no actual wavelength dependence, but using the
     # functional syntax.
     gal1 = galsim.ChromaticObject(gal).expand(lambda w: 1.2)
     # Use a simple bandpass so we can do the integral below analytically
@@ -863,7 +863,7 @@ def test_ChromaticObject_rotate():
     np.testing.assert_almost_equal(myy / (sigma/pixel_scale)**2, (1-0.3)/fact, decimal=4)
     np.testing.assert_almost_equal(mxy / (sigma/pixel_scale)**2, 0, decimal=4)
 
-    # First a very simple case with no actual wavelength dependence, but using the 
+    # First a very simple case with no actual wavelength dependence, but using the
     # functional syntax.
     gal1 = galsim.ChromaticObject(gal).rotate(lambda w: 0.4 * galsim.radians)
     bp = galsim.Bandpass(lambda w: 1. - 0.12*(w-600)**2/100**2, 500, 700)
@@ -963,7 +963,7 @@ def test_ChromaticObject_shear():
     np.testing.assert_almost_equal(myy / (sigma/pixel_scale)**2, 1.0, decimal=4)
     np.testing.assert_almost_equal(mxy / (sigma/pixel_scale)**2, 0.0, decimal=4)
 
-    # First a very simple case with no actual wavelength dependence, but using the 
+    # First a very simple case with no actual wavelength dependence, but using the
     # functional syntax.
     gal1 = galsim.ChromaticObject(gal).shear(lambda w: galsim.Shear(e1=0.23, e2=0.13))
     bp = galsim.Bandpass(lambda w: 1. - 0.12*(w-600)**2/100**2, 500, 700)
@@ -1313,6 +1313,9 @@ def test_interpolated_ChromaticObject():
             ret = ret.shear(g1 = this_shear)
             return ret
 
+        def __repr__(self):
+            return 'galsim.ChromaticGaussian(%r)'%self.sigma
+
     # For this test, we're going to use the ChromaticGaussian defined above.  This class is simple
     # enough that evaluation of both the interpolated and exact versions is very fast, so it won't
     # slow down the tests too much to do both ways.  Note that for initial tests (fair comparison
@@ -1519,7 +1522,7 @@ def test_ChromaticOpticalPSF():
     t1 = time.time()
 
     # For ChromaticOpticalPSF, exact evaluation is too slow for routine unit tests.  So, for
-    # this unit test, we use an interpolated version only.  The tests of 
+    # this unit test, we use an interpolated version only.  The tests of
     # ChromaticObject in the previous unit test should be enough to ensure that exact
     # and interpolated evaluation match in general (given reasonable settings).
 
@@ -1547,7 +1550,7 @@ def test_ChromaticOpticalPSF():
     # obscuration = 0.18
     # nstruts = 2
     # scale = 0.02
-    # 
+    #
     # psf = galsim.ChromaticOpticalPSF(lam=lam, diam=diam, aberrations=aberrations,
     #                                  obscuration=obscuration, nstruts=nstruts)
     # obj = galsim.Convolve(psf, star)
@@ -1643,7 +1646,7 @@ def test_ChromaticAiry():
     # diam = 3.1 # meters
     # obscuration = 0.11
     # scale = 0.02
-    # 
+    #
     # psf = galsim.ChromaticAiry(lam=lam, diam=diam, obscuration=obscuration)
     # obj = galsim.Convolve(psf, star)
     # im_r = obj.drawImage(bandpass, scale=scale)

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -156,6 +156,46 @@ def test_check_all_contiguous():
     t2 = time.time()
     print 'time for %s = %.2f'%(funcname(),t2-t1)
 
+def test_python_LRU_Cache():
+    f = lambda x: x+1
+    size = 10
+    # Test correct size cache gets created
+    cache = galsim.utilities.LRU_Cache(f, maxsize=size)
+    assert len(cache.cache) == size
+    # Insert f(0) = 1 into cache and check that we can get it back
+    assert cache(0) == f(0)
+    assert cache(0) == f(0)
+
+    # Manually manipulate cache so we can check for hit
+    cache.cache[(0,)][3] = 2
+    assert cache(0) == 2
+
+    # Insert (and check) 1 thru size into cache.  This should bump out the (0,).
+    for i in range(1, size+1):
+        assert cache(i) == f(i)
+    assert (0,) not in cache.cache
+
+    # Test non-destructive cache expansion
+    newsize = 20
+    cache.resize(newsize)
+    for i in range(1, size+1):
+        assert (i,) in cache.cache
+        assert cache(i) == f(i)
+    assert len(cache.cache) == 20
+
+    # Add new items until the (1,) gets bumped
+    for i in range(size+1, newsize+2):
+        assert cache(i) == f(i)
+    assert (1,) not in cache.cache
+
+    # Test mostly non-destructive cache contraction.
+    # Already bumped (0,) and (1,), so (2,) should be the first to get bumped
+    for i in range(newsize-1, size, -1):
+        assert (newsize - (i - 1),) in cache.cache
+        cache.resize(i)
+        assert (newsize - (i - 1),) not in cache.cache
+
+
 if __name__ == "__main__":
     test_roll2d_circularity()
     test_roll2d_fwdbck()
@@ -163,3 +203,4 @@ if __name__ == "__main__":
     test_kxky()
     test_kxky_plusone()
     test_check_all_contiguous()
+    test_python_LRU_Cache()


### PR DESCRIPTION
This PR implements two caches in order to avoid recomputing intermediate products that can recur when drawing chromatic objects.  Specifically, these are the integral of the product of SED and bandpass for separable objects, and the effective profiles used in ChromaticConvolution.drawImage.  

The former cache only leads to a speedup of ~10% for the simple test I tried, but this probably depends somewhat on how finely the SED*bandpass integrand is sampled so could be more important in other cases.

The latter cache improves the timing of some ring test code in chroma by a factor of ~18.

The only tricky part I think worth mentioning is that since numpy ndarrays and lists are not hashable, in a few places I had to convert these into tuples to get the cache algorithm to work.