### PR TITLE
#680

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,5 @@ Bug Fixes
 
 - Fixed a bug in some of the WCS classes if the RA/Dec axes in the FITS header
   are reversed (which is allowed by the FITS standard). (#681)
-
+- Improved ability of ChromaticObjects to find fiducial achromatic profiles
+  and wavelengths with non-zero flux. (#680)

--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -147,10 +147,12 @@ class ChromaticObject(object):
         Return a monochromatic profile of a separable chromatic object that can be scaled to give
         the monochromatic profile at any wavelength.
         """
-        candidate_waves = [bandpass.effective_wavelength,
-                           0.5 * (bandpass.blue_limit + bandpass.red_limit),
-                           bandpass.blue_limit,
-                           bandpass.red_limit]
+        bpwave = bandpass.effective_wavelength
+        candidate_waves = [bpwave, 0.5 * (bandpass.blue_limit + bandpass.red_limit)]
+        candidate_waves = np.union1d(candidate_waves, bandpass.wave_list)
+        candidate_waves = np.union1d(candidate_waves, self.wave_list)
+        candidate_waves = candidate_waves[np.argsort(np.abs(candidate_waves - bpwave))]
+
         for w in candidate_waves:
             prof0 = self.evaluateAtWavelength(w)
             if prof0.flux != 0:

--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -144,20 +144,22 @@ class ChromaticObject(object):
 
     def _fiducial_profile(self, bandpass):
         """
-        Return a monochromatic profile of a separable chromatic object that can be scaled to give
-        the monochromatic profile at any wavelength.
+        Return a fiducial achromatic profile of a chromatic object that can be used to estimate
+        default output image characteristics, or in the case of separable profiles, can be scaled to
+        give the monochromatic profile at any wavelength or the wavelength-integrated profile.
         """
         bpwave = bandpass.effective_wavelength
         candidate_waves = [bpwave, 0.5 * (bandpass.blue_limit + bandpass.red_limit)]
         candidate_waves = np.union1d(candidate_waves, bandpass.wave_list)
         candidate_waves = np.union1d(candidate_waves, self.wave_list)
+        # Prioritize wavelengths near the bandpass effective wavelength.
         candidate_waves = candidate_waves[np.argsort(np.abs(candidate_waves - bpwave))]
 
         for w in candidate_waves:
             prof0 = self.evaluateAtWavelength(w)
             if prof0.flux != 0:
                 return w, self.evaluateAtWavelength(w)
-        raise ValueError("Could not fiducial wavelength where SED * Bandpass is nonzero.")
+        raise ValueError("Could not locate fiducial wavelength where SED * Bandpass is nonzero.")
 
     def __repr__(self):
         return 'galsim.ChromaticObject(%r)'%self.obj

--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -149,16 +149,21 @@ class ChromaticObject(object):
         give the monochromatic profile at any wavelength or the wavelength-integrated profile.
         """
         bpwave = bandpass.effective_wavelength
-        candidate_waves = [bpwave, 0.5 * (bandpass.blue_limit + bandpass.red_limit)]
-        candidate_waves = np.union1d(candidate_waves, bandpass.wave_list)
-        candidate_waves = np.union1d(candidate_waves, self.wave_list)
+        prof0 = self.evaluateAtWavelength(bpwave)
+        if prof0.flux != 0:
+            return bpwave, prof0
+
+        candidate_waves = np.concatenate(
+            [np.array([0.5 * (bandpass.blue_limit + bandpass.red_limit)]),
+             bandpass.wave_list,
+             self.wave_list])
         # Prioritize wavelengths near the bandpass effective wavelength.
         candidate_waves = candidate_waves[np.argsort(np.abs(candidate_waves - bpwave))]
-
         for w in candidate_waves:
             prof0 = self.evaluateAtWavelength(w)
             if prof0.flux != 0:
-                return w, self.evaluateAtWavelength(w)
+                return w, prof0
+
         raise ValueError("Could not locate fiducial wavelength where SED * Bandpass is nonzero.")
 
     def __repr__(self):

--- a/tests/test_chromatic.py
+++ b/tests/test_chromatic.py
@@ -1717,6 +1717,31 @@ def test_ChromaticAiry():
     t2 = time.time()
     print 'time for %s = %.2f'%(funcname(),t2-t1)
 
+def test_chromatic_fiducial_wavelength():
+    """ Check that chromatic code can handle profiles with flux(effective_wavelength) = 0.
+    """
+    import time
+    t1 = time.time()
+
+    waves = np.arange(500., 600.1, 10.)
+    blue_flux = waves < 550.0
+    red_flux = waves > 550.0
+    bp = galsim.Bandpass(galsim.LookupTable(waves, waves**0, interpolant='linear'))
+    blue_sed = galsim.SED(galsim.LookupTable(waves, blue_flux, interpolant='linear'))
+    red_sed = galsim.SED(galsim.LookupTable(waves, red_flux, interpolant='linear'))
+
+    gal1 = galsim.Gaussian(fwhm=1) * blue_sed
+    gal2 = galsim.Gaussian(fwhm=1) * red_sed
+    img1 = gal1.drawImage(bp)
+    img2 = gal2.drawImage(bp)
+    # Didn't see an obvious np.testing method for checking finiteness, so just use assert.
+    assert np.isfinite(img1.array.sum()), "drawImage failed to identify fiducial wavelength"
+    assert np.isfinite(img2.array.sum()), "drawImage failed to identify fiducial wavelength"
+
+    t2 = time.time()
+    print 'time for %s = %.2f'%(funcname(),t2-t1)
+
+
 if __name__ == "__main__":
     test_draw_add_commutativity()
     test_ChromaticConvolution_InterpolatedImage()
@@ -1741,3 +1766,4 @@ if __name__ == "__main__":
     test_interpolated_ChromaticObject()
     test_ChromaticOpticalPSF()
     test_ChromaticAiry()
+    test_chromatic_fiducial_wavelength()


### PR DESCRIPTION
This PR adds a method `_fiducial_profile` to chromatic objects that returns an achromatic profile by evaluating the chromatic profile at a fiducial wavelength.  Previously, this fiducial wavelength had just been the effective wavelength of a `Bandpass`.  The new method adds fallback wavelengths to try to ensure that the fiducial achromatic profile has non-zero flux, which is necessary to rapidly draw separable profiles.

