### PR TITLE
#683

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,5 @@ Bug Fixes
 
 - Fixed a bug in some of the WCS classes if the RA/Dec axes in the FITS header
   are reversed (which is allowed by the FITS standard). (#681)
-
+- Fixed a bug in the way Images are instantiated for certain combinations of
+  ChromaticObjects and image-setup keyword arguments (#683)

--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -284,13 +284,7 @@ class ChromaticObject(object):
         # setup output image (semi-arbitrarily using the bandpass effective wavelength)
         prof0 = self.evaluateAtWavelength(bandpass.effective_wavelength)
         image = prof0.drawImage(image=image, setup_only=True, **kwargs)
-        # Remove from kwargs anything that is only used for setting up image:
-        kwargs.pop('dtype', None)
-        kwargs.pop('scale', None)
-        kwargs.pop('wcs', None)
-        kwargs.pop('nx', None)
-        kwargs.pop('ny', None)
-        kwargs.pop('bounds', None)
+        _remove_setup_kwargs(kwargs)
 
         # determine combined self.wave_list and bandpass.wave_list
         wave_list = self._getCombinedWaveList(bandpass)
@@ -888,13 +882,7 @@ class InterpolatedChromaticObject(ChromaticObject):
         # and so on.
         prof0 = self.evaluateAtWavelength(bandpass.effective_wavelength)
         image = prof0.drawImage(image=image, setup_only=True, **kwargs)
-        # Remove from kwargs anything that is only used for setting up image:
-        kwargs.pop('dtype', None)
-        kwargs.pop('scale', None)
-        kwargs.pop('wcs', None)
-        kwargs.pop('nx', None)
-        kwargs.pop('ny', None)
-        kwargs.pop('bounds', None)
+        _remove_setup_kwargs(kwargs)
 
         # determine combination of self.wave_list and bandpass.wave_list
         wave_list = self._getCombinedWaveList(bandpass)
@@ -1575,14 +1563,7 @@ class ChromaticSum(ChromaticObject):
         # Use given add_to_image for the first one, then add_to_image=False for the rest.
         image = self.objlist[0].drawImage(
                 bandpass, image=image, add_to_image=add_to_image, **kwargs)
-        # at this point, image exists, so remove kwargs related to setting up the image
-        # remove kwargs that would interfere with image
-        kwargs.pop('dtype', None)
-        kwargs.pop('scale', None)
-        kwargs.pop('wcs', None)
-        kwargs.pop('nx', None)
-        kwargs.pop('ny', None)
-        kwargs.pop('bounds', None)
+        _remove_setup_kwargs(kwargs)
         for obj in self.objlist[1:]:
             image = obj.drawImage(
                     bandpass, image=image, add_to_image=True, **kwargs)
@@ -1859,13 +1840,7 @@ class ChromaticConvolution(ChromaticObject):
                     tmplist.append(summand)
                     tmpobj = ChromaticConvolution(tmplist)
                     # add to previously started image
-                    # remove kwargs that would interfere with image
-                    kwargs.pop('dtype', None)
-                    kwargs.pop('scale', None)
-                    kwargs.pop('wcs', None)
-                    kwargs.pop('nx', None)
-                    kwargs.pop('ny', None)
-                    kwargs.pop('bounds', None)
+                    _remove_setup_kwargs(kwargs)
                     image = tmpobj.drawImage(bandpass, image=image, integrator=integrator,
                                              iimult=iimult, add_to_image=True, **kwargs)
                 # Return the image here, breaking the loop early.  If there are two ChromaticSum
@@ -1879,13 +1854,7 @@ class ChromaticConvolution(ChromaticObject):
         # setup output image (semi-arbitrarily using the bandpass effective wavelength)
         prof0 = self.evaluateAtWavelength(bandpass.effective_wavelength)
         image = prof0.drawImage(image=image, setup_only=True, **kwargs)
-        # Remove from kwargs anything that is only used for setting up image:
-        kwargs.pop('dtype', None)
-        kwargs.pop('scale', None)
-        kwargs.pop('wcs', None)
-        kwargs.pop('nx', None)
-        kwargs.pop('ny', None)
-        kwargs.pop('bounds', None)
+        _remove_setup_kwargs(kwargs)
 
         # Sort these atomic objects into separable and inseparable lists, and collect
         # the spectral parts of the separable profiles.
@@ -2234,3 +2203,15 @@ def _linearInterp(list, frac, lower_idx):
     interpolation later on if we want to enable something other than linear interpolation.
     """
     return frac*list[lower_idx+1] + (1.-frac)*list[lower_idx]
+
+def _remove_setup_kwargs(kwargs):
+    """
+    Helper function to remove from kwargs anything that is only used for setting up image and that
+    might otherwise interfere with drawImage.
+    """
+    kwargs.pop('dtype', None)
+    kwargs.pop('scale', None)
+    kwargs.pop('wcs', None)
+    kwargs.pop('nx', None)
+    kwargs.pop('ny', None)
+    kwargs.pop('bounds', None)

--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -290,6 +290,7 @@ class ChromaticObject(object):
         kwargs.pop('wcs', None)
         kwargs.pop('nx', None)
         kwargs.pop('ny', None)
+        kwargs.pop('bounds', None)
 
         # determine combined self.wave_list and bandpass.wave_list
         wave_list = self._getCombinedWaveList(bandpass)
@@ -893,6 +894,7 @@ class InterpolatedChromaticObject(ChromaticObject):
         kwargs.pop('wcs', None)
         kwargs.pop('nx', None)
         kwargs.pop('ny', None)
+        kwargs.pop('bounds', None)
 
         # determine combination of self.wave_list and bandpass.wave_list
         wave_list = self._getCombinedWaveList(bandpass)
@@ -1573,6 +1575,14 @@ class ChromaticSum(ChromaticObject):
         # Use given add_to_image for the first one, then add_to_image=False for the rest.
         image = self.objlist[0].drawImage(
                 bandpass, image=image, add_to_image=add_to_image, **kwargs)
+        # at this point, image exists, so remove kwargs related to setting up the image
+        # remove kwargs that would interfere with image
+        kwargs.pop('dtype', None)
+        kwargs.pop('scale', None)
+        kwargs.pop('wcs', None)
+        kwargs.pop('nx', None)
+        kwargs.pop('ny', None)
+        kwargs.pop('bounds', None)
         for obj in self.objlist[1:]:
             image = obj.drawImage(
                     bandpass, image=image, add_to_image=True, **kwargs)
@@ -1849,6 +1859,13 @@ class ChromaticConvolution(ChromaticObject):
                     tmplist.append(summand)
                     tmpobj = ChromaticConvolution(tmplist)
                     # add to previously started image
+                    # remove kwargs that would interfere with image
+                    kwargs.pop('dtype', None)
+                    kwargs.pop('scale', None)
+                    kwargs.pop('wcs', None)
+                    kwargs.pop('nx', None)
+                    kwargs.pop('ny', None)
+                    kwargs.pop('bounds', None)
                     image = tmpobj.drawImage(bandpass, image=image, integrator=integrator,
                                              iimult=iimult, add_to_image=True, **kwargs)
                 # Return the image here, breaking the loop early.  If there are two ChromaticSum
@@ -1868,6 +1885,7 @@ class ChromaticConvolution(ChromaticObject):
         kwargs.pop('wcs', None)
         kwargs.pop('nx', None)
         kwargs.pop('ny', None)
+        kwargs.pop('bounds', None)
 
         # Sort these atomic objects into separable and inseparable lists, and collect
         # the spectral parts of the separable profiles.
@@ -2159,8 +2177,8 @@ class ChromaticAiry(ChromaticObject):
         if diam is not None:
             self.lam_over_diam = (1.e-9*lam/diam)*galsim.radians/scale_unit
         else:
-            self.lam_over_diam = lam_over_diam
-        self.lam = lam
+            self.lam_over_diam = float(lam_over_diam)
+        self.lam = float(lam)
 
         self.kwargs = kwargs
         self.scale_unit = scale_unit

--- a/tests/test_chromatic.py
+++ b/tests/test_chromatic.py
@@ -1728,8 +1728,9 @@ def test_chromatic_image_setup():
 
     # Just going to try drawing a few different combinations of profiles to make sure that
     # the automatic image construction logic doesn't crash.  Most possibilities effectively get
-    # tested in other scripts above anyway, so just focus on possibilities near known previous
-    # failures here.
+    # tested in other scripts above anyway, so just focus on possibilities related to known previous
+    # failures here; specifically, drawing a convolution of two inseparable profiles while
+    # specifying `nx`, `ny`, and `scale` as keywords.
     img = galsim.Convolve(gal1+gal2, psf).drawImage(bandpass)
     img2 = galsim.Convolve(gal1+gal2, psf).drawImage(bandpass, nx=32, ny=32, scale=0.2)
     bds = galsim.BoundsI(1, 32, 1, 32)

--- a/tests/test_chromatic.py
+++ b/tests/test_chromatic.py
@@ -1717,7 +1717,7 @@ def test_ChromaticAiry():
     t2 = time.time()
     print 'time for %s = %.2f'%(funcname(),t2-t1)
 
-def chromatic_image_setup():
+def test_chromatic_image_setup():
     """Test ability for chromatic drawImage to setup output image."""
     import time
     t1 = time.time()
@@ -1730,14 +1730,18 @@ def chromatic_image_setup():
     # the automatic image construction logic doesn't crash.  Most possibilities effectively get
     # tested in other scripts above anyway, so just focus on possibilities near known previous
     # failures here.
-    img = galsim.Convolve(g1+g2, psf).drawImage(bandpass)
-    img2 = galsim.Convolve(g1+g2, psf).drawImage(bandpass, nx=32, ny=32, scale=0.2)
+    img = galsim.Convolve(gal1+gal2, psf).drawImage(bandpass)
+    img2 = galsim.Convolve(gal1+gal2, psf).drawImage(bandpass, nx=32, ny=32, scale=0.2)
     bds = galsim.BoundsI(1, 32, 1, 32)
-    img3 = galsim.Convolve(g1+g2, psf).drawImage(bandpass, bounds=bds, scale=0.2)
-    np.testing.assert_array_equal(img2.array.shape, (32, 32))
-    np.testing.assert_array_equal(img3.array.shape, (32, 32))
-    np.testing.assert_almost_equal(img2.scale, 0.2)
-    np.testing.assert_almost_equal(img3.scale, 0.2)
+    img3 = galsim.Convolve(gal1+gal2, psf).drawImage(bandpass, bounds=bds, scale=0.2)
+    np.testing.assert_array_equal(img2.array.shape, (32, 32),
+                                  "Got wrong size output image using nx=, ny= keywords.")
+    np.testing.assert_array_equal(img3.array.shape, (32, 32),
+                                  "Got wrong size output image using bounds= keyword.")
+    np.testing.assert_almost_equal(img2.scale, 0.2,
+                                   "Got wrong output image scale using nx=, ny= keywords.")
+    np.testing.assert_almost_equal(img3.scale, 0.2,
+                                   "Got wrong output image scale using bounds= keyword.")
 
     t2 = time.time()
     print 'time for %s = %.2f'%(funcname(),t2-t1)

--- a/tests/test_chromatic.py
+++ b/tests/test_chromatic.py
@@ -1717,6 +1717,32 @@ def test_ChromaticAiry():
     t2 = time.time()
     print 'time for %s = %.2f'%(funcname(),t2-t1)
 
+def chromatic_image_setup():
+    """Test ability for chromatic drawImage to setup output image."""
+    import time
+    t1 = time.time()
+
+    psf = galsim.ChromaticAiry(lam=550, diam=0.1)
+    gal1 = galsim.Sersic(n=1, half_light_radius=1.0) * bulge_SED
+    gal2 = galsim.Sersic(n=2, half_light_radius=0.5) * disk_SED
+
+    # Just going to try drawing a few different combinations of profiles to make sure that
+    # the automatic image construction logic doesn't crash.  Most possibilities effectively get
+    # tested in other scripts above anyway, so just focus on possibilities near known previous
+    # failures here.
+    img = galsim.Convolve(g1+g2, psf).drawImage(bandpass)
+    img2 = galsim.Convolve(g1+g2, psf).drawImage(bandpass, nx=32, ny=32, scale=0.2)
+    bds = galsim.BoundsI(1, 32, 1, 32)
+    img3 = galsim.Convolve(g1+g2, psf).drawImage(bandpass, bounds=bds, scale=0.2)
+    np.testing.assert_array_equal(img2.array.shape, (32, 32))
+    np.testing.assert_array_equal(img3.array.shape, (32, 32))
+    np.testing.assert_almost_equal(img2.scale, 0.2)
+    np.testing.assert_almost_equal(img3.scale, 0.2)
+
+    t2 = time.time()
+    print 'time for %s = %.2f'%(funcname(),t2-t1)
+
+
 if __name__ == "__main__":
     test_draw_add_commutativity()
     test_ChromaticConvolution_InterpolatedImage()
@@ -1741,3 +1767,4 @@ if __name__ == "__main__":
     test_interpolated_ChromaticObject()
     test_ChromaticOpticalPSF()
     test_ChromaticAiry()
+    test_chromatic_image_setup()

--- a/tests/test_chromatic.py
+++ b/tests/test_chromatic.py
@@ -1738,9 +1738,9 @@ def test_chromatic_image_setup():
                                   "Got wrong size output image using nx=, ny= keywords.")
     np.testing.assert_array_equal(img3.array.shape, (32, 32),
                                   "Got wrong size output image using bounds= keyword.")
-    np.testing.assert_almost_equal(img2.scale, 0.2,
+    np.testing.assert_almost_equal(img2.scale, 0.2, 9,
                                    "Got wrong output image scale using nx=, ny= keywords.")
-    np.testing.assert_almost_equal(img3.scale, 0.2,
+    np.testing.assert_almost_equal(img3.scale, 0.2, 9,
                                    "Got wrong output image scale using bounds= keyword.")
 
     t2 = time.time()


### PR DESCRIPTION
These are just a few minor changes to the way chromatic profiles' `drawImage` methods setup output `Image`s.  In general, the following `kwargs` are not needed once an image is setup, and therefore it's a good idea to just remove them from `kwargs` once an image exists: `dtype`, `scale`, `wcs`, `nx`, `ny`, `bounds`.  We were doing this inconsistently before, so this PR just introduces consistency and a simple unit test to verify that previous problems are gone.