### PR TITLE
#688 Fix pickling error for InterpolatedImage

### DIFF
--- a/galsim/interpolatedimage.py
+++ b/galsim/interpolatedimage.py
@@ -132,6 +132,7 @@ class InterpolatedImage(GSObject):
                                   to be equal to the total flux.
                               "surface brightness" or "sb" means that the pixels sample
                                   the surface brightness distribution at each location.
+                            This is overridden if you specify an explicit flux value.
                             [default: "flux"]
     @param scale            If provided, use this as the pixel scale for the Image; this will
                             override the pixel scale stored by the provided Image, in any.
@@ -445,7 +446,7 @@ class InterpolatedImage(GSObject):
 
         # If the user specified a surface brightness normalization for the input Image, then
         # need to rescale flux by the pixel area to get proper normalization.
-        if normalization.lower() in ['surface brightness','sb']:
+        if flux is None and normalization.lower() in ['surface brightness','sb']:
             flux = sbii.getFlux() * local_wcs.pixelArea()
 
         # Save this intermediate profile

--- a/galsim/interpolatedimage.py
+++ b/galsim/interpolatedimage.py
@@ -443,6 +443,11 @@ class InterpolatedImage(GSObject):
                 # If not a bool, then value is max_maxk
                 sbii.calculateMaxK(max_maxk=calculate_maxk)
 
+        # If the user specified a surface brightness normalization for the input Image, then
+        # need to rescale flux by the pixel area to get proper normalization.
+        if normalization.lower() in ['surface brightness','sb']:
+            flux = sbii.getFlux() * local_wcs.pixelArea()
+
         # Save this intermediate profile
         self._sbii = sbii
         self._stepk = sbii.stepK() / self.min_scale
@@ -471,11 +476,6 @@ class InterpolatedImage(GSObject):
         # If the user specified a flux, then set to that flux value.
         if flux is not None:
             prof = prof.withFlux(float(flux))
-        # If the user specified a surface brightness normalization for the input Image, then
-        # need to rescale flux by the pixel area to get proper normalization.
-        elif normalization.lower() in ['surface brightness','sb']:
-            prof *= local_wcs.pixelArea()
-            self._flux = prof.flux
 
         # Now, in order for these to pickle correctly if they are the "original" object in a
         # Transform object, we need to hide the current transformation.  An easy way to do that

--- a/include/galsim/SBTransformImpl.h
+++ b/include/galsim/SBTransformImpl.h
@@ -35,9 +35,7 @@ namespace galsim {
 
         ~SBTransformImpl() {}
 
-        double xValue(const Position<double>& p) const 
-        { return _adaptee.xValue(inv(p-_cen)) * _fluxScaling; }
-
+        double xValue(const Position<double>& p) const;
         std::complex<double> kValue(const Position<double>& k) const;
 
         bool isAxisymmetric() const { return _stillIsAxisymmetric; }

--- a/src/SBTransform.cpp
+++ b/src/SBTransform.cpp
@@ -493,6 +493,9 @@ namespace galsim {
         }
     }
 
+    double SBTransform::SBTransformImpl::xValue(const Position<double>& p) const
+    { return _adaptee.xValue(inv(p-_cen)) * _fluxScaling; }
+
     std::complex<double> SBTransform::SBTransformImpl::kValue(const Position<double>& k) const
     { return _kValue(_adaptee,fwdT(k),_absdet,k,_cen); }
 


### PR DESCRIPTION
@danielsf reported an failure in `scons tests` when he ran it on his system:
```
.....................................................................................................................................F.....................................................................................................................................................................................................
======================================================================
FAIL: Test how getCOSMOSNoise works when applied to an image with a WCS.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/danielsf/physics/lsst_150412/DarwinX86/anaconda/master-g68783b1848/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/danielsf/GalSim/tests/test_correlatednoise.py", line 1221, in test_cosmos_wcs
    do_pickle(cn_test, lambda x: (x.rng.serialize(), x.getVariance(), x.wcs))
  File "/Users/danielsf/GalSim/tests/galsim_test_helpers.py", line 241, in do_pickle
    assert f1 == f2
AssertionError: 
-------------------- >> begin captured stdout << ---------------------
galsim.JacobianWCS(0.0, 0.03, -0.03, 0.0)
galsim.PositionD(0.0,0.0) 1.7 1.70057149366 1.70057149366
galsim.PositionD(0.03,0.0) 0.570308928167 0.566060550976 0.570207028074
galsim.PositionD(0.0,0.03) 0.571386562149 0.570207028074 0.566060550976
galsim.PositionD(0.03,-0.03) 0.111432980046 0.108687726405 0.749031947896
galsim.PositionD(0.03,0.03) 0.743758358859 0.749031947896 0.108687726405
galsim.PositionD(0.0,0.0) 1.7 1.70239081377 1.70239081377
galsim.PositionD(0.03,0.0) 0.570308928167 0.568750002382 0.566368532814
galsim.PositionD(0.0,0.03) 0.571386562149 0.566368532814 0.568750002382
galsim.PositionD(0.03,-0.03) 0.111432980046 0.74470154093 0.107114964249
galsim.PositionD(0.03,0.03) 0.743758358859 0.107114964249 0.74470154093
Try pickling  galsim.CorrelatedNoise(galsim.Image(bounds=galsim.BoundsI(1,576,1,576), wcs=galsim.JacobianWCS(0.0, 0.03, -0.03, 0.0)), wcs=galsim.JacobianWCS(0.0, 0.03, -0.03, 0.0))

--------------------- >> end captured stdout << ----------------------

----------------------------------------------------------------------
Ran 331 tests in 121.372s

FAILED (failures=1)
```

I managed to reproduce it when I upgraded my Boost version to 1.58.  I tracked down the problem to a rounding error where the original and the pickled version of an InterpolatedImage do a series of multiplications and division in a different order, so in this case they could end up with a different final bit in the double precision fluxScaling.  Obviously not a huge problem, but I managed to fix it by rearranging the order of calculations in the InterpolatedImage constructor.