### PR TITLE
#682 Improved documentation about coordinates and units.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ New Features
   truth information.  cf. demos 9 and 10. (#301, #691)
 - Added methods calculateHLR, calculateMomentRadius, and calculateFWHM to both
   GSObject and Image. (#308)
+- Added ability to specify lambda and r0 separately for Kolmogorov to have
+  GalSim do the conversion from radians to the given scale unit. (#657)
 - Changed `galsim.fits.writeMulti` to allow any of the "image"s to be
   already-built hdus, which are included as is. (#691)
 - Added optional `wcs` argument to `Image.resize()`. (#691)

--- a/galsim/base.py
+++ b/galsim/base.py
@@ -1911,8 +1911,8 @@ class Kolmogorov(GSObject):
 
     The Kolmogorov profile is normally defined in terms of the ratio lambda / r0, where lambda is
     the wavelength of the light (say in the middle of the bandpass you are using) and r0 is the
-    Fried parameter.  Typical values for the Fried parameter are on the order of 10cm for
-    most observatories and up to 20cm for excellent sites. The values are usually quoted at
+    Fried parameter.  Typical values for the Fried parameter are on the order of 0.1 m for
+    most observatories and up to 0.2 m for excellent sites. The values are usually quoted at
     lambda = 500nm and r0 depends on wavelength as [r0 ~ lambda^(6/5)].
 
     The natural units for this ratio is radians, which is not normally a convenient unit to use for
@@ -1921,13 +1921,13 @@ class Kolmogorov(GSObject):
     should convert this to arcsec as well:
 
         >>> lam = 700  # nm
-        >>> r0 = 15 * (lam/500)**1.2  # cm
-        >>> lam_over_r0 = (lam * 1.e-7) / r0  # radians
+        >>> r0 = 0.15 * (lam/500)**1.2  # meters
+        >>> lam_over_r0 = (lam * 1.e-9) / r0  # radians
         >>> lam_over_r0 *= 206265  # Convert to arcsec
         >>> psf = galsim.Kolmogorov(lam_over_r0)
 
     To make this process a bit simpler, we recommend instead providing the wavelength and Fried
-    parameter separately using the parameters `lam` (in nm) and `r0` (in cm).  GalSim will then
+    parameter separately using the parameters `lam` (in nm) and `r0` (in m).  GalSim will then
     convert this to any of the normal kinds of angular units using the `scale_unit` parameter:
 
         >>> psf = galsim.Kolmogorov(lam=lam, r0=r0, scale_unit=galsim.arcsec)
@@ -1952,9 +1952,9 @@ class Kolmogorov(GSObject):
     @param lam              Lambda (wavelength) in units of nanometers.  Must be supplied with
                             `r0`, and in this case, image scales (`scale`) should be specified in
                             units of `scale_unit`.
-    @param r0               The Fried parameter in units of centimeters.  Must be supplied with
-                            `lam`, and in this case, image scales (`scale`) should be specified in
-                            units of `scale_unit`.
+    @param r0               The Fried parameter in units of meters.  Must be supplied with `lam`,
+                            and in this case, image scales (`scale`) should be specified in units
+                            of `scale_unit`.
     @param flux             The flux (in photons) of the profile. [default: 1]
     @param scale_unit       Units to use for the sky coordinates when calculating lam/r0 if these
                             are supplied separately.  Note that the results of calling methods like
@@ -2017,7 +2017,7 @@ class Kolmogorov(GSObject):
             # In this case we're going to use scale_unit, so parse it in case of string input:
             if isinstance(scale_unit, basestring):
                 scale_unit = galsim.angle.get_angle_unit(scale_unit)
-            lam_over_r0 = (1.e-7*lam/r0)*(galsim.radians/scale_unit)
+            lam_over_r0 = (1.e-9*lam/r0)*(galsim.radians/scale_unit)
 
         GSObject.__init__(self, _galsim.SBKolmogorov(lam_over_r0, flux, gsparams))
         self._gsparams = gsparams

--- a/galsim/base.py
+++ b/galsim/base.py
@@ -70,10 +70,10 @@ class GSObject(object):
     For instance, if you eventually draw onto an image that has a pixel scale of 0.2 arcsec/pixel,
     then the normal thing to do would be to define your surface brightness profiles in terms of
     arcsec and then draw with `pixel_scale=0.2`.  However, nowhere in GalSim do we enforce that sky
-    coordinates need to be in arcsec.  If you wanted, you could instead define the sizes of all 
+    coordinates need to be in arcsec.  If you wanted, you could instead define the sizes of all
     your galaxies and PSFs in terms of radians and then use `pixel_scale=0.2/206265` when you
     draw them.
-    
+
     Transforming Methods
     --------------------
 
@@ -794,7 +794,7 @@ class GSObject(object):
         established (via a pixel_scale or WCS).  So a shift of dx moves the object horizontally
         in the sky (e.g. west in the local tangent plane of the observation), and dy moves the
         object vertically (north in the local tangent plane).
-        
+
         The units are typically arcsec, but we don't enforce that anywhere.  The units here just
         need to be consistent with the units used for any size values used by the GSObject.
         The connection of these units to the eventual image pixels is defined by either the
@@ -1746,9 +1746,12 @@ class Airy(GSObject):
 
     The Airy profile is defined in terms of the diffraction angle, which is a function of the
     ratio lambda / D, where lambda is the wavelength of the light (say in the middle of the
-    bandpass you are using) and D is the diameter of the telescope.  This ratio is the input
-    parameter to pass to the Airy constructor, but as it is naturally in radians, you would
-    typically convert to arcsec.  e.g.
+    bandpass you are using) and D is the diameter of the telescope.
+
+    The natural units for this value is radians, which is not normally a convenient unit to use for
+    other GSObject dimensions.  Assuming that the other sky coordinates you are using are all in
+    arcsec (e.g. the pixel scale when you draw the image, the size of the galaxy, etc.), then you
+    should convert this to arcsec as well:
 
         >>> lam = 700  # nm
         >>> diam = 4.0    # meters
@@ -1756,15 +1759,14 @@ class Airy(GSObject):
         >>> lam_over_diam *= 206265  # Convert to arcsec
         >>> airy = galsim.Airy(lam_over_diam)
 
-    Or, use separate keywords for the telescope diameter and wavelength in meters and nanometers,
-    respectively:
+    To make this process a bit simpler, we recommend instead providing the wavelength and diameter
+    separately using the `lam` and `diam` parameters.  GalSim will then convert this to any of
+    the normal kinds of angular units using the `scale_unit` parameter:
 
-        >>> airy = galsim.Airy(lam=lam, diam=diam)
+        >>> airy = galsim.Airy(lam=lam, diam=diam, scale_unit=galsim.arcsec)
 
-    in which case the user can also choose what units to use for internal descriptions of the light
-    profile using the `scale_unit` keyword (default: galsim.arcsec).  When drawing images, users
-    should then use units of `scale_unit` to specify the pixel scale.
-
+    When drawing images, the scale_unit should match the unit used for the pixel scale or the WCS.
+    e.g. in this case, a pixel scale of 0.2 arcsec/pixel would be specified as `pixel_scale=0.2`.
 
     @param lam_over_diam    The parameter that governs the scale size of the profile.
                             See above for details about calculating it.
@@ -1777,12 +1779,11 @@ class Airy(GSObject):
     @param obscuration      The linear dimension of a central obscuration as a fraction of the
                             pupil dimension.  [default: 0]
     @param flux             The flux (in photons) of the profile. [default: 1]
-    @param scale_unit       Units used to define the diffraction limit and draw images, if the user
-                            has supplied a separate value for `lam` and `diam`.  Note that the
-                            results of calling methods like getFWHM() will be returned in units of
-                            `scale_unit`, as well.  Should be either a galsim.AngleUnit, or a string
-                            that can be used to construct one (e.g., 'arcsec', 'radians', etc.).
-                            [default: galsim.arcsec]
+    @param scale_unit       Units to use for the sky coordinates when calculating lam/diam if these
+                            are supplied separately.  Note that the results of calling methods like
+                            getFWHM() will be returned in units of `scale_unit` as well.  Should be
+                            either a galsim.AngleUnit or a string that can be used to construct one
+                            (e.g., 'arcsec', 'radians', etc.).  [default: galsim.arcsec]
     @param gsparams         An optional GSParams argument.  See the docstring for GSParams for
                             details. [default: None]
 

--- a/galsim/base.py
+++ b/galsim/base.py
@@ -58,14 +58,22 @@ class GSObject(object):
         >>> conv = galsim.Convolve([gal,psf])
 
     All of these classes are subclasses of GSObject, so you should see those docstrings for
-    more details about how to construct the various profiles.
+    more details about how to construct the various profiles.  Here we discuss attributes and
+    methods that are common to all GSObjects.
 
-    Note that most GSObjects have some kind of size specification.  Typically, these would be
-    given in terms of arcsec, with the connection to the pixel size being given in the Pixel
-    class (0.2 arcsec/pixel in the above example).  However, you can have a more complicated
-    relationship between pixel and sky coordinates.  See BaseWCS for more details about
-    how to specify various kinds of world coordinate systems.
+    GSObjects are always defined in sky coordinates.  So all sizes and other linear dimensions
+    should be in terms of some kind of units on the sky, arcsec for instance.  Only later (when
+    they are drawn) is the connection to pixel coordinates established via a pixel scale or WCS.
+    (See the documentation for galsim.BaseWCS for more details about how to specify various kinds
+    of world coordinate systems more complicated than a simple pixel scale.)
 
+    For instance, if you eventually draw onto an image that has a pixel scale of 0.2 arcsec/pixel,
+    then the normal thing to do would be to define your surface brightness profiles in terms of
+    arcsec and then draw with `pixel_scale=0.2`.  However, nowhere in GalSim do we enforce that sky
+    coordinates need to be in arcsec.  If you wanted, you could instead define the sizes of all 
+    your galaxies and PSFs in terms of radians and then use `pixel_scale=0.2/206265` when you
+    draw them.
+    
     Transforming Methods
     --------------------
 
@@ -781,6 +789,21 @@ class GSObject(object):
         Note: in addition to the dx,dy parameter names, you may also supply dx,dy as a tuple,
         or as a PositionD or PositionI object.
 
+        The shift coordinates here are sky coordinates.  GSObjects are always defined in sky
+        coordinates and only later (when they are drawn) is the connection to pixel coordinates
+        established (via a pixel_scale or WCS).  So a shift of dx moves the object horizontally
+        in the sky (e.g. west in the local tangent plane of the observation), and dy moves the
+        object vertically (north in the local tangent plane).
+        
+        The units are typically arcsec, but we don't enforce that anywhere.  The units here just
+        need to be consistent with the units used for any size values used by the GSObject.
+        The connection of these units to the eventual image pixels is defined by either the
+        `pixel_scale` or the `wcs` parameter of `drawImage`.
+
+        Note: if you want to shift the object by a set number (or fraction) of pixels in the
+        drawn image, you probably want to use the `offset` parameter of `drawImage` rather than
+        this method.
+
         @param dx       Horizontal shift to apply.
         @param dy       Vertical shift to apply.
 
@@ -1134,9 +1157,10 @@ class GSObject(object):
                             of the image (using the function image.bounds.trueCenter()).
                             If you would rather use the integer center (given by
                             image.bounds.center()), set this to `False`.  [default: True]
-        @param offset       The location at which to center the profile being drawn relative to the
-                            center of the image (either the true center if `use_true_center=True`,
-                            or the nominal center if `use_true_center=False`). [default: None]
+        @param offset       The location in pixel coordinates at which to center the profile being
+                            drawn relative to the center of the image (either the true center if
+                            `use_true_center=True` or nominal center if `use_true_center=False`).
+                            [default: None]
         @param n_photons    If provided, the number of photons to use for photon shooting.
                             If not provided (i.e. `n_photons = 0`), use as many photons as
                             necessary to result in an image with the correct Poisson shot

--- a/galsim/base.py
+++ b/galsim/base.py
@@ -1951,7 +1951,7 @@ class Kolmogorov(GSObject):
                             [One of `lam_over_r0`, `fwhm`, `half_light_radius`, or both `lam` and
                             `r0` is required.]
     @param lam              Lambda (wavelength) in units of nanometers.  Must be supplied with
-                            `diam`, and in this case, image scales (`scale`) should be specified in
+                            `r0`, and in this case, image scales (`scale`) should be specified in
                             units of `scale_unit`.
     @param r0               The Fried parameter in units of cm.  Must be supplied with `lam`, and
                             in this case, image scales (`scale`) should be specified in units of

--- a/galsim/base.py
+++ b/galsim/base.py
@@ -69,10 +69,9 @@ class GSObject(object):
 
     For instance, if you eventually draw onto an image that has a pixel scale of 0.2 arcsec/pixel,
     then the normal thing to do would be to define your surface brightness profiles in terms of
-    arcsec and then draw with `pixel_scale=0.2`.  However, nowhere in GalSim do we enforce that sky
-    coordinates need to be in arcsec.  If you wanted, you could instead define the sizes of all
-    your galaxies and PSFs in terms of radians and then use `pixel_scale=0.2/206265` when you
-    draw them.
+    arcsec and then draw with `pixel_scale=0.2`.  However, while arcsec are the usual choice of
+    units for the sky coordinates, if you wanted, you could instead define the sizes of all your
+    galaxies and PSFs in terms of radians and then use `pixel_scale=0.2/206265` when you draw them.
 
     Transforming Methods
     --------------------

--- a/galsim/base.py
+++ b/galsim/base.py
@@ -1916,26 +1916,52 @@ class Kolmogorov(GSObject):
     most observatories and up to 20cm for excellent sites. The values are usually quoted at
     lambda = 500nm and r0 depends on wavelength as [r0 ~ lambda^(6/5)].
 
-    This ratio is naturally in radians, so you would typically convert to arcsec.  e.g.
+    The natural units for this ratio is radians, which is not normally a convenient unit to use for
+    other GSObject dimensions.  Assuming that the other sky coordinates you are using are all in
+    arcsec (e.g. the pixel scale when you draw the image, the size of the galaxy, etc.), then you
+    should convert this to arcsec as well:
 
         >>> lam = 700  # nm
         >>> r0 = 0.15 * (lam/500)**1.2  # meters
         >>> lam_over_r0 = (lam * 1.e-9) / r0  # radians
         >>> lam_over_r0 *= 206265  # Convert to arcsec
+        >>> psf = galsim.Kolmogorov(lam_over_r0)
 
-    The FWHM of the Kolmogorov PSF is ~0.976 lambda/r0 (e.g., Racine 1996, PASP 699, 108).
+    To make this process a bit simpler, we recommend instead providing the wavelength and Fried
+    parameter separately using the `lam` and `r0` parameters.  GalSim will then convert this to any
+    of the normal kinds of angular units using the `scale_unit` parameter:
 
-    A Kolmogorov can be initialized using one (and only one) of three possible size parameters:
-    `lam_over_r0`, `fwhm`, or `half_light_radius`.  Exactly one of these three is required.
+        >>> psf = galsim.Kolmogorov(lam=lam, r0=r0, scale_unit=galsim.arcsec)
+
+    When drawing images, the scale_unit should match the unit used for the pixel scale or the WCS.
+    e.g. in this case, a pixel scale of 0.2 arcsec/pixel would be specified as `pixel_scale=0.2`.
+
+    A Kolmogorov object may also be initialized using `fwhm` or `half_light_radius`.  Exactly one
+    of these four ways to define the size is required.
+
+    The FWHM of the Kolmogorov PSF is ~0.976 lambda/r0 arcsec (e.g., Racine 1996, PASP 699, 108).
 
     @param lam_over_r0      The parameter that governs the scale size of the profile.
                             See above for details about calculating it.  [One of `lam_over_r0`,
-                            `fwhm`, or `half_light_radius` is required.]
+                            `fwhm`, `half_light_radius`, or both `lam` and `r0` is required.]
     @param fwhm             The full-width-half-max of the profile.  Typically given in arcsec.
-                            [One of `lam_over_r0`, `fwhm`, or `half_light_radius` is required.]
+                            [One of `lam_over_r0`, `fwhm`, `half_light_radius`, or both `lam` and
+                            `r0` is required.]
     @param half_light_radius  The half-light radius of the profile.  Typically given in arcsec.
-                            [One of `lam_over_r0`, `fwhm`, or `half_light_radius` is required.]
+                            [One of `lam_over_r0`, `fwhm`, `half_light_radius`, or both `lam` and
+                            `r0` is required.]
+    @param lam              Lambda (wavelength) in units of nanometers.  Must be supplied with
+                            `diam`, and in this case, image scales (`scale`) should be specified in
+                            units of `scale_unit`.
+    @param r0               The Fried parameter in units of cm.  Must be supplied with `lam`, and
+                            in this case, image scales (`scale`) should be specified in units of
+                            `scale_unit`.
     @param flux             The flux (in photons) of the profile. [default: 1]
+    @param scale_unit       Units to use for the sky coordinates when calculating lam/r0 if these
+                            are supplied separately.  Note that the results of calling methods like
+                            getFWHM() will be returned in units of `scale_unit` as well.  Should be
+                            either a galsim.AngleUnit or a string that can be used to construct one
+                            (e.g., 'arcsec', 'radians', etc.).  [default: galsim.arcsec]
     @param gsparams         An optional GSParams argument.  See the docstring for GSParams for
                             details. [default: None]
 
@@ -1949,8 +1975,12 @@ class Kolmogorov(GSObject):
         >>> hlr = kolm.getHalfLightRadius()
     """
     _req_params = {}
-    _opt_params = { "flux" : float }
-    _single_params = [ { "lam_over_r0" : float, "fwhm" : float, "half_light_radius" : float } ]
+    _opt_params = { "flux" : float, "r0" : float, "scale_unit" : str }
+    # Note that this is not quite right; it's true that exactly one of these 4 should be supplied,
+    # but if lam is supplied then r0 is required.  Errors in which parameters are used may be
+    # caught either by config or by the python code itself, depending on the particular error.
+    _single_params = [ { "lam_over_r0" : float, "fwhm" : float, "half_light_radius" : float,
+                         "lam" : float } ]
     _takes_rng = False
 
     # The FWHM of the Kolmogorov PSF is ~0.976 lambda/r0 (e.g., Racine 1996, PASP 699, 108).
@@ -1959,27 +1989,36 @@ class Kolmogorov(GSObject):
     # Similarly, SBKolmogorov calculates the relation between lambda/r0 and half-light radius
     _hlr_factor = 0.554811
 
-    def __init__(self, lam_over_r0=None, fwhm=None, half_light_radius=None, flux=1.,
-                 gsparams=None):
+    def __init__(self, lam_over_r0=None, fwhm=None, half_light_radius=None, lam=None, r0=None,
+                 flux=1., scale_unit=galsim.arcsec, gsparams=None):
 
         if fwhm is not None :
-            if lam_over_r0 is not None or half_light_radius is not None:
+            if (lam_over_r0 is not None or half_light_radius is not None or
+                lam is not None or r0 is not None):
                 raise TypeError(
-                        "Only one of lam_over_r0, fwhm, and half_light_radius may be " +
-                        "specified for Kolmogorov")
+                        "Only one of lam_over_r0, fwhm, half_light_radius, or both lam and r0 "+
+                        "may be specified for Kolmogorov")
             else:
                 lam_over_r0 = fwhm / Kolmogorov._fwhm_factor
         elif half_light_radius is not None:
-            if lam_over_r0 is not None:
+            if lam_over_r0 is not None or lam is not None or r0 is not None:
                 raise TypeError(
-                        "Only one of lam_over_r0, fwhm, and half_light_radius may be " +
-                        "specified for Kolmogorov")
+                        "Only one of lam_over_r0, fwhm, half_light_radius, or both lam and r0 "+
+                        "may be specified for Kolmogorov")
             else:
                 lam_over_r0 = half_light_radius / Kolmogorov._hlr_factor
-        elif lam_over_r0 is None:
+        elif lam_over_r0 is not None:
+            if lam is not None or r0 is not None:
+                raise TypeError("Cannot specify lam or r0 in conjunction with lam_over_r0.")
+        else:
+            if lam is None or r0 is None:
                 raise TypeError(
-                        "One of lam_over_r0, fwhm, or half_light_radius must be " +
-                        "specified for Kolmogorov")
+                        "One of lam_over_r0, fwhm, half_light_radius, or both lam and r0 "+
+                        "must be specified for Kolmogorov")
+            # In this case we're going to use scale_unit, so parse it in case of string input:
+            if isinstance(scale_unit, basestring):
+                scale_unit = galsim.angle.get_angle_unit(scale_unit)
+            lam_over_r0 = (1.e-7*lam/r0)*(galsim.radians/scale_unit)
 
         GSObject.__init__(self, _galsim.SBKolmogorov(lam_over_r0, flux, gsparams))
         self._gsparams = gsparams

--- a/galsim/base.py
+++ b/galsim/base.py
@@ -1922,7 +1922,7 @@ class Kolmogorov(GSObject):
 
         >>> lam = 700  # nm
         >>> r0 = 15 * (lam/500)**1.2  # cm
-        >>> lam_over_r0 = (lam * 1.e-9) / r0  # radians
+        >>> lam_over_r0 = (lam * 1.e-7) / r0  # radians
         >>> lam_over_r0 *= 206265  # Convert to arcsec
         >>> psf = galsim.Kolmogorov(lam_over_r0)
 

--- a/galsim/base.py
+++ b/galsim/base.py
@@ -1760,8 +1760,8 @@ class Airy(GSObject):
         >>> airy = galsim.Airy(lam_over_diam)
 
     To make this process a bit simpler, we recommend instead providing the wavelength and diameter
-    separately using the `lam` and `diam` parameters.  GalSim will then convert this to any of
-    the normal kinds of angular units using the `scale_unit` parameter:
+    separately using the parameters `lam` (in nm) and `diam` (in m).  GalSim will then convert this
+    to any of the normal kinds of angular units using the `scale_unit` parameter:
 
         >>> airy = galsim.Airy(lam=lam, diam=diam, scale_unit=galsim.arcsec)
 
@@ -1922,14 +1922,14 @@ class Kolmogorov(GSObject):
     should convert this to arcsec as well:
 
         >>> lam = 700  # nm
-        >>> r0 = 0.15 * (lam/500)**1.2  # meters
+        >>> r0 = 15 * (lam/500)**1.2  # cm
         >>> lam_over_r0 = (lam * 1.e-9) / r0  # radians
         >>> lam_over_r0 *= 206265  # Convert to arcsec
         >>> psf = galsim.Kolmogorov(lam_over_r0)
 
     To make this process a bit simpler, we recommend instead providing the wavelength and Fried
-    parameter separately using the `lam` and `r0` parameters.  GalSim will then convert this to any
-    of the normal kinds of angular units using the `scale_unit` parameter:
+    parameter separately using the parameters `lam` (in nm) and `r0` (in cm).  GalSim will then
+    convert this to any of the normal kinds of angular units using the `scale_unit` parameter:
 
         >>> psf = galsim.Kolmogorov(lam=lam, r0=r0, scale_unit=galsim.arcsec)
 
@@ -1953,9 +1953,9 @@ class Kolmogorov(GSObject):
     @param lam              Lambda (wavelength) in units of nanometers.  Must be supplied with
                             `r0`, and in this case, image scales (`scale`) should be specified in
                             units of `scale_unit`.
-    @param r0               The Fried parameter in units of cm.  Must be supplied with `lam`, and
-                            in this case, image scales (`scale`) should be specified in units of
-                            `scale_unit`.
+    @param r0               The Fried parameter in units of centimeters.  Must be supplied with
+                            `lam`, and in this case, image scales (`scale`) should be specified in
+                            units of `scale_unit`.
     @param flux             The flux (in photons) of the profile. [default: 1]
     @param scale_unit       Units to use for the sky coordinates when calculating lam/r0 if these
                             are supplied separately.  Note that the results of calling methods like

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -652,8 +652,12 @@ class Image(object):
 
             >>> im = galsim.Image(numpy.array(range(16),dtype=float).reshape((4,4)))
             >>> im.center()
+            galsim.PositionI(x=3, y=3)
+            >>> im.trueCenter()
             galsim.PositionI(x=2.5, y=2.5)
             >>> im.setCenter(56,72)
+            >>> im.center()
+            galsim.PositionI(x=56, y=72)
             >>> im.trueCenter()
             galsim.PositionD(x=55.5, y=71.5)
             >>> im.setOrigin(0,0)

--- a/galsim/optics.py
+++ b/galsim/optics.py
@@ -52,12 +52,26 @@ class OpticalPSF(GSObject):
 
     The diffraction effects are characterized by the diffraction angle, which is a function of the
     ratio lambda / D, where lambda is the wavelength of the light and D is the diameter of the
-    telescope.  Users can specify this diffraction angle in one of two ways.  The first option is to
-    specify the ratio as `lam_over_diam` in whatever arbitrary units they choose (and then
-    self-consistently specify the image scale in the same units).  The second option is to specify
-    the wavelength as `lam` in units of nanometers and the telescope diameter as `diam` in units of
-    meters.  OpticalPSF will then convert the ratio to units of `scale_units`, and image scales must
-    be specified in `scale_units` as well.
+    telescope.  The natural units for this value is radians, which is not normally a convenient
+    unit to use for other GSObject dimensions.  Assuming that the other sky coordinates you are
+    using are all in arcsec (e.g. the pixel scale when you draw the image, the size of the galaxy,
+    etc.), then you should convert this to arcsec as well:
+
+        >>> lam = 700  # nm
+        >>> diam = 4.0    # meters
+        >>> lam_over_diam = (lam * 1.e-9) / diam  # radians
+        >>> lam_over_diam *= 206265  # Convert to arcsec
+        >>> psf = galsim.OpticalPSF(lam_over_diam, ...)
+
+    To make this process a bit simpler, we recommend instead providing the wavelength and diameter
+    separately using the `lam` and `diam` parameters.  GalSim will then convert this to any of
+    the normal kinds of angular units using the `scale_unit` parameter (the default if omitted
+    is arcsec):
+
+        >>> psf = galsim.OpticalPSF(lam=lam, diam=diam, scale_unit=galsim.arcsec, ...)
+
+    When drawing images, the scale_unit should match the unit used for the pixel scale or the WCS.
+    e.g. in this case, a pixel scale of 0.2 arcsec/pixel would be specified as `pixel_scale=0.2`.
 
     Input aberration coefficients are assumed to be supplied in units of wavelength, and correspond
     to the Zernike polynomials in the Noll convention defined in
@@ -96,7 +110,7 @@ class OpticalPSF(GSObject):
     Initialization
     --------------
 
-    Either specify the lam/diam ratio directly in arbitrary units:
+    As described above, either specify the lam/diam ratio directly in arbitrary units:
 
         >>> optical_psf = galsim.OpticalPSF(lam_over_diam=lam_over_diam, defocus=0., astig1=0.,
                                             astig2=0., coma1=0., coma2=0., trefoil1=0., trefoil2=0.,
@@ -189,11 +203,10 @@ class OpticalPSF(GSObject):
     @param pupil_angle      If `pupil_plane_im` is not None, rotation angle for the pupil plane
                             (positive in the counter-clockwise direction).  Must be an Angle
                             instance. [default: 0. * galsim.degrees]
-    @param scale_unit       Units used to define the diffraction limit and draw images, if the user
-                            has supplied a separate value for `lam` and `diam`.  Should be either a
-                            galsim.AngleUnit, or a string that can be used to construct one (e.g.,
-                            'arcsec', 'radians', etc.).
-                            [default: galsim.arcsec]
+    @param scale_unit       Units to use for the sky coordinates when calculating lam/diam if these
+                            are supplied separately.  Should be either a galsim.AngleUnit or a
+                            string that can be used to construct one (e.g., 'arcsec', 'radians',
+                            etc.).  [default: galsim.arcsec]
     @param gsparams         An optional GSParams argument.  See the docstring for GSParams for
                             details. [default: None]
 

--- a/galsim/optics.py
+++ b/galsim/optics.py
@@ -64,9 +64,8 @@ class OpticalPSF(GSObject):
         >>> psf = galsim.OpticalPSF(lam_over_diam, ...)
 
     To make this process a bit simpler, we recommend instead providing the wavelength and diameter
-    separately using the `lam` and `diam` parameters.  GalSim will then convert this to any of
-    the normal kinds of angular units using the `scale_unit` parameter (the default if omitted
-    is arcsec):
+    separately using the parameters `lam` (in nm) and `diam` (in m).  GalSim will then convert this
+    to any of the normal kinds of angular units using the `scale_unit` parameter:
 
         >>> psf = galsim.OpticalPSF(lam=lam, diam=diam, scale_unit=galsim.arcsec, ...)
 

--- a/galsim/real.py
+++ b/galsim/real.py
@@ -82,6 +82,10 @@ class RealGalaxy(GSObject):
     for exposures taken with a different telescope diameter than the HST 2.4 meter diameter
     this way.
 
+    Note that RealGalaxy objects use arcsec for the units of their linear dimension.  If you
+    are using a different unit for other things (the PSF, WCS, etc.), then you should dilate
+    the resulting object with `gal.dilate(galsim.arcsec / scale_unit)`.
+
     @param real_galaxy_catalog  A RealGalaxyCatalog object with basic information about where to
                             find the data, etc.
     @param index            Index of the desired galaxy in the catalog. [One of `index`, `id`, or

--- a/galsim/scene.py
+++ b/galsim/scene.py
@@ -280,6 +280,10 @@ class COSMOSCatalog(object):
         appropriate for the HST effective telescope diameter and a 1 second exposure time, so users
         who are simulating another scenario should account for this.
 
+        Note that the returned objects use arcsec for the units of their linear dimension.  If you
+        are using a different unit for other things (the PSF, WCS, etc.), then you should dilate
+        the resulting object with `gal.dilate(galsim.arcsec / scale_unit)`.
+
         @param index            Index of the desired galaxy in the catalog for which a GSObject
                                 should be constructed.  You may also provide a list or array of
                                 indices, in which case a list of objects is returned. If None,

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -970,6 +970,7 @@ def test_airy():
     """Test the generation of a specific Airy profile against a known result.
     """
     import time
+    import math
     t1 = time.time()
     savedImg = galsim.fits.read(os.path.join(imgdir, "airy_.8_.1.fits"))
     dx = 0.2
@@ -1014,13 +1015,16 @@ def test_airy():
     # have lam/diam = 1./0.8 in arbitrary units, we will tell it that lam=1.e9 nm and diam=0.8 m,
     # and use `scale_unit` of galsim.radians.  This is rather silly, but it should work.
     airy = galsim.Airy(lam_over_diam=1./0.8, obscuration=0.1, flux=1.7)
-    test_im1 = airy.drawImage(scale=0.2)
-    test_im2 = test_im1.copy()
     airy2 = galsim.Airy(lam=1.e9, diam=0.8, scale_unit=galsim.radians, obscuration=0.1, flux=1.7)
-    airy2.drawImage(image=test_im2, scale=0.2)
-    np.testing.assert_array_almost_equal(
-            test_im1.array, test_im2.array, 8,
-            err_msg="Using GSObject Airy with different kwargs disagrees with expected result")
+    gsobject_compare(airy,airy2)
+    # For lam/diam = 1.25 arcsec, and diam = 0.3 m, lam = (1.25/3600/180*pi) * 0.3 * 1.e9
+    lam = 1.25 * 0.3 / 3600. / 180. * math.pi * 1.e9
+    print 'lam = ',lam
+    airy3 = galsim.Airy(lam=lam, diam=0.3, scale_unit=galsim.arcsec, obscuration=0.1, flux=1.7)
+    gsobject_compare(airy,airy3)
+    # arcsec is the default scale_unit, so can leave this off.
+    airy4 = galsim.Airy(lam=lam, diam=0.3, obscuration=0.1, flux=1.7)
+    gsobject_compare(airy,airy4)
 
     t2 = time.time()
     print 'time for %s = %.2f'%(funcname(),t2-t1)
@@ -1660,6 +1664,7 @@ def test_kolmogorov():
     """Test the generation of a specific Kolmogorov profile against a known result.
     """
     import time
+    import math
     t1 = time.time()
     dx = 0.2
     # This savedImg was created from the SBKolmogorov implementation in
@@ -1702,6 +1707,21 @@ def test_kolmogorov():
     do_pickle(kolm, lambda x: x.drawImage(method='no_pixel'))
     do_pickle(kolm)
     do_pickle(kolm.SBProfile)
+
+    # Test initialization separately with lam and r0, in various units.  Since the above profiles
+    # have lam/r0 = 3./2. in arbitrary units, we will tell it that lam=3.e7 nm and r0=2.0 cm,
+    # and use `scale_unit` of galsim.radians.  This is rather silly, but it should work.
+    kolm = galsim.Kolmogorov(lam_over_r0=1.5, flux=test_flux)
+    kolm2 = galsim.Kolmogorov(lam=3.e7, r0=2.0, scale_unit=galsim.radians, flux=test_flux)
+    gsobject_compare(kolm,kolm2)
+    # For lam/r0 = 1.5 arcsec, and r0 = 20, lam = (1.5/3600/180*pi) * 20 * 1.e7
+    lam = 1.5 * 20 / 3600. / 180. * math.pi * 1.e7
+    print 'lam = ',lam
+    kolm3 = galsim.Kolmogorov(lam=lam, r0=20., scale_unit=galsim.arcsec, flux=test_flux)
+    gsobject_compare(kolm,kolm3)
+    # arcsec is the default scale_unit, so can leave this off.
+    kolm4 = galsim.Kolmogorov(lam=lam, r0=20., flux=test_flux)
+    gsobject_compare(kolm,kolm4)
 
     t2 = time.time()
     print 'time for %s = %.2f'%(funcname(),t2-t1)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1082,7 +1082,7 @@ def test_airy_flux_scaling():
     test_loD = 1.9
     test_obscuration = 0.32
 
-    # init with lam_over_r0 and flux only (should be ok given last tests)
+    # init with lam_over_diam and flux only (should be ok given last tests)
     obj = galsim.Airy(lam_over_diam=test_loD, flux=test_flux, obscuration=test_obscuration)
     obj *= 2.
     np.testing.assert_almost_equal(
@@ -1709,18 +1709,18 @@ def test_kolmogorov():
     do_pickle(kolm.SBProfile)
 
     # Test initialization separately with lam and r0, in various units.  Since the above profiles
-    # have lam/r0 = 3./2. in arbitrary units, we will tell it that lam=3.e7 nm and r0=2.0 cm,
+    # have lam/r0 = 3./2. in arbitrary units, we will tell it that lam=3.e9 nm and r0=2.0 m,
     # and use `scale_unit` of galsim.radians.  This is rather silly, but it should work.
     kolm = galsim.Kolmogorov(lam_over_r0=1.5, flux=test_flux)
-    kolm2 = galsim.Kolmogorov(lam=3.e7, r0=2.0, scale_unit=galsim.radians, flux=test_flux)
+    kolm2 = galsim.Kolmogorov(lam=3.e9, r0=2.0, scale_unit=galsim.radians, flux=test_flux)
     gsobject_compare(kolm,kolm2)
-    # For lam/r0 = 1.5 arcsec, and r0 = 20, lam = (1.5/3600/180*pi) * 20 * 1.e7
-    lam = 1.5 * 20 / 3600. / 180. * math.pi * 1.e7
+    # For lam/r0 = 1.5 arcsec, and r0 = 0.2, lam = (1.5/3600/180*pi) * 0.2 * 1.e9
+    lam = 1.5 * 0.2 / 3600. / 180. * math.pi * 1.e9
     print 'lam = ',lam
-    kolm3 = galsim.Kolmogorov(lam=lam, r0=20., scale_unit=galsim.arcsec, flux=test_flux)
+    kolm3 = galsim.Kolmogorov(lam=lam, r0=0.2, scale_unit=galsim.arcsec, flux=test_flux)
     gsobject_compare(kolm,kolm3)
     # arcsec is the default scale_unit, so can leave this off.
-    kolm4 = galsim.Kolmogorov(lam=lam, r0=20., flux=test_flux)
+    kolm4 = galsim.Kolmogorov(lam=lam, r0=0.2, flux=test_flux)
     gsobject_compare(kolm,kolm4)
 
     t2 = time.time()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1722,6 +1722,10 @@ def test_kolmogorov():
     # arcsec is the default scale_unit, so can leave this off.
     kolm4 = galsim.Kolmogorov(lam=lam, r0=0.2, flux=test_flux)
     gsobject_compare(kolm,kolm4)
+    # Test using r0_500 instead
+    r0_500 = 0.2 * (lam/500)**-1.2
+    kolm5 = galsim.Kolmogorov(lam=lam, r0_500=r0_500, flux=test_flux)
+    gsobject_compare(kolm,kolm5)
 
     t2 = time.time()
     print 'time for %s = %.2f'%(funcname(),t2-t1)


### PR DESCRIPTION
This PR addresses issues #682 and #657, both related to documentation.

For #682, I added documentation about what our convention for x,y is in terms of the rows and columns in the numpy array. I also added some concrete examples that will hopefully make clear what some of the image methods that shift around the coordinates do.  @esheldon Please see if the documentation update here addresses your concerns.

For #657, I tried to improve the documentation about the units used in Airy, OpticalPSF and Kolmogorov.  In particular with respect to the units of the `lam_over_diam` and `lam_over_r0` parameters.  I also added a calculation of lam / r0, giving those values directly for Kolmogorov, analogous to the lam / diam calculation that Rachel added to Airy and OpticalPSF.  @dkirkby Please see if this adequately addresses the concerns you raised about the units of these parameters.

In addition, I added some more documentation about the fact that GSObjects are always in sky coordinates.  In particular that `GSObject.shift` is necessarily in terms of sky coordinates, since the GSObject doesn't know about the pixel scale yet, but that `drawImage(offset)` is in terms of pixels.  This is a question that has come up a number of times, so it seems like our documentation on this had been insufficient.