### PR TITLE
#308 Code to calculate HLR, Sigma, FWHM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,9 @@ Bug Fixes
   ChromaticObjects and image-setup keyword arguments (#683)
 - Added ability to manipulate the width of the moment-measuring weight function
   for the KSB shear estimation method of the galsim.hsm package. (#686)
+
+
+New Features
+------------
+
+- Added methods calculateHLR, calculateMomentRadius, and calculateFWHM. (#308)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,4 +17,5 @@ Bug Fixes
 New Features
 ------------
 
-- Added methods calculateHLR, calculateMomentRadius, and calculateFWHM. (#308)
+- Added methods calculateHLR, calculateMomentRadius, and calculateFWHM to both
+  GSObject and Image. (#308)

--- a/galsim/base.py
+++ b/galsim/base.py
@@ -406,7 +406,11 @@ class GSObject(object):
         it to return det(Q)^1/4.  And `rtype='both'` will return a tuple with both values.
 
         Note that for the special case of a Gaussian profile, no calculation is necessary, and
-        the `sigma` attribute will be used in both cases.
+        the `sigma` attribute will be used in both cases.  In the limit as scale->0, this 
+        function will return the same value, but because finite pixels are drawn, the results
+        will not be precisely equal for real use cases.  The approximation being made is that
+        the integral of I(x,y) i j dx dy over each pixel can be approximated as
+        int(I(x,y) dx dy) * i_center * j_center.
 
         The function optionally takes size and scale values to use for the image drawing.
         The default scale is the nyquist scale, which generally produces results accurate

--- a/galsim/base.py
+++ b/galsim/base.py
@@ -344,21 +344,27 @@ class GSObject(object):
         If the profile has a half_light_radius attribute, it will just return that, but in the
         general case, we draw the profile and estimate the half-light radius directly.
 
-        The function optionally takes size and scale values to use for the image drawing.
-        The default scale is half the nyquist scale, which generally produces results accurate
-        to about 1 decimal place.  Using a smaller scale will be more accurate at the expense
-        of speed.  The default size is None, which means drawImage will choose a size designed
-        to contain around 99.5% of the flux.  This is overkill for this calculation, so 
-        choosing a smaller size than this may speed up this calculation somewhat.
+        This function (by default at least) is only accurate to a few percent, typically.
+        Possibly worse depending on the profile being measured.  If you care about a high 
+        precision estimate of the half-light radius, the accuracy can be improved using the
+        optional parameter scale to change the pixel scale used to draw the profile.
+
+        The default scale is half the Nyquist scale, which were found to produce results accurate
+        to a few percent on our internal tests.  Using a smaller scale will be more accurate at
+        the expense of speed.
+
+        In addition, you can optionally specify the size of the image to draw. The default size is
+        None, which means drawImage will choose a size designed to contain around 99.5% of the
+        flux.  This is overkill for this calculation, so choosing a smaller size than this may
+        speed up this calculation somewhat.
 
         Also, while the name of this function refers to the half-light radius, in fact it can also
         calculate radii that enclose other fractions of the light, according to the parameter
         `flux_frac`.  E.g. for r90, you would set flux_frac=0.90.
 
-        Note: The results from this calculation should be taken as approximate at best.
-              They should usually be acceptable for things like testing that a galaxy has a
-              reasonable resolution, but they should not be trusted for very fine grain
-              discriminations.
+        The default scale should usually be acceptable for things like testing that a galaxy
+        has a reasonable resolution, but they should not be trusted for very fine grain
+        discriminations.
 
         @param size         If given, the stamp size to use for the drawn image. [default: None,
                             which will let drawImage choose the size automatically]
@@ -412,17 +418,19 @@ class GSObject(object):
         the integral of I(x,y) i j dx dy over each pixel can be approximated as
         int(I(x,y) dx dy) * i_center * j_center.
 
-        The function optionally takes size and scale values to use for the image drawing.
-        The default scale is the nyquist scale, which generally produces results accurate
-        to about 1 decimal place.  Using a smaller scale will be more accurate at the expense
-        of speed.  The default size is None, which means drawImage will choose a size designed
-        to contain around 99.5% of the flux.  Using a larger size will again be more accurate
-        at the expense of speed.
+        This function (by default at least) is only accurate to a few percent, typically.
+        Possibly worse depending on the profile being measured.  If you care about a high 
+        precision estimate of the radius, the accuracy can be improved using the optional
+        parameters size and scale to change the size and pixel scale used to draw the profile.
 
-        Note: The results from this calculation should be taken as approximate at best.
-              They should usually be acceptable for things like testing that a galaxy has a
-              reasonable resolution, but they should not be trusted for very fine grain
-              discriminations.  For a more accurate estimate, see galsim.hsm.FindAdaptiveMom.
+        The default is to use the the Nyquist scale for the pixel scale and let drawImage 
+        choose a size for the stamp that will enclose at least 99.5% of the flux.  These
+        were found to produce results accurate to a few percent on our internal tests.
+        Using a smaller scale and larger size will be more accurate at the expense of speed.
+
+        The default parameters should usually be acceptable for things like testing that a galaxy
+        has a reasonable resolution, but they should not be trusted for very fine grain
+        discriminations.  For a more accurate estimate, see galsim.hsm.FindAdaptiveMom.
 
         @param size         If given, the stamp size to use for the drawn image. [default: None,
                             which will let drawImage choose the size automatically]
@@ -465,17 +473,13 @@ class GSObject(object):
         If the profile has a fwhm attribute, it will just return that, but in the general case,
         we draw the profile and estimate the FWHM directly.
 
-        The function optionally takes size and scale values to use for the image drawing.
-        The default scale is half the nyquist scale, which generally produces results accurate
-        to about 1 decimal place.  Using a smaller scale will be more accurate at the expense
-        of speed.  The default size is None, which means drawImage will choose a size designed
-        to contain around 99.5% of the flux.  This is overkill for this calculation, so 
-        choosing a smaller size than this may speed up this calculation somewhat.
-
-        Note: The results from this calculation should be taken as approximate at best.
-              They should usually be acceptable for things like testing that a galaxy has a
-              reasonable resolution, but they should not be trusted for very fine grain
-              discriminations.
+        As with calculateHLR and calculateMomentRadius, this function optionally takes size and
+        scale values to use for the image drawing.  The default is to use the the Nyquist scale
+        for the pixel scale and let drawImage choose a size for the stamp that will enclose at
+        least 99.5% of the flux.  These were found to produce results accurate to well below
+        one percent on our internal tests, so it is unlikely that you will want to adjust
+        them for accuracy.  However, using a smaller size than default could help speed up
+        the calculation, since the default is usually much larger than is needed.
 
         @param size         If given, the stamp size to use for the drawn image. [default: None,
                             which will let drawImage choose the size automatically]

--- a/galsim/base.py
+++ b/galsim/base.py
@@ -368,7 +368,7 @@ class GSObject(object):
         @param flux_frac    The fraction of light to be enclosed by the returned radius.
                             [default: 0.5]
 
-        @returns an estimate of the half-light radius
+        @returns an estimate of the half-light radius in physical units
         """
         if hasattr(self, 'half_light_radius'): 
             return self.half_light_radius
@@ -417,9 +417,9 @@ class GSObject(object):
 
 
     def calculateMomentRadius(self, size=None, scale=None, centroid=None, rtype='det'):
-        """Returns an estimate of the radius based on second moments.
+        """Returns an estimate of the radius based on unweighted second moments.
 
-        The second moments are defines as:
+        The second moments are defined as:
 
         Q_ij = int( I(x,y) i j dx dy ) / int( I(x,y) dx dy )
         where i,j may be either x or y.
@@ -446,7 +446,7 @@ class GSObject(object):
         Note: The results from this calculation should be taken as approximate at best.
               They should usually be acceptable for things like testing that a galaxy has a
               reasonable resolution, but they should not be trusted for very fine grain
-              discriminations.  For a more accurate estimate, see galsim.hlm.FindAdaptiveMom.
+              discriminations.  For a more accurate estimate, see galsim.hsm.FindAdaptiveMom.
 
         @param size         If given, the stamp size to use for the drawn image. [default: None,
                             which will let drawImage choose the size automatically]
@@ -459,7 +459,7 @@ class GSObject(object):
                             - 'both' means return both: (sqrt(T/2), det(Q)^1/4)
                             [default: 'det']
 
-        @returns an estimate of the radius (or both estimates if rtype == 'both')
+        @returns an estimate of the radius in physical units (or both estimates if rtype == 'both')
         """
         if rtype not in ['trace', 'det', 'both']:
             raise ValueError("rtype must be one of 'trace', 'det', or 'both'")
@@ -533,7 +533,7 @@ class GSObject(object):
                             self.nyquistScale()]
         @param centroid     The position to use for the centroid. [default: self.centroid()]
 
-        @returns an estimate of the full-width half-maximum
+        @returns an estimate of the full-width half-maximum in physical units
         """
         if hasattr(self, 'fwhm'): 
             return self.fwhm

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -600,6 +600,8 @@ class Image(object):
         been drawn onto an image.  Note that the profile should be drawn using a method that
         integrates over pixels and does not add noise. (The default method='auto' is acceptable.)
 
+        If the image has a wcs other than a PixelScale, an AttributeError will be raised.
+
         @param center       The position in pixels to use for the center, r=0. 
                             [default: self.trueCenter()]
         @param flux         The total flux.  [default: sum(self.array)]
@@ -652,6 +654,8 @@ class Image(object):
         This method is equivalent to GSObject.calculateMomentRadius when the object has already
         been drawn onto an image.  Note that the profile should be drawn using a method that
         integrates over pixels and does not add noise. (The default method='auto' is acceptable.)
+
+        If the image has a wcs other than a PixelScale, an AttributeError will be raised.
 
         @param center       The position in pixels to use for the center, r=0. 
                             [default: self.trueCenter()]
@@ -711,6 +715,8 @@ class Image(object):
         been drawn onto an image.  Note that the profile should be drawn using a method that
         does not integrate over pixels, so either 'sb' or 'no_pixel'.  Also, if there is a
         significant amount of noise in the image, this method may not work well.
+
+        If the image has a wcs other than a PixelScale, an AttributeError will be raised.
 
         @param center       The position in pixels to use for the center, r=0. 
                             [default: self.trueCenter()]

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -593,6 +593,169 @@ class Image(object):
         """
         self.image.invertSelf()
 
+    def calculateHLR(self, center=None, flux=None, flux_frac=0.5):
+        """Returns the half-light radius of a drawn object.
+
+        This method is equivalent to GSObject.calculateHLR when the object has already been
+        been drawn onto an image.  Note that the profile should be drawn using a method that
+        integrates over pixels and does not add noise. (The default method='auto' is acceptable.)
+
+        @param center       The position in pixels to use for the center, r=0. 
+                            [default: self.trueCenter()]
+        @param flux         The total flux.  [default: sum(self.array)]
+        @param flux_frac    The fraction of light to be enclosed by the returned radius.
+                            [default: 0.5]
+
+        @returns an estimate of the half-light radius in physical units defined by the pixel scale.
+        """
+        if center is None:
+            center = self.trueCenter()
+
+        if flux is None:
+            flux = numpy.sum(self.array)
+
+        # Use radii at centers of pixels as approximation to the radial integral
+        x,y = numpy.meshgrid(range(self.array.shape[0]), range(self.array.shape[1]))
+        x = x - (center.x - self.bounds.xmin)
+        y = y - (center.y - self.bounds.ymin)
+        rsq = x*x + y*y
+
+        # Sort by radius
+        indx = numpy.argsort(rsq.flatten())
+        rsqf = rsq.flatten()[indx]
+        data = self.array.flatten()[indx]
+        cumflux = numpy.cumsum(data)
+
+        # Find the first value with cumflux > 0.5 * flux
+        k = numpy.argmax(cumflux > flux_frac * flux)
+        flux_k = cumflux[k] / flux  # normalize to unit total flux
+
+        # Interpolate (linearly) between this and the previous value.
+        if k == 0:
+            hlrsq = rsqf[0] * (flux_frac / flux_k)
+        else:
+            fkm1 = cumflux[k-1] / flux
+            # For brevity in the next formula:
+            fk = flux_k
+            f = flux_frac
+            hlrsq = (rsqf[k-1] * (fk-f) + rsqf[k] * (f-fkm1)) / (fk-fkm1)
+
+        # This has all been done in pixels.  So normalize according to the pixel scale.
+        hlr = numpy.sqrt(hlrsq) * self.scale
+
+        return hlr
+
+
+    def calculateMomentRadius(self, center=None, flux=None, rtype='det'):
+        """Returns an estimate of the radius based on unweighted second moments of a drawn object.
+
+        This method is equivalent to GSObject.calculateMomentRadius when the object has already
+        been drawn onto an image.  Note that the profile should be drawn using a method that
+        integrates over pixels and does not add noise. (The default method='auto' is acceptable.)
+
+        @param center       The position in pixels to use for the center, r=0. 
+                            [default: self.trueCenter()]
+        @param flux         The total flux.  [default: sum(self.array)]
+        @param rtype        There are three options for this parameter:
+                            - 'trace' means return sqrt(T/2)
+                            - 'det' means return det(Q)^1/4
+                            - 'both' means return both: (sqrt(T/2), det(Q)^1/4)
+                            [default: 'det']
+
+        @returns an estimate of the radius in physical units defined by the pixel scale 
+                 (or both estimates if rtype == 'both').
+        """
+        if rtype not in ['trace', 'det', 'both']:
+            raise ValueError("rtype must be one of 'trace', 'det', or 'both'")
+
+        if center is None:
+            center = self.trueCenter()
+
+        if flux is None:
+            flux = numpy.sum(self.array)
+
+        # Use radii at centers of pixels as approximation to the radial integral
+        x,y = numpy.meshgrid(range(self.array.shape[0]), range(self.array.shape[1]))
+        x = x - (center.x - self.bounds.xmin)
+        y = y - (center.y - self.bounds.ymin)
+
+        if rtype in ['trace', 'both']:
+            # Calculate trace measure:
+            rsq = x*x + y*y
+            Irr = numpy.sum(rsq * self.array) / flux
+
+            # This has all been done in pixels.  So normalize according to the pixel scale.
+            sigma_trace = (Irr/2.)**0.5 * self.scale
+
+        if rtype in ['det', 'both']:
+            # Calculate det measure:
+            Ixx = numpy.sum(x*x * self.array) / flux
+            Iyy = numpy.sum(y*y * self.array) / flux
+            Ixy = numpy.sum(x*y * self.array) / flux
+
+            # This has all been done in pixels.  So normalize according to the pixel scale.
+            sigma_det = (Ixx*Iyy-Ixy**2)**0.25 * self.scale
+
+        if rtype == 'trace':
+            return sigma_trace
+        elif rtype == 'det':
+            return sigma_det
+        else:
+            return sigma_trace, sigma_det
+
+
+    def calculateFWHM(self, center=None, Imax=0.):
+        """Returns the full-width half-maximum (FWHM) of a drawn object.
+
+        This method is equivalent to GSObject.calculateMomentRadius when the object has already
+        been drawn onto an image.  Note that the profile should be drawn using a method that
+        does not integrate over pixels, so either 'sb' or 'no_pixel'.  Also, if there is a
+        significant amount of noise in the image, this method may not work well.
+
+        @param center       The position in pixels to use for the center, r=0. 
+                            [default: self.trueCenter()]
+        @param Imax         The maximum surface brightness.  [default: max(self.array)]
+                            Note: If Imax is provided, and the maximum pixel value is larger than
+                            this value, Imax will be updated to use the larger value.
+
+        @returns an estimate of the full-width half-maximum in physical units defined by the
+                 pixel scale.
+        """
+        if center is None:
+            center = self.trueCenter()
+
+        # If the full image has a larger maximum, use that.
+        Imax2 = numpy.max(self.array)
+        if Imax2 > Imax: Imax = Imax2
+
+        # Use radii at centers of pixels.
+        x,y = numpy.meshgrid(range(self.array.shape[0]), range(self.array.shape[1]))
+        x = x - (center.x - self.bounds.xmin)
+        y = y - (center.y - self.bounds.ymin)
+        rsq = x*x + y*y
+
+        # Sort by radius
+        indx = numpy.argsort(rsq.flatten())
+        rsqf = rsq.flatten()[indx]
+        data = self.array.flatten()[indx]
+
+        # Find the first value with I < 0.5 * Imax
+        k = numpy.argmax(data < 0.5 * Imax)
+        Ik = data[k] / Imax
+
+        # Interpolate (linearly) between this and the previous value.
+        if k == 0:
+            rsqhm = rsqf[0] * (0.5 / Ik)
+        else:
+            Ikm1 = data[k-1] / Imax
+            rsqhm = (rsqf[k-1] * (Ik-0.5) + rsqf[k] * (0.5-Ikm1)) / (Ik-Ikm1)
+
+        # This has all been done in pixels.  So normalize according to the pixel scale.
+        fwhm = 2. * numpy.sqrt(rsqhm) * self.scale
+
+        return fwhm
+
+
     def __eq__(self, other):
         return ( isinstance(other, Image) and
                  self.bounds == other.bounds and

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -615,7 +615,7 @@ class Image(object):
             flux = numpy.sum(self.array)
 
         # Use radii at centers of pixels as approximation to the radial integral
-        x,y = numpy.meshgrid(range(self.array.shape[0]), range(self.array.shape[1]))
+        x,y = numpy.meshgrid(range(self.array.shape[1]), range(self.array.shape[0]))
         x = x - (center.x - self.bounds.xmin)
         y = y - (center.y - self.bounds.ymin)
         rsq = x*x + y*y
@@ -675,7 +675,7 @@ class Image(object):
             flux = numpy.sum(self.array)
 
         # Use radii at centers of pixels as approximation to the radial integral
-        x,y = numpy.meshgrid(range(self.array.shape[0]), range(self.array.shape[1]))
+        x,y = numpy.meshgrid(range(self.array.shape[1]), range(self.array.shape[0]))
         x = x - (center.x - self.bounds.xmin)
         y = y - (center.y - self.bounds.ymin)
 
@@ -729,7 +729,7 @@ class Image(object):
         if Imax2 > Imax: Imax = Imax2
 
         # Use radii at centers of pixels.
-        x,y = numpy.meshgrid(range(self.array.shape[0]), range(self.array.shape[1]))
+        x,y = numpy.meshgrid(range(self.array.shape[1]), range(self.array.shape[0]))
         x = x - (center.x - self.bounds.xmin)
         y = y - (center.y - self.bounds.ymin)
         rsq = x*x + y*y

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -618,8 +618,8 @@ class Image(object):
 
         # Use radii at centers of pixels as approximation to the radial integral
         x,y = numpy.meshgrid(range(self.array.shape[1]), range(self.array.shape[0]))
-        x = x - (center.x - self.bounds.xmin)
-        y = y - (center.y - self.bounds.ymin)
+        x = x - center.x + self.bounds.xmin
+        y = y - center.y + self.bounds.ymin
         rsq = x*x + y*y
 
         # Sort by radius
@@ -680,8 +680,8 @@ class Image(object):
 
         # Use radii at centers of pixels as approximation to the radial integral
         x,y = numpy.meshgrid(range(self.array.shape[1]), range(self.array.shape[0]))
-        x = x - (center.x - self.bounds.xmin)
-        y = y - (center.y - self.bounds.ymin)
+        x = x - center.x + self.bounds.xmin
+        y = y - center.y + self.bounds.ymin
 
         if rtype in ['trace', 'both']:
             # Calculate trace measure:
@@ -736,8 +736,8 @@ class Image(object):
 
         # Use radii at centers of pixels.
         x,y = numpy.meshgrid(range(self.array.shape[1]), range(self.array.shape[0]))
-        x = x - (center.x - self.bounds.xmin)
-        y = y - (center.y - self.bounds.ymin)
+        x = x - center.x + self.bounds.xmin
+        y = y - center.y + self.bounds.ymin
         rsq = x*x + y*y
 
         # Sort by radius

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -101,5 +101,64 @@ def test_hlr():
     print 'time for %s = %.2f'%(funcname(),t2-t1)
 
 
+def test_sigma():
+    """Test the calculateSigma method.
+    """
+    import time
+    t1 = time.time()
+
+    # Compare the calculation for a simple Gaussian.
+    g1 = galsim.Gaussian(sigma=5, flux=1.7)
+
+    print 'g1 native sigma = ',g1.sigma
+    print 'g1.calculateSigma = ',g1.calculateSigma()
+    # These should be exactly equal.
+    np.testing.assert_equal(g1.sigma, g1.calculateSigma(),
+                            err_msg="Gaussian.calculateSigma() returned wrong value.")
+
+    # Check for a convolution of two Gaussians.  Should be equivalent, but now will need to 
+    # do the calculation.
+    g2 = galsim.Convolve(galsim.Gaussian(sigma=3, flux=1.3), galsim.Gaussian(sigma=4, flux=23))
+    test_sigma = g2.calculateSigma()
+    print 'g2.calculateSigma = ',test_sigma
+    print 'ratio - 1 = ',test_sigma/g1.sigma-1
+    np.testing.assert_almost_equal(test_sigma/g1.sigma, 1.0, decimal=1,
+                                   err_msg="Gaussian.calculateSigma() is not accurate.")
+
+    # The default scale and size is only accurate to around 1 dp.# Using scale = 0.1 is accurate
+    # to 3 dp.
+    test_sigma = g2.calculateSigma(scale=0.1)
+    print 'g2.calculateSigma(scale=0.1) = ',test_sigma
+    print 'ratio - 1 = ',test_sigma/g1.sigma-1
+    np.testing.assert_almost_equal(test_sigma/g1.sigma, 1.0, decimal=3,
+                                   err_msg="Gaussian.calculateSigma(scale=0.1) is not accurate.")
+    
+    # Next, use an Exponential profile
+    e1 = galsim.Exponential(scale_radius=5, flux=1.7)
+
+    # The true "sigma" for this is analytic, but not an attribute.
+    e1_sigma = np.sqrt(3.0) * e1.scale_radius
+    print 'true e1 sigma = sqrt(3) * e1.scale_radius = ',e1_sigma
+
+    # Test with the default scale and size.
+    test_sigma = e1.calculateSigma()
+    print 'e1.calculateSigma = ',test_sigma
+    print 'ratio - 1 = ',test_sigma/e1_sigma-1
+    np.testing.assert_almost_equal(test_sigma/e1_sigma, 1.0, decimal=1,
+                                   err_msg="Exponential.calculateSigma() is not accurate.")
+
+    # The default scale and size is only accurate to around 1 dp.  This time we have to both
+    # decrease the scale and also increase the size to get 3 dp of precision.
+    test_sigma = e1.calculateSigma(scale=0.1, size=2000)
+    print 'e1.calculateSigma(scale=0.1) = ',test_sigma
+    print 'ratio - 1 = ',test_sigma/e1_sigma-1
+    np.testing.assert_almost_equal(test_sigma/e1_sigma, 1.0, decimal=3,
+                                   err_msg="Exponential.calculateSigma(scale=0.1) is not accurate.")
+
+    t2 = time.time()
+    print 'time for %s = %.2f'%(funcname(),t2-t1)
+
+
 if __name__ == "__main__":
     test_hlr()
+    test_sigma()

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -97,6 +97,17 @@ def test_hlr():
     np.testing.assert_almost_equal(test_hlr/e1.half_light_radius, 1.0, decimal=3,
                                    err_msg="Exponential.calculateHLR(scale=0.1) is not accurate.")
 
+    # The calculateHLR method can also return other radii like r90, rather than r50 using the
+    # parameter flux_fraction.  This is also analytic for Exponential
+    r90 = 3.889720170 * e1.scale_radius
+    test_r90 = e2.calculateHLR(scale=0.1, flux_frac=0.9)
+    print 'r90 = ',r90
+    print 'e2.calculateHLR(scale=0.1, flux_frac=0.9) = ',test_r90
+    print 'ratio - 1 = ',test_r90/r90-1
+    np.testing.assert_almost_equal(test_r90/r90, 1.0, decimal=3,
+                                   err_msg="Exponential r90 calculation is not accurate.")
+
+
     t2 = time.time()
     print 'time for %s = %.2f'%(funcname(),t2-t1)
 

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2012-2015 by the GalSim developers team on GitHub
+# https://github.com/GalSim-developers
+#
+# This file is part of GalSim: The modular galaxy image simulation toolkit.
+# https://github.com/GalSim-developers/GalSim
+#
+# GalSim is free software: redistribution and use in source and binary forms,
+# with or without modification, are permitted provided that the following
+# conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions, and the disclaimer given in the accompanying LICENSE
+#    file.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions, and the disclaimer given in the documentation
+#    and/or other materials provided with the distribution.
+#
+import numpy as np
+
+from galsim_test_helpers import *
+
+try:
+    import galsim
+except ImportError:
+    sys.path.append(os.path.abspath(os.path.join(path, "..")))
+    import galsim
+
+def test_hlr():
+    """Test the calculateHLR method.
+    """
+    import time
+    t1 = time.time()
+
+    # Compare the calculation for a simple Gaussian.
+    g1 = galsim.Gaussian(sigma=5, flux=1.7)
+
+    print 'g1 native hlr = ',g1.half_light_radius
+    print 'g1.calculateHLR = ',g1.calculateHLR()
+    print 'nyquist scale = ',g1.nyquistScale()
+    # These should be exactly equal.
+    np.testing.assert_equal(g1.half_light_radius, g1.calculateHLR(),
+                            err_msg="Gaussian.calculateHLR() returned wrong value.")
+
+    # Check for a convolution of two Gaussians.  Should be equivalent, but now will need to 
+    # do the calculation.
+    g2 = galsim.Convolve(galsim.Gaussian(sigma=3, flux=1.3), galsim.Gaussian(sigma=4, flux=23))
+    test_hlr = g2.calculateHLR()
+    print 'g2.calculateHLR = ',test_hlr
+    print 'ratio - 1 = ',test_hlr/g1.half_light_radius-1
+    np.testing.assert_almost_equal(test_hlr/g1.half_light_radius, 1.0, decimal=1,
+                                   err_msg="Gaussian.calculateHLR() is not accurate.")
+
+    # The default scale is only accurate to around 1 dp.  Using scale = 0.1 is accurate to 3 dp.
+    # Note: Nyquist scale is about 4.23 for this profile.
+    test_hlr = g2.calculateHLR(scale=0.1)
+    print 'g2.calculateHLR(scale=0.1) = ',test_hlr
+    print 'ratio - 1 = ',test_hlr/g1.half_light_radius-1
+    np.testing.assert_almost_equal(test_hlr/g1.half_light_radius, 1.0, decimal=3,
+                                   err_msg="Gaussian.calculateHLR(scale=0.1) is not accurate.")
+
+    # Finally, we don't expect this to be accurate, but make sure the code can handle having
+    # more than half the flux in the central pixel.
+    test_hlr = g2.calculateHLR(scale=15)
+    print 'g2.calculateHLR(scale=15) = ',test_hlr
+    print 'ratio - 1 = ',test_hlr/g1.half_light_radius-1
+    np.testing.assert_almost_equal(test_hlr/g1.half_light_radius/10, 0.1, decimal=1,
+                                   err_msg="Gaussian.calculateHLR(scale=15) is not accurate.")
+
+    # Next, use an Exponential profile
+    e1 = galsim.Exponential(scale_radius=5, flux=1.7)
+
+    print 'e1 native hlr = ',e1.half_light_radius
+    print 'e1.calculateHLR = ',e1.calculateHLR()
+    print 'nyquist scale = ',e1.nyquistScale()
+    # These should be exactly equal.
+    np.testing.assert_equal(e1.half_light_radius, e1.calculateHLR(),
+                            err_msg="Exponential.calculateHLR() returned wrong value.")
+
+    # Check for a convolution with a delta function.  Should be equivalent, but now will need to 
+    # do the calculation.
+    e2 = galsim.Convolve(galsim.Exponential(scale_radius=5, flux=1.3), 
+                         galsim.Gaussian(sigma=1.e-4, flux=23))
+    test_hlr = e2.calculateHLR()
+    print 'e2.calculateHLR = ',test_hlr
+    print 'ratio - 1 = ',test_hlr/e1.half_light_radius-1
+    np.testing.assert_almost_equal(test_hlr/e1.half_light_radius, 1.0, decimal=1,
+                                   err_msg="Exponential.calculateHLR() is not accurate.")
+
+    # The default scale is only accurate to around 1 dp.  Using scale = 0.1 is accurate to 3 dp.
+    # Note: Nyquist scale is about 1.57 for this profile.
+    # We can also decrease the size, which should still be accurate, but maybe a little faster.
+    # Go a bit more that 2*hlr in units of the pixels.
+    size = 2.1 * e1.half_light_radius / 0.1
+    test_hlr = e2.calculateHLR(scale=0.1, size=size)
+    print 'e2.calculateHLR(scale=0.1) = ',test_hlr
+    print 'ratio - 1 = ',test_hlr/e1.half_light_radius-1
+    np.testing.assert_almost_equal(test_hlr/e1.half_light_radius, 1.0, decimal=3,
+                                   err_msg="Exponential.calculateHLR(scale=0.1) is not accurate.")
+
+    t2 = time.time()
+    print 'time for %s = %.2f'%(funcname(),t2-t1)
+
+
+if __name__ == "__main__":
+    test_hlr()

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -97,6 +97,20 @@ def test_hlr():
     np.testing.assert_almost_equal(test_hlr/e1.half_light_radius, 1.0, decimal=3,
                                    err_msg="Exponential.calculateHLR(scale=0.1) is not accurate.")
 
+    # Check that it works if the centroid is not at the origin
+    e3 = e2.shift(2,3)
+    test_hlr = e3.calculateHLR(scale=0.1)
+    print 'e3.calculateHLR(scale=0.1) = ',test_hlr
+    print 'ratio - 1 = ',test_hlr/e1.half_light_radius-1
+    np.testing.assert_almost_equal(test_hlr/e1.half_light_radius, 1.0, decimal=3,
+                                   err_msg="shifted Exponential HLR is not accurate.")
+
+    # Can set a centroid manually.  This should be equivalent to the default.
+    print 'e3.centroid = ',e3.centroid()
+    test_hlr = e3.calculateHLR(scale=0.1, centroid=e3.centroid())
+    np.testing.assert_almost_equal(test_hlr/e1.half_light_radius, 1.0, decimal=3,
+                                   err_msg="shifted HLR with explicit centroid is not accurate.")
+
     # The calculateHLR method can also return other radii like r90, rather than r50 using the
     # parameter flux_fraction.  This is also analytic for Exponential
     r90 = 3.889720170 * e1.scale_radius
@@ -106,7 +120,6 @@ def test_hlr():
     print 'ratio - 1 = ',test_r90/r90-1
     np.testing.assert_almost_equal(test_r90/r90, 1.0, decimal=3,
                                    err_msg="Exponential r90 calculation is not accurate.")
-
 
     t2 = time.time()
     print 'time for %s = %.2f'%(funcname(),t2-t1)
@@ -211,6 +224,23 @@ def test_sigma():
             test_sigma/e1_sigma, 1.0, decimal=4,
             err_msg="Exponential.calculateMomentRadius(scale=0.1) is not accurate.")
 
+    # Check that it works if the centroid is not at the origin
+    e3 = e1.shift(2,3)
+    test_sigma = e3.calculateMomentRadius(scale=0.1, size=2000)
+    print 'e1.calculateMomentRadius(scale=0.1) = ',test_sigma
+    print 'ratio - 1 = ',test_sigma/e1_sigma-1
+    np.testing.assert_almost_equal(
+            test_sigma/e1_sigma, 1.0, decimal=4,
+            err_msg="shifted Exponential MomentRadius is not accurate.")
+
+    # Can set a centroid manually.  This should be equivalent to the default.
+    print 'e3.centroid = ',e3.centroid()
+    test_sigma = e3.calculateMomentRadius(scale=0.1, size=2000, centroid=e3.centroid())
+    np.testing.assert_almost_equal(
+            test_sigma/e1_sigma, 1.0, decimal=4,
+            err_msg="shifted MomentRadius with explicit centroid is not accurate.")
+
+
     t2 = time.time()
     print 'time for %s = %.2f'%(funcname(),t2-t1)
 
@@ -277,6 +307,21 @@ def test_fwhm():
     print 'ratio - 1 = ',test_fwhm/e1_fwhm-1
     np.testing.assert_almost_equal(test_fwhm/e1_fwhm, 1.0, decimal=7,
                                    err_msg="Exponential.calculateFWHM(scale=0.1) is not accurate.")
+
+    # Check that it works if the centroid is not at the origin
+    e3 = e1.shift(2,3)
+    test_fwhm = e3.calculateFWHM(scale=0.1)
+    print 'e3.calculateFWHM(scale=0.1) = ',test_fwhm
+    print 'ratio - 1 = ',test_fwhm/e1_fwhm-1
+    np.testing.assert_almost_equal(test_fwhm/e1_fwhm, 1.0, decimal=6,
+                                   err_msg="shifted Exponential FWHM is not accurate.")
+
+    # Can set a centroid manually.  This should be equivalent to the default.
+    print 'e3.centroid = ',e3.centroid()
+    test_fwhm = e3.calculateFWHM(scale=0.1)
+    np.testing.assert_almost_equal(test_fwhm/e1_fwhm, 1.0, decimal=6,
+                                   err_msg="shifted FWHM with explicit centroid is not accurate.")
+
 
     t2 = time.time()
     print 'time for %s = %.2f'%(funcname(),t2-t1)

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -90,7 +90,7 @@ def test_hlr():
     # Note: Nyquist scale is about 1.57 for this profile.
     # We can also decrease the size, which should still be accurate, but maybe a little faster.
     # Go a bit more that 2*hlr in units of the pixels.
-    size = 2.1 * e1.half_light_radius / 0.1
+    size = int(2.2 * e1.half_light_radius / 0.1)
     test_hlr = e2.calculateHLR(scale=0.1, size=size)
     print 'e2.calculateHLR(scale=0.1) = ',test_hlr
     print 'ratio - 1 = ',test_hlr/e1.half_light_radius-1
@@ -120,6 +120,26 @@ def test_hlr():
     print 'ratio - 1 = ',test_r90/r90-1
     np.testing.assert_almost_equal(test_r90/r90, 1.0, decimal=3,
                                    err_msg="Exponential r90 calculation is not accurate.")
+
+    # Check the image version.
+    im = e1.drawImage(scale=0.1)
+    test_hlr = im.calculateHLR(flux=e1.flux)
+    print 'im.calculateHLR() = ',test_hlr
+    print 'ratio - 1 = ',test_hlr/e1.half_light_radius-1
+    np.testing.assert_almost_equal(test_hlr/e1.half_light_radius, 1.0, decimal=3,
+                                   err_msg="image.calculateHLR is not accurate.")
+
+    # Check that a non-square image works correctly.  Also, not centered anywhere in particular.
+    #bounds = galsim.BoundsI(-1234, -1234+size*2, 8234, 8234+size)
+    bounds = galsim.BoundsI(1, 1+size*2, 1, 1+size)
+    #offset = galsim.PositionD(29,1)
+    offset = galsim.PositionD(0,0)
+    im = e1.drawImage(scale=0.1, bounds=bounds, offset=offset)
+    test_hlr = im.calculateHLR(flux=e1.flux, center=im.trueCenter()+offset)
+    print 'im.calculateHLR() = ',test_hlr
+    print 'ratio - 1 = ',test_hlr/e1.half_light_radius-1
+    np.testing.assert_almost_equal(test_hlr/e1.half_light_radius, 1.0, decimal=3,
+                                   err_msg="non-square image.calculateHLR is not accurate.")
 
     t2 = time.time()
     print 'time for %s = %.2f'%(funcname(),t2-t1)
@@ -240,6 +260,26 @@ def test_sigma():
             test_sigma/e1_sigma, 1.0, decimal=4,
             err_msg="shifted MomentRadius with explicit centroid is not accurate.")
 
+    # Check the image version.
+    size = 2000
+    im = e1.drawImage(scale=0.1, nx=size, ny=size)
+    test_sigma = im.calculateMomentRadius(flux=e1.flux)
+    print 'im.calculateMomentRadius() = ',test_sigma
+    print 'ratio - 1 = ',test_sigma/e1_sigma-1
+    np.testing.assert_almost_equal(
+            test_sigma/e1_sigma, 1.0, decimal=4,
+            err_msg="image.calculateMomentRadius is not accurate.")
+
+    # Check that a non-square image works correctly.  Also, not centered anywhere in particular.
+    bounds = galsim.BoundsI(-1234, -1234+size*2, 8234, 8234+size)
+    offset = galsim.PositionD(29,1)
+    im = e1.drawImage(scale=0.1, bounds=bounds, offset=offset)
+    test_hlr = im.calculateMomentRadius(flux=e1.flux, center=im.trueCenter()+offset)
+    print 'im.calculateMomentRadius() = ',test_sigma
+    print 'ratio - 1 = ',test_sigma/e1_sigma-1
+    np.testing.assert_almost_equal(
+            test_sigma/e1_sigma, 1.0, decimal=4,
+            err_msg="non-square image.calculateMomentRadius is not accurate.")
 
     t2 = time.time()
     print 'time for %s = %.2f'%(funcname(),t2-t1)
@@ -301,7 +341,7 @@ def test_fwhm():
     # The default scale already accurate to around 3 dp.  Using scale = 0.1 is accurate to 7 dp.
     # We can also decrease the size, which should still be accurate, but maybe a little faster.
     # Go a bit more that fwhm in units of the pixels.
-    size = 1.2 * e1_fwhm / 0.1
+    size = int(1.2 * e1_fwhm / 0.1)
     test_fwhm = e1.calculateFWHM(scale=0.1, size=size)
     print 'e1.calculateFWHM(scale=0.1) = ',test_fwhm
     print 'ratio - 1 = ',test_fwhm/e1_fwhm-1
@@ -322,6 +362,23 @@ def test_fwhm():
     np.testing.assert_almost_equal(test_fwhm/e1_fwhm, 1.0, decimal=6,
                                    err_msg="shifted FWHM with explicit centroid is not accurate.")
 
+    # Check the image version.
+    im = e1.drawImage(scale=0.1, method='sb')
+    test_fwhm = im.calculateFWHM(Imax=e1.xValue(0,0))
+    print 'im.calculateFWHM() = ',test_fwhm
+    print 'ratio - 1 = ',test_fwhm/e1_fwhm-1
+    np.testing.assert_almost_equal(test_fwhm/e1_fwhm, 1.0, decimal=6,
+                                   err_msg="image.calculateFWHM is not accurate.")
+
+    # Check that a non-square image works correctly.  Also, not centered anywhere in particular.
+    bounds = galsim.BoundsI(-1234, -1234+size*2, 8234, 8234+size)
+    offset = galsim.PositionD(29,1)
+    im = e1.drawImage(scale=0.1, bounds=bounds, offset=offset, method='sb')
+    test_fwhm = im.calculateFWHM(Imax=e1.xValue(0,0), center=im.trueCenter()+offset)
+    print 'im.calculateFWHM() = ',test_fwhm
+    print 'ratio - 1 = ',test_fwhm/e1_fwhm-1
+    np.testing.assert_almost_equal(test_fwhm/e1_fwhm, 1.0, decimal=6,
+                                   err_msg="non-square image.calculateFWHM is not accurate.")
 
     t2 = time.time()
     print 'time for %s = %.2f'%(funcname(),t2-t1)


### PR DESCRIPTION
(Take 2, this time to merge into master.)

Adding three new methods of GSObject to calculate the half-light radius, sigma=sqrt(T/2), and the fwhm for profiles that don't have these already as attributes.

We're thinking of using these on branch #693. They aren't necessarily hugely optimized for either speed or accuracy. Tests indicate that at least for Gaussian and Exponential, the defaults are accurate to 1 decimal place, which is probably sufficient for the kinds of uses we are planning for them. There are parameters to allow for greater accuracy if desired.