### PR TITLE
Pyfits 2.4 compatibility.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,9 +60,11 @@ New Features
   (#501)
 - Added new methods of the image class to simulate detector effects:
   inter-pixel capacitance (#555) and image quantization (#558).
-- Enable constructing a FitsHeader object from a dict.  This had been a hidden
+- Enabled constructing a FitsHeader object from a dict.  This had been a hidden
   feature that only half worked.  It should now work correctly.  Also, allow
   FitsHeader to be default constructed, which creates it with no keys. (#590)
+- Enabled constructing a FitsHeader object from a list of (key, value) pairs,
+  which preserves the order of the items in the header. (#672)
 - Added a module, galsim.wfirst, that includes information about the planned
   WFIRST mission, along with helper routines for constructing appropriate PSFs,
   bandpasses, WCS, etc.  (#590)

--- a/galsim/__init__.py
+++ b/galsim/__init__.py
@@ -88,19 +88,6 @@ from _version import __version__, __version_info__
 # previous GalSim versions that indicated the version number in this way.
 version = __version__
 
-# Two options for pyfits module:
-try:
-    import astropy.io.fits as pyfits
-    # astropy started their versioning over at 0.  (Understandably.)
-    # To make this seamless with pyfits versions, we add 4 to the astropy version.
-    from astropy import version as astropy_version
-    pyfits_version = str( (4 + astropy_version.major) + astropy_version.minor/10.)
-    pyfits_str = 'astropy.io.fits'
-except:
-    import pyfits
-    pyfits_version = pyfits.__version__
-    pyfits_str = 'pyfits'
-
 # Import things from other files we want to be in the galsim namespace
 
 # First some basic building blocks that don't usually depend on anything else

--- a/galsim/_pyfits.py
+++ b/galsim/_pyfits.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2012-2015 by the GalSim developers team on GitHub
+# https://github.com/GalSim-developers
+#
+# This file is part of GalSim: The modular galaxy image simulation toolkit.
+# https://github.com/GalSim-developers/GalSim
+#
+# GalSim is free software: redistribution and use in source and binary forms,
+# with or without modification, are permitted provided that the following
+# conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions, and the disclaimer given in the accompanying LICENSE
+#    file.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions, and the disclaimer given in the documentation
+#    and/or other materials provided with the distribution.
+#
+
+# Make it so we can use either pyfits or astropy.io.fits as pyfits.
+
+try:
+    import astropy.io.fits as pyfits
+    # astropy started their versioning over at 0.  (Understandably.)
+    # To make this seamless with pyfits versions, we add 4 to the astropy version.
+    from astropy import version as astropy_version
+    pyfits_version = str( (4 + astropy_version.major) + astropy_version.minor/10.)
+    pyfits_str = 'astropy.io.fits'
+except:
+    import pyfits
+    pyfits_version = pyfits.__version__
+    pyfits_str = 'pyfits'
+
+

--- a/galsim/catalog.py
+++ b/galsim/catalog.py
@@ -126,7 +126,7 @@ class Catalog(object):
     def read_fits(self, hdu, _nobjects_only=False):
         """Read in an input catalog from a FITS file.
         """
-        from galsim import pyfits, pyfits_version
+        from galsim._pyfits import pyfits, pyfits_version
         raw_data = pyfits.getdata(self.file_name, hdu)
         if pyfits_version > '3.0':
             self.names = raw_data.columns.names

--- a/galsim/des/des_meds.py
+++ b/galsim/des/des_meds.py
@@ -193,7 +193,7 @@ def write_meds(file_name, obj_list, clobber=True):
 
     import numpy
     import sys
-    from galsim import pyfits
+    from galsim._pyfits import pyfits
 
     # initialise the catalog
     cat = {}

--- a/galsim/des/des_psfex.py
+++ b/galsim/des/des_psfex.py
@@ -120,7 +120,7 @@ class DES_PSFEx(object):
         self.read()
 
     def read(self):
-        from galsim import pyfits
+        from galsim._pyfits import pyfits
         if isinstance(self.file_name, basestring):
             hdu = pyfits.open(self.file_name)[1]
         else:

--- a/galsim/des/des_shapelet.py
+++ b/galsim/des/des_shapelet.py
@@ -135,7 +135,7 @@ class DES_Shapelet(object):
     def read_fits(self):
         """Read in a DES_Shapelet stored using the the FITS-file version.
         """
-        from galsim import pyfits
+        from galsim._pyfits import pyfits
         cat = pyfits.getdata(self.file_name,1)
         # These fields each only contain one element, hence the [0]'s.
         self.psf_order = cat.field('psf_order')[0]

--- a/galsim/fits.py
+++ b/galsim/fits.py
@@ -1328,7 +1328,7 @@ class FitsHeader(object):
         # cf. https://aeon.stsci.edu/ssb/trac/pyfits/ticket/115
         from galsim._pyfits import pyfits, pyfits_version
         import copy
-        # Biolerplate deepcopy implementation.
+        # Boilerplate deepcopy implementation.
         # cf. http://stackoverflow.com/questions/1500718/what-is-the-right-way-to-override-the-copy-deepcopy-operations-on-an-object-in-p
         cls = self.__class__
         result = cls.__new__(cls)

--- a/galsim/fits.py
+++ b/galsim/fits.py
@@ -540,8 +540,10 @@ def write(image, file_name=None, dir=None, hdu_list=None, clobber=True, compress
 
     hdu = _add_hdu(hdu_list, image.array, pyfits_compress)
     if hasattr(image, 'header'):
+        # Automatically handle old pyfits versions correctly...
+        hdu_header = galsim.FitsHeader(hdu.header)
         for key in image.header.keys():
-            hdu.header[key] = image.header[key]
+            hdu_header[key] = image.header[key]
     if image.wcs:
         image.wcs.writeToFitsHeader(hdu.header, image.bounds)
 

--- a/galsim/fits.py
+++ b/galsim/fits.py
@@ -1229,13 +1229,25 @@ class FitsHeader(object):
         return self.header.items()
 
     def iteritems(self):
-        return self.header.iteritems()
+        from galsim._pyfits import pyfits_version
+        if pyfits_version < '3.1':
+            return self.header.items()
+        else:
+            return self.header.iteritems()
 
     def iterkeys(self):
-        return self.header.iterkeys()
+        from galsim._pyfits import pyfits_version
+        if pyfits_version < '3.1':
+            return self.header.keys()
+        else:
+            return self.header.iterkeys()
 
     def itervalues(self):
-        return self.header.itervalues()
+        from galsim._pyfits import pyfits_version
+        if pyfits_version < '3.1':
+            return self.header.values()
+        else:
+            return self.header.itervalues()
 
     def keys(self):
         return self.header.keys()

--- a/galsim/fits.py
+++ b/galsim/fits.py
@@ -1245,7 +1245,7 @@ class FitsHeader(object):
     def itervalues(self):
         from galsim._pyfits import pyfits_version
         if pyfits_version < '3.1':
-            return self.header.values()
+            return self.header.ascard.values()
         else:
             return self.header.itervalues()
 
@@ -1263,7 +1263,11 @@ class FitsHeader(object):
             self.header.update(dict2)
 
     def values(self):
-        return self.header.values()
+        from galsim._pyfits import pyfits_version
+        if pyfits_version < '3.1':
+            return self.header.ascard.values()
+        else:
+            return self.header.values()
 
     def append(self, key, value='', useblanks=True):
         """Append an item to the end of the header.

--- a/galsim/fits.py
+++ b/galsim/fits.py
@@ -1316,11 +1316,8 @@ class FitsHeader(object):
             return "galsim.FitsHeader(%s)"%self._tag
 
     def __eq__(self, other):
-        from galsim._pyfits import pyfits, pyfits_version
-        if pyfits_version < '3.1':
-            return isinstance(other,FitsHeader) and self.header.items() == other.header.items()
-        else:
-            return isinstance(other,FitsHeader) and self.header == other.header
+        return isinstance(other,FitsHeader) and self.header.items() == other.header.items()
+
     def __ne__(self, other): return not self.__eq__(other)
 
     def __hash__(self):

--- a/galsim/fits.py
+++ b/galsim/fits.py
@@ -1225,8 +1225,13 @@ class FitsHeader(object):
             self.header[key] = value
 
     def clear(self):
+        from galsim._pyfits import pyfits_version
         self._tag = None
-        self.header.clear()
+        if pyfits_version < '3.1':
+            # Not sure when clear() was added, but not present in 2.4, and present in 3.1.
+            del self.header.ascardlist()[:]
+        else:
+            self.header.clear()
 
     def get(self, key, default=None):
         return self.header.get(key, default)

--- a/galsim/fits.py
+++ b/galsim/fits.py
@@ -1303,7 +1303,11 @@ class FitsHeader(object):
             return "galsim.FitsHeader(%s)"%self._tag
 
     def __eq__(self, other):
-        return isinstance(other,FitsHeader) and self.header == other.header
+        from galsim._pyfits import pyfits, pyfits_version
+        if pyfits_version < '3.1':
+            return isinstance(other,FitsHeader) and self.header.items() == other.header.items()
+        else:
+            return isinstance(other,FitsHeader) and self.header == other.header
     def __ne__(self, other): return not self.__eq__(other)
 
     def __hash__(self):

--- a/galsim/fitswcs.py
+++ b/galsim/fitswcs.py
@@ -464,7 +464,7 @@ class PyAstWCS(galsim.wcs.CelestialWCS):
         # PyFITSAdapter requires an hdu, not a header, so if we were given a header directly,
         # then we need to mock it up.
         if hdu is None:
-            from galsim import pyfits
+            from galsim._pyfits import pyfits
             hdu = pyfits.PrimaryHDU()
             galsim.fits.FitsHeader(hdu_list=hdu).update(header)
         import warnings
@@ -542,7 +542,7 @@ class PyAstWCS(galsim.wcs.CelestialWCS):
         # See https://github.com/Starlink/starlink/issues/24 for helpful information from 
         # David Berry, who assisted me in getting this working.
 
-        from galsim import pyfits
+        from galsim._pyfits import pyfits
         import starlink.Atl
 
         hdu = pyfits.PrimaryHDU()

--- a/galsim/real.py
+++ b/galsim/real.py
@@ -38,7 +38,6 @@ some lower-resolution telescope.
 import galsim
 import utilities
 from galsim import GSObject
-from galsim import pyfits
 import os
 
 class RealGalaxy(GSObject):
@@ -393,6 +392,7 @@ class RealGalaxyCatalog(object):
     def __init__(self, file_name=None, image_dir=None, dir=None, preload=False,
                  noise_dir=None, logger=None, _nobjects_only=False):
 
+        from galsim._pyfits import pyfits
         self.file_name, self.image_dir, self.noise_dir = \
             _parse_files_dirs(file_name, image_dir, dir, noise_dir)
 
@@ -489,6 +489,7 @@ class RealGalaxyCatalog(object):
         """
         import numpy
         from multiprocessing import Lock
+        from galsim._pyfits import pyfits
         if self.logger:
             self.logger.debug('RealGalaxyCatalog: start preload')
         for file_name in numpy.concatenate((self.gal_file_name , self.psf_file_name)):
@@ -508,6 +509,7 @@ class RealGalaxyCatalog(object):
 
     def _getFile(self, file_name):
         from multiprocessing import Lock
+        from galsim._pyfits import pyfits
         if file_name in self.loaded_files:
             if self.logger:
                 self.logger.debug('RealGalaxyCatalog: File %s is already open',file_name)
@@ -591,6 +593,7 @@ class RealGalaxyCatalog(object):
                         self.logger.debug('RealGalaxyCatalog %d: Got saved noise im',i)
                 else:
                     import numpy
+                    from galsim._pyfits import pyfits
                     array = pyfits.getdata(self.noise_file_name[i])
                     im = galsim.Image(numpy.ascontiguousarray(array.astype(numpy.float64)),
                                       scale=self.pixel_scale[i])

--- a/galsim/scene.py
+++ b/galsim/scene.py
@@ -22,7 +22,6 @@ COSMOS-based galaxy sample, but it could be expanded to include star samples as 
 """
 
 import galsim
-from galsim import pyfits
 import numpy as np
 import math
 import os
@@ -140,6 +139,7 @@ class COSMOSCatalog(object):
     def __init__(self, file_name=None, image_dir=None, dir=None, preload=False, noise_dir=None,
                  use_real=True, exclude_fail=True, exclude_bad=True, max_hlr=0.,
                  _nobjects_only=False):
+        from galsim._pyfits import pyfits
         self.use_real = use_real
 
         if self.use_real:

--- a/galsim/wcs.py
+++ b/galsim/wcs.py
@@ -524,7 +524,6 @@ class BaseWCS(object):
         @param bounds       The bounds of the image.
         """
         # First write the XMIN, YMIN values
-        from galsim import pyfits_version
         if not isinstance(header, galsim.fits.FitsHeader):
             header = galsim.fits.FitsHeader(header)
         header["GS_XMIN"] = (bounds.xmin, "GalSim image minimum x coordinate")

--- a/galsim/wfirst/wfirst_psfs.py
+++ b/galsim/wfirst/wfirst_psfs.py
@@ -20,7 +20,6 @@ import galsim
 import galsim.wfirst
 import numpy as np
 import os
-from galsim import pyfits
 
 """
 @file wfirst_psfs.py
@@ -243,6 +242,7 @@ def storePSFImages(PSF_dict, filename, bandpass_list=None, clobber=False):
     @param clobber             Should the routine clobber `filename` (if they already exist)?
                                [default: False]
     """
+    from galsim._pyfits import pyfits
     # Check for sane input PSF_dict.
     if len(PSF_dict) == 0 or len(PSF_dict) > galsim.wfirst.n_sca or \
             min(PSF_dict.keys()) < 1 or max(PSF_dict.keys()) > galsim.wfirst.n_sca:

--- a/tests/test_fitsheader.py
+++ b/tests/test_fitsheader.py
@@ -29,7 +29,7 @@ except ImportError:
     import galsim
 
 # Get whatever version of pyfits or astropy we are using
-from galsim import pyfits
+from galsim._pyfits import pyfits
 
 def test_read():
     """Test reading a FitsHeader from an existing FITS file

--- a/tests/test_fitsheader.py
+++ b/tests/test_fitsheader.py
@@ -29,13 +29,18 @@ except ImportError:
     import galsim
 
 # Get whatever version of pyfits or astropy we are using
-from galsim._pyfits import pyfits
+from galsim._pyfits import pyfits, pyfits_version
 
 def test_read():
     """Test reading a FitsHeader from an existing FITS file
     """
     import time
     t1 = time.time()
+
+    # Older pyfits versions treat the blank rows differently, so it comes out as 213.
+    # I don't know exactly when it switched, but for < 3.1, I'll just update this to 
+    # whatever the initial value is.
+    tpv_len = 215
 
     def check_tpv(header):
         """Check that the header object has correct values from the tpv.fits file
@@ -44,7 +49,7 @@ def test_read():
         assert header['TIME-OBS'] == '04:28:14.105'
         assert header.get('FILTER') == 'I'
         assert header['AIRMASS'] == 1.185
-        assert len(header) == 215
+        assert len(header) == tpv_len
         assert 'ADC' in header
         assert ('FILPOS',6) in header.items()
         assert ('FILPOS',6) in header.iteritems()
@@ -57,6 +62,8 @@ def test_read():
     dir = 'fits_files'
     # First option: give a file_name
     header = galsim.FitsHeader(file_name=os.path.join(dir,file_name))
+    if pyfits_version < '3.1':
+        tpv_len = len(header)
     check_tpv(header)
     do_pickle(header)
     # Let the FitsHeader init handle the dir
@@ -89,14 +96,16 @@ def test_read():
     header = galsim.FitsHeader(file_name=os.path.join(dir,file_name))
     del header['AIRMASS']
     assert 'AIRMASS' not in header
-    assert len(header) == 214
+    if pyfits_version >= '3.1':
+        assert len(header) == tpv_len-1
     do_pickle(header)
 
     # Should be able to get with a default value if the key is not present
     assert header.get('AIRMASS', 2.0) == 2.0
     # key should still not be in the header
     assert 'AIRMASS' not in header
-    assert len(header) == 214
+    if pyfits_version >= '3.1':
+        assert len(header) == tpv_len-1
 
     # Add items to a header
     header['AIRMASS'] = 2

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -55,7 +55,7 @@ except ImportError:
     sys.path.append(os.path.abspath(os.path.join(path, "..")))
     import galsim
 
-from galsim import pyfits
+from galsim._pyfits import pyfits
 
 # Setup info for tests, not likely to change
 ntypes = 4  # Note: Most tests below only run through the first 4 types.

--- a/tests/test_wfirst.py
+++ b/tests/test_wfirst.py
@@ -31,6 +31,7 @@ except ImportError:
     path, filename = os.path.split(__file__)
     sys.path.append(os.path.abspath(os.path.join(path, "..")))
     import galsim
+    import galsim.wfirst
 
 def test_wfirst_wcs():
     """Test the WFIRST WCS routines against those from software provided by WFIRST project office.
@@ -217,6 +218,7 @@ def test_wfirst_bandpass():
     """
     import time
     t1 = time.time()
+    from galsim._pyfits import pyfits
 
     # Obtain the bandpasses with AB_zeropoint set
     exp_time = 200. # non WFIRST exposure time
@@ -243,7 +245,7 @@ def test_wfirst_bandpass():
     # Jeff used the C-K template with solar metallicity, T=9550K, surface gravity logg=3.95.  I
     # downloaded a grid of templates and just used the nearest one, which has solar metallicity,
     # T=9500K, surface gravity logg=4.0.
-    sed_data = galsim.pyfits.getdata(os.path.join('wfirst_files','ckp00_9500.fits'))
+    sed_data = pyfits.getdata(os.path.join('wfirst_files','ckp00_9500.fits'))
     lam = sed_data.WAVELENGTH.astype(np.float64)
     t = sed_data.g40.astype(np.float64)
     sed_tab = galsim.LookupTable(x=lam, f=t, interpolant='linear')


### PR DESCRIPTION
This is a fairly small PR to address some failures in the test suite for older versions of pyfits.  I have a system with pyfits 2.4 that was failing many of the FitsHeader tests we introduced in #590.  So I fixed those.

The two changes that matter for people who don't care about that are:
1. I now allow a FitsHeader to be constructed from a list of (key, value) pairs in addition to a pyfits.header or a dict.  And I made that the way the repr works when there isn't a more succinct string to use, rather than the string version of the pyfits.Header object.  (The latter didn't work for my old pyfits, but also I think the list of (key, value) pairs looks cleaner in those cases anyway.)
2. I also took the opportunity to move our pyfits import out of `__init__.py` and into `_pyfits.py`.  So now `import galsim` is much faster, which is nice for an interactive session.  And you now get the galsim pyfits by writing `from galsim._pyfits import pyfits`.  The first time you do so, it will do the try/except bit to import either astropy.io.fits or pyfits.

BTW, I didn't bother to create an issue for this, so the branch is pyfits_2.4.