### PR TITLE
KSB width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,5 @@ Bug Fixes
 
 - Fixed a bug in some of the WCS classes if the RA/Dec axes in the FITS header
   are reversed (which is allowed by the FITS standard). (#681)
-
+- Added ability to manipulate the width of the moment-measuring weight function
+  for the KSB shear estimation method of the galsim.hsm package. (#686)

--- a/galsim/hsm.py
+++ b/galsim/hsm.py
@@ -15,7 +15,7 @@
 #    this list of conditions, and the disclaimer given in the documentation
 #    and/or other materials provided with the distribution.
 #
-"""@file hsm.py 
+"""@file hsm.py
 Routines for adaptive moment estimation and PSF correction.
 
 This file contains the python interface to C++ routines for estimation of second moments of images,
@@ -46,7 +46,7 @@ originated by others and one that was originated by Hirata & Seljak:
 
 These methods return shear (or shape) estimators, which may not in fact satisfy conditions like
 |e|<=1, and so they are represented simply as e1/e2 or g1/g2 (depending on the method) rather than
-using a Shear object, which IS required to satisfy |e|<=1. 
+using a Shear object, which IS required to satisfy |e|<=1.
 
 These methods are all based on correction of moments, but with different sets of assumptions.  For
 more detailed discussion on all of these algorithms, see the relevant papers above.
@@ -162,7 +162,7 @@ class ShapeData(object):
             self.correction_method = data.correction_method
             self.resolution_factor = data.resolution_factor
             self.psf_sigma = data.psf_sigma
-            # We use "None" in CppShapeData to indicate no error messages to avoid problems on 
+            # We use "None" in CppShapeData to indicate no error messages to avoid problems on
             # (some) Macs using zero-length strings.  Here, we revert that back to "".
             if data.error_message == "None":
                 self.error_message = ""
@@ -254,7 +254,7 @@ _galsim.CppShapeData.__getinitargs__ = lambda self: (
         self.corrected_g1, self.corrected_g2, self.meas_type, self.corrected_shape_err,
         self.correction_method, self.resolution_factor, self.psf_sigma,
         self.psf_e1, self.psf_e2, self.error_message)
-    
+
 _galsim.CppShapeData.__repr__ = lambda self: \
         ('galsim._galsim.CppShapeData(' + 21*'%r,' + '%r)')%self.__getinitargs__()
 
@@ -265,10 +265,11 @@ _galsim.CppShapeData.__hash__ = lambda self: hash(repr(self))
 _galsim.HSMParams.__getinitargs__ = lambda self: (
         self.nsig_rg, self.nsig_rg2, self.max_moment_nsig2, self.regauss_too_small,
         self.adapt_order, self.max_mom2_iter, self.num_iter_default, self.bound_correct_wt,
-        self.max_amoment, self.max_ashift, self.ksb_moments_max, self.failed_moments)
+        self.max_amoment, self.max_ashift, self.ksb_moments_max, self.ksb_sig_weight,
+        self.ksb_sig_factor, self.failed_moments)
 
 _galsim.HSMParams.__repr__ = lambda self: \
-        ('galsim.hsm.HSMParams(' + 11*'%r,' + '%r)')%self.__getinitargs__()
+        ('galsim.hsm.HSMParams(' + 13*'%r,' + '%r)')%self.__getinitargs__()
 
 _galsim.HSMParams.__eq__ = lambda self, other: repr(self) == repr(other)
 _galsim.HSMParams.__ne__ = lambda self, other: not self.__eq__(other)
@@ -357,14 +358,14 @@ def EstimateShear(gal_image, PSF_image, weight=None, badpix=None, sky_var=0.0,
     Typical application to a single object:
 
         >>> galaxy = galsim.Gaussian(flux=1.0, sigma=1.0)
-        >>> galaxy = galaxy.shear(g1=0.05, g2=0.0)  # shears the Gaussian by (0.05, 0) using the 
+        >>> galaxy = galaxy.shear(g1=0.05, g2=0.0)  # shears the Gaussian by (0.05, 0) using the
         >>>                                         # |g| = (a-b)/(a+b) definition
         >>> psf = galsim.Kolmogorov(flux=1.0, fwhm=0.7)
         >>> final = galsim.Convolve(galaxy, psf)
         >>> final_image = final.drawImage(scale=0.2)
         >>> final_epsf_image = psf.drawImage(scale=0.2)
         >>> result = galsim.hsm.EstimateShear(final_image, final_epsf_image)
-    
+
     After running the above code, `result.observed_shape` is a galsim.Shear object with a value of
     `(0.0438925349133, -2.85747392701e-18)` and `result.corrected_e1`, `result_corrected_e2` are
     `(0.09934103488922119, -3.746108423463568e-10)`, compared with the expected `(0.09975, 0)` for a perfect
@@ -413,9 +414,9 @@ def EstimateShear(gal_image, PSF_image, weight=None, badpix=None, sky_var=0.0,
                             not set).  The convention for centroids is such that the center of
                             the lower-left pixel is (image.xmin, image.ymin).
                             [default: gal_image.trueCenter()]
-    @param strict           Whether to require success. If `strict=True`, then there will be a 
+    @param strict           Whether to require success. If `strict=True`, then there will be a
                             `RuntimeError` exception if shear estimation fails.  If set to `False`,
-                            then information about failures will be silently stored in the output 
+                            then information about failures will be silently stored in the output
                             ShapeData object. [default: True]
     @param hsmparams        The hsmparams keyword can be used to change the settings used by
                             EstimateShear() when estimating shears; see HSMParams documentation
@@ -473,7 +474,7 @@ def FindAdaptiveMom(object_image, weight=None, badpix=None, guess_sig=5.0, preci
         >>> my_moments = galsim.hsm.FindAdaptiveMom(my_gaussian_image)
 
     OR
-    
+
         >>> my_moments = my_gaussian_image.FindAdaptiveMom()
 
     Assuming a successful measurement, the most relevant pieces of information are
@@ -523,9 +524,9 @@ def FindAdaptiveMom(object_image, weight=None, badpix=None, guess_sig=5.0, preci
                             convention for centroids is such that the center of the lower-left pixel
                             is (image.xmin, image.ymin).
                             [default: object_image.trueCenter()]
-    @param strict           Whether to require success. If `strict=True`, then there will be a 
+    @param strict           Whether to require success. If `strict=True`, then there will be a
                             `RuntimeError` exception if shear estimation fails.  If set to `False`,
-                            then information about failures will be silently stored in the output 
+                            then information about failures will be silently stored in the output
                             ShapeData object. [default: True]
     @param hsmparams        The hsmparams keyword can be used to change the settings used by
                             FindAdaptiveMom when estimating moments; see HSMParams documentation

--- a/include/galsim/hsm/PSFCorr.h
+++ b/include/galsim/hsm/PSFCorr.h
@@ -21,10 +21,10 @@
 #define GalSim_PsfCorr_H
 
 /**
- * @file PSFCorr.h 
+ * @file PSFCorr.h
  *
  * @brief Contains functions for the hsm shape measurement code, which has functions to carry out
- *        PSF correction and measurement of adaptive moments. 
+ *        PSF correction and measurement of adaptive moments.
  *
  * All functions are in the hsm namespace.
  */
@@ -137,6 +137,11 @@ namespace hsm {
      *                           exception.
      * @param ksb_moments_max    Use moments up to ksb_moments_max order for KSB method of PSF
      *                           correction.
+     * @param ksb_sig_weight     The width of the weight function for the KSB method.  Normally,
+     *                           this is computed from the measured moments of the galaxy image.
+     *                           This keyword overrides this calculation.
+     * @param ksb_sig_factor     Factor by which to multiply the weight function width for the KSB
+     *                           method.  Default is 1.0.
      * @param failed_moments     Value to report for ellipticities and resolution factor if shape
      *                           measurement fails.
      */
@@ -151,6 +156,8 @@ namespace hsm {
                   double _max_amoment,
                   double _max_ashift,
                   int _ksb_moments_max,
+                  double _ksb_sig_weight,
+                  double _ksb_sig_factor,
                   double _failed_moments) :
             nsig_rg(_nsig_rg),
             nsig_rg2(_nsig_rg2),
@@ -163,6 +170,8 @@ namespace hsm {
             max_amoment(_max_amoment),
             max_ashift(_max_ashift),
             ksb_moments_max(_ksb_moments_max),
+            ksb_sig_weight(_ksb_sig_weight),
+            ksb_sig_factor(_ksb_sig_factor),
             failed_moments(_failed_moments)
         {}
 
@@ -181,6 +190,8 @@ namespace hsm {
             max_amoment(8000.),
             max_ashift(15.),
             ksb_moments_max(4),
+            ksb_sig_weight(0.0),
+            ksb_sig_factor(1.0),
             failed_moments(-1000.)
             {}
 
@@ -196,6 +207,8 @@ namespace hsm {
         double max_amoment;
         double max_ashift;
         int ksb_moments_max;
+        double ksb_sig_weight;
+        double ksb_sig_factor;
         double failed_moments;
     };
 
@@ -231,12 +244,12 @@ namespace hsm {
      * aligned with the pixel grid and the 2nd aligned at 45 degrees with respect to it.  There are
      * two choices for measurement type: 'e' = Bernstein & Jarvis (2002) ellipticity (or
      * distortion), 'g' = shear estimator = shear*responsivity.  The sigma is defined based on the
-     * observed moments M_xx, M_xy, and M_yy as sigma = (Mxx Myy - M_xy^2)^(1/4) = 
+     * observed moments M_xx, M_xy, and M_yy as sigma = (Mxx Myy - M_xy^2)^(1/4) =
      * [ det(M) ]^(1/4). */
-    struct ObjectData 
+    struct ObjectData
     {
         // Make sure everything starts with 0's.
-        ObjectData() : 
+        ObjectData() :
             x0(0.), y0(0.), sigma(0.), flux(0.), e1(0.), e2(0.), responsivity(0.),
             meas_type('\0'), resolution(0.) {}
 
@@ -246,11 +259,11 @@ namespace hsm {
         double flux; ///< total flux
         double e1; ///< first ellipticity component
         double e2; ///< second ellipticity component
-        double responsivity; ///< responsivity of ellipticity estimator 
-        char meas_type; ///< type of measurement (see function description) 
-        double resolution; ///< resolution factor (0=unresolved, 1=resolved) 
+        double responsivity; ///< responsivity of ellipticity estimator
+        char meas_type; ///< type of measurement (see function description)
+        double resolution; ///< resolution factor (0=unresolved, 1=resolved)
     };
-  
+
     /**
      * @brief Struct containing information about the shape of an object.
      *
@@ -348,7 +361,7 @@ namespace hsm {
         CppShapeData() : image_bounds(galsim::Bounds<int>()), moments_status(-1),
             observed_e1(0.), observed_e2(0.), moments_sigma(-1.), moments_amp(-1.),
             moments_centroid(galsim::Position<double>(0.,0.)), moments_rho4(-1.), moments_n_iter(0),
-            correction_status(-1), corrected_e1(-10.), corrected_e2(-10.), corrected_g1(-10.), 
+            correction_status(-1), corrected_e1(-10.), corrected_e2(-10.), corrected_g1(-10.),
             corrected_g2(-10.), meas_type("None"), corrected_shape_err(-1.),
             correction_method("None"), resolution_factor(-1.),
             psf_sigma(-1.0), psf_e1(0.), psf_e2(0.), error_message("None")
@@ -440,7 +453,7 @@ namespace hsm {
      * flags parameter is only used for the REGAUSS shape measurement method, and is defined as
      * follows: 0x1=recompute galaxy flux by summing unmasked pixels, 0x2=recompute galaxy flux from
      * Gaussian-quartic fit, 0x4=cut off Gaussian approximator at NSIG_RG sigma to save time,
-     * 0x8=cut off PSF residual at NSIG_RG2 to save time.    
+     * 0x8=cut off PSF residual at NSIG_RG2 to save time.
      * @param[in] gal_image    The galaxy Image.
      * @param[in] PSF_image    The PSF Image.
      * @param[in] gal_data     The ObjectData object for the galaxy
@@ -453,8 +466,8 @@ namespace hsm {
      * @return A status flag that should be zero if the measurement was successful.
      */
     unsigned int general_shear_estimator(
-        ConstImageView<double> gal_image, ConstImageView<double> PSF_image, 
-        ObjectData& gal_data, ObjectData& PSF_data, 
+        ConstImageView<double> gal_image, ConstImageView<double> PSF_image,
+        ObjectData& gal_data, ObjectData& PSF_data,
         const std::string& shear_est, unsigned long flags,
         boost::shared_ptr<HSMParams> hsmparams = boost::shared_ptr<HSMParams>());
 
@@ -485,7 +498,7 @@ namespace hsm {
         ConstImageView<double> data, double& A, double& x0, double& y0,
         double& Mxx, double& Mxy, double& Myy, double& rho4, double epsilon, int& num_iter,
         boost::shared_ptr<HSMParams> hsmparams = boost::shared_ptr<HSMParams>());
-  
+
 }
 }
 #endif

--- a/include/galsim/hsm/PSFCorr.h
+++ b/include/galsim/hsm/PSFCorr.h
@@ -137,11 +137,12 @@ namespace hsm {
      *                           exception.
      * @param ksb_moments_max    Use moments up to ksb_moments_max order for KSB method of PSF
      *                           correction.
-     * @param ksb_sig_weight     The width of the weight function for the KSB method.  Normally,
-     *                           this is computed from the measured moments of the galaxy image.
-     *                           This keyword overrides this calculation.
+     * @param ksb_sig_weight     The width of the weight function (in pixels) to use for the KSB
+     *                           method.  Normally, this is derived from the measured moments of the
+     *                           galaxy image; this keyword overrides this calculation.  Can be
+     *                           combined with ksb_sig_factor.
      * @param ksb_sig_factor     Factor by which to multiply the weight function width for the KSB
-     *                           method.  Default is 1.0.
+     *                           method (default: 1.0).  Can be combined with ksb_sig_weight.
      * @param failed_moments     Value to report for ellipticities and resolution factor if shape
      *                           measurement fails.
      */

--- a/pysrc/HSM.cpp
+++ b/pysrc/HSM.cpp
@@ -38,7 +38,7 @@ struct PyHSMParams {
 
     static void wrap() {
 
-        static const char* doc = 
+        static const char* doc =
             "HSMParams stores a set of numbers that determine how the moments/shape estimation\n"
             "routines make speed/accuracy tradeoff decisions and/or store their results.\n"
             "\n"
@@ -110,13 +110,19 @@ struct PyHSMParams {
             "                   exception.\n"
             "ksb_moments_max    Use moments up to ksb_moments_max order for KSB method of PSF\n"
             "                   correction.\n"
+            "ksb_sig_weight     The width of the weight function for the KSB method.  Normally,\n"
+            "                   this is computed from the measured moments of the galaxy image.\n"
+            "                   This keyword overrides this calculation."
+            "ksb_sig_factor     Factor by which to multiply the weight function width for the KSB\n"
+            "                   method.  Default is 1.0.\n"
             "failed_moments     Value to report for ellipticities and resolution factor if shape\n"
             "                   measurement fails.\n";
 
         bp::class_<HSMParams> pyHSMParams("HSMParams", doc, bp::no_init);
         pyHSMParams
             .def(bp::init<
-                 double, double, double, int, int, long, long, double, double, double, int, double>(
+                 double, double, double, int, int, long, long, double, double, double, int, double,
+                 double, double>(
                      (bp::arg("nsig_rg")=3.0,
                       bp::arg("nsig_rg2")=3.6,
                       bp::arg("max_moment_nsig2")=25.0,
@@ -128,6 +134,8 @@ struct PyHSMParams {
                       bp::arg("max_amoment")=8000.,
                       bp::arg("max_ashift")=15.,
                       bp::arg("ksb_moments_max")=4,
+                      bp::arg("ksb_sig_weight")=0.0,
+                      bp::arg("ksb_sig_factor")=1.0,
                       bp::arg("failed_moments")=-1000.))
             )
             .def(bp::init<const HSMParams&>())
@@ -142,6 +150,8 @@ struct PyHSMParams {
             .def_readonly("max_amoment",&HSMParams::max_amoment)
             .def_readonly("max_ashift",&HSMParams::max_ashift)
             .def_readonly("ksb_moments_max",&HSMParams::ksb_moments_max)
+            .def_readonly("ksb_sig_weight",&HSMParams::ksb_sig_weight)
+            .def_readonly("ksb_sig_factor",&HSMParams::ksb_sig_factor)
             .def_readonly("failed_moments",&HSMParams::failed_moments)
             .enable_pickling()
             ;
@@ -160,7 +170,7 @@ struct PyShapeData {
         float corrected_g1, float corrected_g2, std::string meas_type,
         float corrected_shape_err, std::string correction_method,
         float resolution_factor, float psf_sigma,
-        float psf_e1, float psf_e2, std::string error_message) 
+        float psf_e1, float psf_e2, std::string error_message)
     {
         CppShapeData* data = new CppShapeData();
         data->image_bounds = image_bounds;
@@ -190,17 +200,17 @@ struct PyShapeData {
 
     template <typename U, typename V>
     static void wrapTemplates() {
-        typedef CppShapeData (*FAM_func)(const BaseImage<U>&, const BaseImage<int>&, 
+        typedef CppShapeData (*FAM_func)(const BaseImage<U>&, const BaseImage<int>&,
                                          double, double, Position<double>,
                                          boost::shared_ptr<HSMParams>);
         bp::def("_FindAdaptiveMomView",
                 FAM_func(&FindAdaptiveMomView),
-                (bp::arg("object_image"), bp::arg("object_mask_image"), bp::arg("guess_sig")=5.0, 
-                 bp::arg("precision")=1.0e-6, bp::arg("guess_centroid")=Position<double>(0.,0.), 
+                (bp::arg("object_image"), bp::arg("object_mask_image"), bp::arg("guess_sig")=5.0,
+                 bp::arg("precision")=1.0e-6, bp::arg("guess_centroid")=Position<double>(0.,0.),
                  bp::arg("hsmparams")=bp::object()),
                 "Find adaptive moments of an image (with some optional args).");
 
-        typedef CppShapeData (*ESH_func)(const BaseImage<U>&, const BaseImage<V>&, 
+        typedef CppShapeData (*ESH_func)(const BaseImage<U>&, const BaseImage<V>&,
                                          const BaseImage<int>&, float, const char *,
                                          const std::string&, double, double, double, Position<double>,
                                          boost::shared_ptr<HSMParams>);
@@ -278,4 +288,3 @@ void pyExportHSM() {
 
 } // namespace hsm
 } // namespace galsim
-

--- a/pysrc/HSM.cpp
+++ b/pysrc/HSM.cpp
@@ -110,11 +110,12 @@ struct PyHSMParams {
             "                   exception.\n"
             "ksb_moments_max    Use moments up to ksb_moments_max order for KSB method of PSF\n"
             "                   correction.\n"
-            "ksb_sig_weight     The width of the weight function for the KSB method.  Normally,\n"
-            "                   this is computed from the measured moments of the galaxy image.\n"
-            "                   This keyword overrides this calculation.\n"
+            "ksb_sig_weight     The width of the weight function (in pixels) to use for the KSB\n"
+            "                   method.  Normally, this is derived from the measured moments of the\n"
+            "                   galaxy image; this keyword overrides this calculation.  Can be\n"
+            "                   combined with ksb_sig_factor.\n"
             "ksb_sig_factor     Factor by which to multiply the weight function width for the KSB\n"
-            "                   method.  Default is 1.0.\n"
+            "                   method (default: 1.0).  Can be combined with ksb_sig_weight.\n"
             "failed_moments     Value to report for ellipticities and resolution factor if shape\n"
             "                   measurement fails.\n";
 

--- a/pysrc/HSM.cpp
+++ b/pysrc/HSM.cpp
@@ -112,7 +112,7 @@ struct PyHSMParams {
             "                   correction.\n"
             "ksb_sig_weight     The width of the weight function for the KSB method.  Normally,\n"
             "                   this is computed from the measured moments of the galaxy image.\n"
-            "                   This keyword overrides this calculation."
+            "                   This keyword overrides this calculation.\n"
             "ksb_sig_factor     Factor by which to multiply the weight function width for the KSB\n"
             "                   method.  Default is 1.0.\n"
             "failed_moments     Value to report for ellipticities and resolution factor if shape\n"

--- a/src/hsm/PSFCorr.cpp
+++ b/src/hsm/PSFCorr.cpp
@@ -1341,7 +1341,8 @@ namespace hsm {
             if (hsmparams->ksb_sig_weight > 0.0) {
                 sig_gal = hsmparams->ksb_sig_weight;
                 find_mom_1(gal_image, moments, hsmparams->ksb_moments_max, x0_gal, y0_gal, sig_gal);
-            } else if (hsmparams->ksb_sig_factor != 1.0) {
+            }
+            if (hsmparams->ksb_sig_factor != 1.0) {
                 sig_gal *= hsmparams->ksb_sig_factor;
                 find_mom_1(gal_image, moments, hsmparams->ksb_moments_max, x0_gal, y0_gal, sig_gal);
             }

--- a/src/hsm/PSFCorr.cpp
+++ b/src/hsm/PSFCorr.cpp
@@ -61,7 +61,7 @@ std::ostream* dbgout = new std::ofstream("debug.out");
 int verbose_level = 1;
 // There are three levels of verbosity which can be helpful when debugging,
 // which are written as dbg, xdbg, xxdbg (all defined in Std.h).
-// It's Mike's way to have debug statements in the code that are really easy to turn 
+// It's Mike's way to have debug statements in the code that are really easy to turn
 // on and off.
 //
 // If DEBUGLOGGING is #defined, then these write out to *dbgout, according to the value
@@ -90,7 +90,7 @@ namespace hsm {
         boost::shared_ptr<HSMParams> hsmparams);
 
     // Make a masked_image based on the input image and mask.  The returned ImageView is a
-    // sub-image of the given masked_image.  It is the smallest sub-image that contains all the 
+    // sub-image of the given masked_image.  It is the smallest sub-image that contains all the
     // non-zero elements in the masked_image, so subsequent operations can safely use this
     // instead of the full masked_image.
     template <typename T>
@@ -117,9 +117,9 @@ namespace hsm {
                     *pF = *pI++;
                     if (*pF != 0.) b2 += Position<int>(x,y);
                     ++pF;
-                } else { 
+                } else {
                     *pF++ = 0.;
-                    ++pI; 
+                    ++pI;
                 }
             }
             pM += sM;
@@ -129,7 +129,7 @@ namespace hsm {
         dbg<<"Done MakeMaskedImage"<<std::endl;
         dbg<<"Final b2 bounds = "<<b2<<std::endl;
         // Make sure we have at least 1 pixel in the final mask.  Throw an exception if not.
-        if (!b2.isDefined()) 
+        if (!b2.isDefined())
             throw HSMError("Masked image is all 0's.");
         return masked_image[b2];
     }
@@ -184,7 +184,7 @@ namespace hsm {
 
         // Apply the mask
         ImageAlloc<double> full_masked_gal_image;
-        ImageView<double> masked_gal_image = 
+        ImageView<double> masked_gal_image =
             MakeMaskedImage(full_masked_gal_image,gal_image,gal_mask_image);
         ImageAlloc<double> masked_PSF_image(PSF_image);
         ConstImageView<double> masked_gal_image_cview = masked_gal_image.view();
@@ -246,13 +246,13 @@ namespace hsm {
         return results;
     }
 
-    // Measure the adaptive moments of an object directly using ImageViews, repackaging for 
+    // Measure the adaptive moments of an object directly using ImageViews, repackaging for
     // find_ellipmom_2.
     template <typename T>
     CppShapeData FindAdaptiveMomView(
-        const BaseImage<T>& object_image, const BaseImage<int>& object_mask_image, 
+        const BaseImage<T>& object_image, const BaseImage<int>& object_mask_image,
         double guess_sig, double precision, galsim::Position<double> guess_centroid,
-        boost::shared_ptr<HSMParams> hsmparams) 
+        boost::shared_ptr<HSMParams> hsmparams)
     {
         dbg<<"Start FindAdaptiveMomView"<<std::endl;
         dbg<<"Setting defaults and so on before calling find_ellipmom_2"<<std::endl;
@@ -279,7 +279,7 @@ namespace hsm {
         dbg<<"obj bounds = "<<object_image.getBounds()<<std::endl;
         dbg<<"mask bounds = "<<object_mask_image.getBounds()<<std::endl;
         ImageAlloc<double> full_masked_object_image;
-        ImageView<double> masked_object_image = 
+        ImageView<double> masked_object_image =
             MakeMaskedImage(full_masked_object_image,object_image,object_mask_image);
         ConstImageView<double> masked_object_image_cview = masked_object_image.view();
         dbg<<"full masked obj bounds = "<<full_masked_object_image.getBounds()<<std::endl;
@@ -331,7 +331,7 @@ namespace hsm {
      *
      */
 
-    void fourier_trans_1(double *data, long nn, int isign) 
+    void fourier_trans_1(double *data, long nn, int isign)
     {
 #if 1
         // Allocate memory
@@ -339,7 +339,7 @@ namespace hsm {
         FFTW_Array<std::complex<double> > b2(nn);
 
         // Copy data to b1
-        // Note: insert - sign for imag part because 
+        // Note: insert - sign for imag part because
         //       Num Rec FFT  uses exp(+i*2*pi*m*n/N) whereas
         //               FFTW uses exp(-i*2*pi*m*n/N)
         for (int i=0; i<nn; ++i){
@@ -348,7 +348,7 @@ namespace hsm {
 
         // Make the fftw plan
         fftw_plan plan=fftw_plan_dft_1d(nn, b1.get_fftw(), b2.get_fftw(),
-                                        isign == 1 ? FFTW_FORWARD : FFTW_BACKWARD, 
+                                        isign == 1 ? FFTW_FORWARD : FFTW_BACKWARD,
                                         FFTW_ESTIMATE);
         if (plan == NULL) throw FFTInvalid();
 
@@ -476,8 +476,8 @@ namespace hsm {
      *      at x = xmin+xstep*j.
      */
 
-    void qho1d_wf_1(long nx, double xmin, double xstep, long Nmax, double sigma, 
-                    tmv::Matrix<double>& psi) 
+    void qho1d_wf_1(long nx, double xmin, double xstep, long Nmax, double sigma,
+                    tmv::Matrix<double>& psi)
     {
 
         double beta, beta2__2, norm0;
@@ -523,7 +523,7 @@ namespace hsm {
             for(j=0;j<nx;j++) {
 
                 /* The recurrance */
-                psi(j,n+1) = coef1 * x * psi(j,n) + coef2 * psi(j,n-1);         
+                psi(j,n+1) = coef1 * x * psi(j,n) + coef2 * psi(j,n-1);
 
                 x += xstep; /* Increment x */
             } /* End j loop */
@@ -547,7 +547,7 @@ namespace hsm {
      */
     void find_mom_1(
         ConstImageView<double> data,
-        tmv::Matrix<double>& moments, int max_order, 
+        tmv::Matrix<double>& moments, int max_order,
         double x0, double y0, double sigma)
     {
 
@@ -566,7 +566,7 @@ namespace hsm {
         qho1d_wf_1(ny, (double)ymin - y0, 1., max_order, sigma, psi_y);
 
         tmv::ConstMatrixView<double> mdata(data.getData(),nx,ny,1,data.getStride(),tmv::NonConj);
-        
+
         moments = psi_x.transpose() * mdata * psi_y;
     }
 
@@ -593,7 +593,7 @@ namespace hsm {
         ConstImageView<double> data,
         tmv::Matrix<double>& moments, int max_order,
         double& x0, double& y0, double& sigma, double epsilon, int& num_iter,
-        boost::shared_ptr<HSMParams> hsmparams) 
+        boost::shared_ptr<HSMParams> hsmparams)
     {
 
         double sigma0 = sigma;
@@ -680,7 +680,7 @@ namespace hsm {
     void find_ellipmom_1(
         ConstImageView<double> data, double x0, double y0, double Mxx,
         double Mxy, double Myy, double& A, double& Bx, double& By, double& Cxx,
-        double& Cxy, double& Cyy, double& rho4w, boost::shared_ptr<HSMParams> hsmparams) 
+        double& Cxy, double& Cyy, double& rho4w, boost::shared_ptr<HSMParams> hsmparams)
     {
         long xmin = data.getXMin();
         long xmax = data.getXMax();
@@ -730,7 +730,7 @@ namespace hsm {
         dbg<<"iy1,iy2 = "<<iy1<<','<<iy2<<std::endl;
         assert(iy1 <= iy2);
 
-        // 
+        //
         /* Use these pointers to speed up referencing arrays */
         for(int y=iy1;y<=iy2;y++) {
             double y_y0 = y-y0;
@@ -812,7 +812,7 @@ namespace hsm {
     void find_ellipmom_2(
         ConstImageView<double> data, double& A, double& x0, double& y0,
         double& Mxx, double& Mxy, double& Myy, double& rho4, double epsilon, int& num_iter,
-        boost::shared_ptr<HSMParams> hsmparams) 
+        boost::shared_ptr<HSMParams> hsmparams)
     {
 
         double convergence_factor = 1.0;
@@ -894,7 +894,7 @@ namespace hsm {
              * report a failure */
             if (std::abs(Mxx)>hsmparams->max_amoment || std::abs(Mxy)>hsmparams->max_amoment
                 || std::abs(Myy)>hsmparams->max_amoment
-                || std::abs(x0-x00)>hsmparams->max_ashift 
+                || std::abs(x0-x00)>hsmparams->max_ashift
                 || std::abs(y0-y00)>hsmparams->max_ashift) {
                 throw HSMError("Error: adaptive moment failed\n");
             }
@@ -905,8 +905,8 @@ namespace hsm {
 
             // See http://www.boost.org/doc/libs/1_41_0/libs/math/doc/sf_and_dist/html/math_toolkit/utils/fpclass.html
             // for why we seem to have extra parentheses here.
-            if ((boost::math::isnan)(convergence_factor) || (boost::math::isnan)(Mxx) || 
-                (boost::math::isnan)(Myy) || (boost::math::isnan)(Mxy) || 
+            if ((boost::math::isnan)(convergence_factor) || (boost::math::isnan)(Mxx) ||
+                (boost::math::isnan)(Myy) || (boost::math::isnan)(Mxy) ||
                 (boost::math::isnan)(x0) || (boost::math::isnan)(y0)) {
                 throw HSMError("Error: NaN in calculation of adaptive moments\n");
             }
@@ -919,7 +919,7 @@ namespace hsm {
 
     /* fast_convolve_image_1
      *
-     * *** CONVOLVES TWO IMAGES *** 
+     * *** CONVOLVES TWO IMAGES ***
      *
      * Note that this routine ADDS the convolution to the pre-existing image.
      *
@@ -1001,7 +1001,7 @@ namespace hsm {
         // Note: (MJ) I don't really understand the offsets here.  Nor the N/4 offsets for
         // the initial assignments.  The choices were made to match the original algorithm
         // below.  This now matches the original behavior (below), but it seems like someone
-        // might want to change these somewhat to get im1 and im2 centered in the center of the 
+        // might want to change these somewhat to get im1 and im2 centered in the center of the
         // XTable rather than kind of offcenter as they are now.  Another time perhaps....
         int offset_x3 = image_out.getXMin() - image1.getXMin() - image2.getXMin();
         int offset_y3 = image_out.getYMin() - image1.getYMin() - image2.getYMin();
@@ -1053,7 +1053,7 @@ namespace hsm {
 
         /* Build input maps */
         for(int x=image1.getXMin();x<=image1.getXMax();x++)
-            for(int y=image1.getYMin();y<=image1.getYMax();y++) 
+            for(int y=image1.getYMin();y<=image1.getYMax();y++)
                 m1(x-image1.getXMin(),y-image1.getYMin()) = image1(x,y);
         for(i=image2.getXMin();i<=image2.getXMax();i++)
             for(j=image2.getYMin();j<=image2.getYMax();j++)
@@ -1113,7 +1113,7 @@ namespace hsm {
         dbg<<"Center is "<<mIm3.subMatrix(nx3/2-2,nx3/2+2,ny3/2-2,ny3/2+2)<<std::endl;
     }
 
-    void matrix22_invert(double& a, double& b, double& c, double& d) 
+    void matrix22_invert(double& a, double& b, double& c, double& d)
     {
 
         double det,temp;
@@ -1141,7 +1141,7 @@ namespace hsm {
      */
 
     void shearmult(double e1a, double e2a, double e1b, double e2b,
-                   double& e1out, double& e2out) 
+                   double& e1out, double& e2out)
     {
 
         /* This is eq. 2-13 of Bernstein & Jarvis */
@@ -1174,7 +1174,7 @@ namespace hsm {
 
     void psf_corr_bj(
         double Tratio, double e1p, double e2p, double a4p, double e1o,
-        double e2o, double a4o, double& e1, double& e2) 
+        double e2o, double a4o, double& e1, double& e2)
     {
 
         double e1red, e2red; /* ellipticities reduced to circular PSF */
@@ -1219,7 +1219,7 @@ namespace hsm {
 
     void psf_corr_linear(
         double Tratio, double e1p, double e2p, double a4p, double e1o,
-        double e2o, double a4o, double& e1, double& e2) 
+        double e2o, double a4o, double& e1, double& e2)
     {
 
         double e1red, e2red; /* ellipticities reduced to circular PSF */
@@ -1258,7 +1258,7 @@ namespace hsm {
         EI = std::sqrt(e1red*e1red + e2red*e2red);
         // TODO: etai was set, but not used.
         // Is this a bug?  Or just a legacy of an old calculation?
-        //etai = 0.5 * log( (1./a2-1) / (1./b2-1) ); 
+        //etai = 0.5 * log( (1./a2-1) / (1./b2-1) );
         coshetao = 1./std::sqrt(1-e1red*e1red-e2red*e2red);
         deltamu = (-1.5*A*A - A*B - 1.5*B*B +2*(A+B)) * a4i
             + (-1.5*a2*a2 - a2*b2 - 1.5*b2*b2 + 2*(a2+b2))*a4p;
@@ -1302,7 +1302,7 @@ namespace hsm {
         double& e1, double& e2,
         double& responsivity, double& R, unsigned long flags, double& x0_gal, double& y0_gal,
         double& sig_gal, double& flux_gal, double& x0_psf, double& y0_psf, double& sig_psf,
-        boost::shared_ptr<HSMParams> hsmparams) 
+        boost::shared_ptr<HSMParams> hsmparams)
     {
 
         unsigned int status = 0;
@@ -1324,7 +1324,7 @@ namespace hsm {
         tmv::Matrix<double> moments(hsmparams->ksb_moments_max+1,hsmparams->ksb_moments_max+1);
         tmv::Matrix<double> psfmoms(hsmparams->ksb_moments_max+1,hsmparams->ksb_moments_max+1);
 
-        /* Determine the adaptive variance of the measured galaxy */
+        /* Determine the adaptive centroid and variance of the measured galaxy */
         x0 = x0_gal;
         y0 = y0_gal;
         sigma0 = sig_gal;
@@ -1336,6 +1336,15 @@ namespace hsm {
             y0_gal = y0;
             sig_gal = sigma0;
             find_mom_1(gal_image, moments, hsmparams->ksb_moments_max, x0, y0, sigma0);
+        } else {
+            /* If requested, recompute with asserted weight fn sigma */
+            if (hsmparams->ksb_sig_weight > 0.0) {
+                sig_gal = hsmparams->ksb_sig_weight;
+                find_mom_1(gal_image, moments, hsmparams->ksb_moments_max, x0_gal, y0_gal, sig_gal);
+            } else if (hsmparams->ksb_sig_factor != 1.0) {
+                sig_gal *= hsmparams->ksb_sig_factor;
+                find_mom_1(gal_image, moments, hsmparams->ksb_moments_max, x0_gal, y0_gal, sig_gal);
+            }
         }
         flux_gal = 3.544907701811 * sig_gal * moments(0,0);
 
@@ -1513,7 +1522,7 @@ namespace hsm {
         double& e1, double& e2, double& R, unsigned long flags, double& x0_gal,
         double& y0_gal, double& sig_gal, double& x0_psf, double& y0_psf,
         double& sig_psf, double& e1_psf, double& e2_psf, double& flux_gal,
-        boost::shared_ptr<HSMParams> hsmparams) 
+        boost::shared_ptr<HSMParams> hsmparams)
     {
         int num_iter;
         unsigned int status = 0;
@@ -1651,7 +1660,7 @@ namespace hsm {
 
         /* Figure out the size of the bounding box for the PSF residual.
          * We don't necessarily need the whole PSF,
-         * just the part that will affect regions inside the hsmparams->nsig_rg2 sigma ellipse 
+         * just the part that will affect regions inside the hsmparams->nsig_rg2 sigma ellipse
          * of the Intensity.
          */
         Bounds<int> pbounds = PSF_image.getBounds();
@@ -1685,7 +1694,7 @@ namespace hsm {
                 dx = x - x0_psf;
                 dy = y - y0_psf;
 
-                PSF_resid(x,y) = -PSF_image(x,y) + center_amp_psf * 
+                PSF_resid(x,y) = -PSF_image(x,y) + center_amp_psf *
                     std::exp (-0.5 * ( Minvpsf_xx*dx*dx + Minvpsf_yy*dy*dy ) - Minvpsf_xy*dx*dy);
             }
         }
@@ -1719,7 +1728,7 @@ namespace hsm {
         e1psf = (Mxxpsf - Myypsf) / Tpsf;
         e2psf = 2 * Mxypsf / Tpsf;
 
-        psf_corr_bj(Tpsf/Tgal, e1psf, e2psf, 0., e1gal, e2gal, 0.5*rho4gal-1., e1, e2); 
+        psf_corr_bj(Tpsf/Tgal, e1psf, e2psf, 0., e1gal, e2gal, 0.5*rho4gal-1., e1, e2);
         /* Use 0 for radial 4th moment of PSF because it's been * re-Gaussianized.  */
 
         R = 1. - Tpsf/Tgal;
@@ -1748,7 +1757,7 @@ namespace hsm {
     unsigned int general_shear_estimator(
         ConstImageView<double> gal_image, ConstImageView<double> PSF_image,
         ObjectData& gal_data, ObjectData& PSF_data, const std::string& shear_est,
-        unsigned long flags, boost::shared_ptr<HSMParams> hsmparams) 
+        unsigned long flags, boost::shared_ptr<HSMParams> hsmparams)
     {
         unsigned int status = 0;
         int num_iter;

--- a/tests/test_hsm.py
+++ b/tests/test_hsm.py
@@ -44,7 +44,7 @@ pixel_scale = 0.2
 decimal = 2 # decimal place at which to require equality in sizes
 decimal_shape = 3 # decimal place at which to require equality in shapes
 
-# The timing tests can be unreliable in environments with other processes running at the 
+# The timing tests can be unreliable in environments with other processes running at the
 # same time.  So we disable them by default.  However, on a clean system, they should all pass.
 test_timing = False
 
@@ -564,7 +564,7 @@ def test_hsmparams():
     do_pickle(res)
     do_pickle(res2)
     do_pickle(galsim._galsim.CppShapeData())
- 
+
     try:
         # Then check failure modes: force it to fail by changing HSMParams.
         new_params_niter = galsim.hsm.HSMParams(max_mom2_iter = res.moments_n_iter-1)
@@ -781,6 +781,30 @@ def test_bounds_centroid():
     t2 = time.time()
     print 'time for %s = %.2f'%(funcname(),t2-t1)
 
+def test_ksb_sig():
+    """Check that modification of KSB weight function width is consistent."""
+    import time
+    t1 = time.time()
+
+    gal = galsim.Gaussian(fwhm=1.0).shear(e1=0.2, e2=0.1)
+    psf = galsim.Gaussian(fwhm=0.7)
+    gal_img = galsim.Convolve(gal, psf).drawImage(nx=32, ny=32, scale=0.2)
+    psf_img = psf.drawImage(nx=16, ny=16, scale=0.2)
+
+    hsmparams1 = galsim.hsm.HSMParams(ksb_sig_weight=2.0)
+    result1 = galsim.hsm.EstimateShear(gal_img, psf_img, shear_est='KSB', hsmparams=hsmparams1)
+
+    hsmparams2 = galsim.hsm.HSMParams(ksb_sig_weight=1.0, ksb_sig_factor=2.0)
+    result2 = galsim.hsm.EstimateShear(gal_img, psf_img, shear_est='KSB', hsmparams=hsmparams2)
+
+    np.testing.assert_almost_equal(result1.corrected_g1, result2.corrected_g1, 9,
+                                   "KSB weight fn width inconsistently manipulated")
+    np.testing.assert_almost_equal(result1.corrected_g2, result2.corrected_g2, 9,
+                                   "KSB weight fn width inconsistently manipulated")
+
+    t2 = time.time()
+    print 'time for %s = %.2f'%(funcname(),t2-t1)
+
 if __name__ == "__main__":
     test_moments_basic()
     test_shearest_basic()
@@ -792,3 +816,4 @@ if __name__ == "__main__":
     test_shapedata()
     test_strict()
     test_bounds_centroid()
+    test_ksb_sig()


### PR DESCRIPTION
A quick issue-less PR (in branch ksb_width).  For treating galaxy color-gradients, [Semboloni++13](http://adsabs.harvard.edu/abs/2013MNRAS.432.2385S) show that one can trade off SNR and shear bias for moments-based algorithms by manipulating the width of the moments-measuring weight function.  @sowmyakth (grad student at Stanford) and I would like to investigate this further.

After a brief email exchange with @rmandelb , I learned that flexible weight functions could be pretty quickly added to the galsim.hsm package for the KSB method.  This PR adds two keywords to HSMParams that affect the weight function used by the KSB method:

- ksb_sig_weight: assert the width of the weight function (in pixels) directly
- ksb_sig_factor: multiply the auto-generated width by this factor

(Sorry about the whitespace.  Anyone know what happens if I clean up the whitespace in master now?   will it then show up in other existing PRs?, or are PR diffs only relative to the branch at the time of the PR?)