### PR TITLE
#721 Fix SCons for El Capitan when DYLD_LIBRARY_PATH is needed

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -341,6 +341,17 @@ than the default `g++`, type
 
     scons CXX=icpc
 
+On El Capitan, Apple instituted a new security measure wherein system calls
+lose some of the system environment variables, including DYLD_LIBRARY_PATH
+among others.  If your system is set up to use that environment variable to
+resolve library locations at runtime, then this will cause problems when SCons
+is trying to figure out if things are installed correctly.  To override this
+behavior, you can explicitly send this environment variable to SCons by writing
+
+    scons DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH
+
+and it will be able to re-set this value within the SCons processing.
+
 One nice feature of SCons is that once you have specified a parameter, it will
 save that value for future builds in the file `gs_scons.conf`, so once you have
 the build process working, for later builds you only need to type `scons`. It

--- a/SConstruct
+++ b/SConstruct
@@ -239,6 +239,22 @@ def ErrorExit(*args, **kwargs):
         out.write("Error trying to get output of conftest executables.\n")
         out.write(sys.exc_info()[0])
 
+    # Give a helpful message if running El Capitan.
+    if sys.platform.find('darwin') != -1:
+        import platform
+        major, minor, rev = platform.mac_ver()[0].split('.')
+        print 'Mac version: ',major,minor
+        if int(major) > 10 or int(minor) >= 11:
+            print
+            print 'Starting with El Capitan (OSX 10.11), Apple instituted a new policy called'
+            print '"System Integrity Protection" (SIP) where they strip "dangerous" environment'
+            print 'variables from system calls (including SCons).  So if your system is using'
+            print 'DYLD_LIBRARY_PATH for run-time library resolution, then SCons cannot see it'
+            print 'so that may be why this is failing.  cf. Issues #721 and #725.'
+            print 'You should try executing:'
+            print
+            print '    scons DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH'
+
     print
     print 'Please fix the above error(s) and rerun scons.'
     print 'Note: you may want to look through the file INSTALL.md for advice.'
@@ -1620,7 +1636,8 @@ int main()
             # Don't require the user to have xcode installed.
             xcode_version = None
             print 'Unable to determine XCode version'
-        if (platform.mac_ver()[0] >= '10.7' and '-latlas' not in tmv_link and
+        major, minor, rev = platform.mac_ver()[0].split('.')
+        if ((int(major) > 10 or int(minor) >= 7) and '-latlas' not in tmv_link and
                 ('-lblas' in tmv_link or '-lcblas' in tmv_link)):
             print 'WARNING: The Apple BLAS library has been found not to be thread safe on'
             print '         Mac OS versions 10.7+, even across multiple processes (i.e. not'
@@ -1825,7 +1842,6 @@ Help(opts.GenerateHelpText(env))
 env['final_messages'] = []
 # Everything we are going to build so we can have the final message depend on these.
 env['all_builds'] = []
-
 
 if not GetOption('help'):
 

--- a/SConstruct
+++ b/SConstruct
@@ -217,8 +217,9 @@ def ErrorExit(*args, **kwargs):
                 cmd = conftest
             else:
                 cmd = env['PYTHON'] + " < " + conftest
-            p = subprocess.Popen([cmd], stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                                 shell=True)
+            cmd = PrependLibraryPaths(cmd,env)
+            p = subprocess.Popen(['bash','-c',cmd], stdout=subprocess.PIPE,
+                                 stderr=subprocess.STDOUT, shell=False)
             conftest_out = p.stdout.readlines()
             out.write('Output of the command %s is:\n'%cmd)
             out.write(''.join(conftest_out) + '\n')

--- a/SConstruct
+++ b/SConstruct
@@ -1892,6 +1892,7 @@ if not GetOption('help'):
     env['_RunInstall'] = RunInstall
     env['_RunUninstall'] = RunUninstall
     env['_AddRPATH'] = AddRPATH
+    env['_PrependLibraryPaths'] = PrependLibraryPaths
 
     # Both bin and examples use this:
     env['BUILDERS']['ExecScript'] = Builder(action = BuildExecutableScript)

--- a/SConstruct
+++ b/SConstruct
@@ -1,4 +1,4 @@
-# vim: set filetype=python et ts=4 sw=4:
+
 
 # Copyright (c) 2012-2015 by the GalSim developers team on GitHub
 # https://github.com/GalSim-developers
@@ -43,7 +43,7 @@ subdirs=['src', 'pysrc', 'bin', 'galsim', 'share']
 config_file = 'gs_scons.conf'
 
 # Default directory for installation.
-# This is the only UNIX specific things I am aware
+
 # of in the script.  On the other hand, these are not required for the
 # script to work since prefix can be set on the command line and the
 # extra paths are not needed, but I wish I knew how to get the default
@@ -104,7 +104,8 @@ opts.Add(PathVariable('DYLD_LIBRARY_PATH',
          'Set the DYLD_LIBRARY_PATH inside of SCons.  '+
          'Particularly useful on El Capitan (and later), since Apple strips out '+
          'DYLD_LIBRARY_PATH from the environment that SCons sees, so if you need it, '+
-         'this option enables SCons to set it back in for you.',
+         'this option enables SCons to set it back in for you by doing '+
+         '`scons DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH`.',
          '', PathVariable.PathAccept))
 opts.Add('NOSETESTS','Name of nosetests executable','')
 opts.Add(BoolVariable('CACHE_LIB','Cache the results of the library checks',True))

--- a/SConstruct
+++ b/SConstruct
@@ -715,20 +715,13 @@ def ReadFileList(fname):
 def PrependLibraryPaths(pname, env):
     """Turn a system command, pname, into "DYLD_LIBRARY_PATH=blah "+pname
 
-    env is the relevant SCons environment.  But also check os.environ if nothing is there.
+    env is the relevant SCons environment.
     """
-    osenv = os.environ
     if 'DYLD_LIBRARY_PATH' in env and env['DYLD_LIBRARY_PATH'] != '':
         pre = 'DYLD_LIBRARY_PATH=%r'%env['DYLD_LIBRARY_PATH']
         pname = "%s %s"%(pre,pname)
-    elif 'DYLD_LIBRARY_PATH' in osenv and osenv['DYLD_LIBRARY_PATH'] != '':
-        pre = 'DYLD_LIBRARY_PATH=%r'%osenv['DYLD_LIBRARY_PATH']
-        pname = "%s %s"%(pre,pname)
     if 'LD_LIBRARY_PATH' in env and env['LD_LIBRARY_PATH'] != '':
         pre = 'LD_LIBRARY_PATH=%r'%env['LD_LIBRARY_PATH']
-        pname = "%s %s"%(pre,pname)
-    elif 'LD_LIBRARY_PATH' in osenv and osenv['LD_LIBRARY_PATH'] != '':
-        pre = 'LD_LIBRARY_PATH=%r'%osenv['LD_LIBRARY_PATH']
         pname = "%s %s"%(pre,pname)
     return pname
 

--- a/SConstruct
+++ b/SConstruct
@@ -107,6 +107,11 @@ opts.Add(PathVariable('DYLD_LIBRARY_PATH',
          'this option enables SCons to set it back in for you by doing '+
          '`scons DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH`.',
          '', PathVariable.PathAccept))
+opts.Add(PathVariable('LD_LIBRARY_PATH',
+         'Set the LD_LIBRARY_PATH inside of SCons. '+
+         'cf. DYLD_LIBRARY_PATH for why this may be useful.',
+         '', PathVariable.PathAccept))
+
 opts.Add('NOSETESTS','Name of nosetests executable','')
 opts.Add(BoolVariable('CACHE_LIB','Cache the results of the library checks',True))
 opts.Add(BoolVariable('WITH_PROF',
@@ -734,6 +739,9 @@ def AltTryRun(config, text, extension):
         if 'DYLD_LIBRARY_PATH' in sconf.env:
             pre = 'DYLD_LIBRARY_PATH=%r'%sconf.env['DYLD_LIBRARY_PATH']
             pname = "%s %s"%(pre,pname)
+        if 'LD_LIBRARY_PATH' in sconf.env:
+            pre = 'LD_LIBRARY_PATH=%r'%sconf.env['LD_LIBRARY_PATH']
+            pname = "%s %s"%(pre,pname)
         node = config.env.Command(output, prog, [ [ 'bash', '-c', pname, ">", "${TARGET}"] ]) 
         ok = sconf.BuildNodes(node) 
     if ok:
@@ -996,6 +1004,9 @@ def TryScript(config,text,executable):
     # Just like in AltTryRun, we need to add the DYLD_LIBRARY_PATH for El Capitan.
     if 'DYLD_LIBRARY_PATH' in config.sconf.env:
         pre = 'DYLD_LIBRARY_PATH=%r'%config.sconf.env['DYLD_LIBRARY_PATH']
+        executable = "%s %s"%(pre,executable)
+    if 'LD_LIBRARY_PATH' in config.sconf.env:
+        pre = 'LD_LIBRARY_PATH=%r'%config.sconf.env['LD_LIBRARY_PATH']
         executable = "%s %s"%(pre,executable)
     node = config.env.Command(output, source, 
             [[ 'bash', '-c', executable, "<", "${SOURCE}", ">", "${TARGET}", "2>&1"]]) 

--- a/SConstruct
+++ b/SConstruct
@@ -1,4 +1,4 @@
-
+# vim: set filetype=python et ts=4 sw=4:
 
 # Copyright (c) 2012-2015 by the GalSim developers team on GitHub
 # https://github.com/GalSim-developers
@@ -43,7 +43,7 @@ subdirs=['src', 'pysrc', 'bin', 'galsim', 'share']
 config_file = 'gs_scons.conf'
 
 # Default directory for installation.
-
+# This is the only UNIX specific things I am aware
 # of in the script.  On the other hand, these are not required for the
 # script to work since prefix can be set on the command line and the
 # extra paths are not needed, but I wish I knew how to get the default

--- a/SConstruct
+++ b/SConstruct
@@ -100,7 +100,12 @@ opts.Add(BoolVariable('IMPORT_ENV',
 opts.Add('EXTRA_LIBS','Libraries to send to the linker','')
 opts.Add(BoolVariable('IMPORT_PREFIX',
          'Use PREFIX/include and PREFIX/lib in search paths', True))
-
+opts.Add(PathVariable('DYLD_LIBRARY_PATH',
+         'Set the DYLD_LIBRARY_PATH inside of SCons.  '+
+         'Particularly useful on El Capitan (and later), since Apple strips out '+
+         'DYLD_LIBRARY_PATH from the environment that SCons sees, so if you need it, '+
+         'this option enables SCons to set it back in for you.',
+         '', PathVariable.PathAccept))
 opts.Add('NOSETESTS','Name of nosetests executable','')
 opts.Add(BoolVariable('CACHE_LIB','Cache the results of the library checks',True))
 opts.Add(BoolVariable('WITH_PROF',
@@ -701,6 +706,41 @@ def ReadFileList(fname):
     files = [f.strip() for f in files]
     return files
 
+def AltTryRun(config, text, extension):
+    #ok, out = config.TryRun(text,'.cpp')
+    # The above line works on most systems, but on El Capitan, Apple decided to
+    # strip out the DYLD_LIBRARY_PATH from any system call.  So the above won't
+    # be able to find the right runtime libraries that are in their 
+    # DYLD_LIBRARY_PATH.  The next few lines are a copy of the SCons TryRun
+    # implementation, but then adding the DYLD_LIBRARY_PATH to the environment
+    # on the command line.
+    ok = config.TryLink(text, '.cpp')
+    if ok: 
+        prog = config.lastTarget 
+        try:
+            pname = prog.get_internal_path() 
+        except:
+            pname = prog.get_abspath()
+        try:
+            # I didn't track this down, but sometimes we TryRun (now AltTryRun)
+            # with config as a SConfBase, other times it is a CheckContext instance,
+            # so the SConfBase object is found as config.sconf.
+            # Just try this and if it fails, assume that config is already the sconf.
+            sconf = config.sconf
+        except:
+            sconf = config
+        output = sconf.confdir.File(os.path.basename(pname)+'.out') 
+        if 'DYLD_LIBRARY_PATH' in sconf.env:
+            pre = 'DYLD_LIBRARY_PATH=%r'%sconf.env['DYLD_LIBRARY_PATH']
+            pname = "%s %s"%(pre,pname)
+        node = config.env.Command(output, prog, [ [ 'bash', '-c', pname, ">", "${TARGET}"] ]) 
+        ok = sconf.BuildNodes(node) 
+    if ok:
+        # For successful execution, also return the output contents
+        outputStr = output.get_contents()
+        return 1, outputStr.strip()
+    else:
+        return 0, ""
 
 def TryRunResult(config,text,name):
     # Check if a particular program (given as text) is compilable, runs, and returns the
@@ -710,9 +750,8 @@ def TryRunResult(config,text,name):
     save_spawn = config.sconf.env['SPAWN']
     config.sconf.env['SPAWN'] = config.sconf.pspawn_wrapper
 
-    # First use the normal TryRun command
-    ok, out = config.TryRun(text,'.cpp')
-
+    # This is the normal TryRun command that I am slightly modifying:
+    ok, out = AltTryRun(config,text,'.cpp')
     config.sconf.env['SPAWN'] = save_spawn
 
     # We have an arbitrary requirement that the executable output the answer 23.
@@ -880,7 +919,7 @@ def CheckBoost(config):
 #include "boost/version.hpp"
 int main() { std::cout<<BOOST_VERSION<<std::endl; return 0; }
 """
-    ok, boost_version = config.TryRun(boost_version_file,'.cpp')
+    ok, boost_version = AltTryRun(config,boost_version_file,'.cpp')
     boost_version = int(boost_version.strip())
     print 'Boost version is %d.%d.%d' % (
             boost_version / 100000, boost_version / 100 % 1000, boost_version % 100)
@@ -952,9 +991,15 @@ def TryScript(config,text,executable):
 
     # Run the given executable with the source file we just built
     output = config.sconf.confdir.File(f + '.out')
-    node = config.env.Command(output, source, executable + " < $SOURCE > $TARGET 2>&1")
+    #node = config.env.Command(output, source, executable + " < $SOURCE >& $TARGET")
+    # Just like in AltTryRun, we need to add the DYLD_LIBRARY_PATH for El Capitan.
+    if 'DYLD_LIBRARY_PATH' in config.sconf.env:
+        pre = 'DYLD_LIBRARY_PATH=%r'%config.sconf.env['DYLD_LIBRARY_PATH']
+        executable = "%s %s"%(pre,executable)
+    node = config.env.Command(output, source, 
+            [[ 'bash', '-c', executable, "<", "${SOURCE}", ">", "${TARGET}", "2>&1"]]) 
     ok = config.sconf.BuildNodes(node)
-
+ 
     config.sconf.env['SPAWN'] = save_spawn
 
     if ok:
@@ -1526,7 +1571,7 @@ def DoCppChecks(config):
 int main()
 { std::cout<<tmv::TMV_Version()<<std::endl; return 0; }
 """
-    ok, tmv_version = config.TryRun(tmv_version_file,'.cpp')
+    ok, tmv_version = AltTryRun(config,tmv_version_file,'.cpp')
     print 'TMV version is '+tmv_version.strip()
 
     compiler = config.env['CXXTYPE']

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -10,6 +10,7 @@ import glob
 Import('env')
 ReadFileList = env['_ReadFileList']
 AddRPATH = env['_AddRPATH']
+PrependLibraryPaths = env['_PrependLibraryPaths']
 
 libs=['galsim']
 
@@ -40,6 +41,8 @@ def run_tests(target, source, env):
     if env['NOSETESTS']:
         print 'Using nosetests from: ',env['NOSETESTS']
         cmd = env['NOSETESTS']
+        # Account for SIP on El Capitan
+        cmd = PrependLibraryPaths(cmd,env)
         if env['NOSETESTSVERSION'] >= '1.1' and env.GetOption('num_jobs') > 1:
             cmd += ' --processes=%d --process-timeout=60'%(env.GetOption('num_jobs'))
             print 'nosetests is version %s... running tests in parallel with %d jobs'%(

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -119,11 +119,13 @@ def run_tests(target, source, env):
     # Always run cpp tests
     if True:
         print '\nStarting cpp tests...'
+        cmd = str(source[0])
+        cmd = PrependLibraryPaths(cmd,env)
         cpp_proc = subprocess.Popen(
-            str(source[0]),
+            ['bash', '-c', cmd],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            shell=True)
+            shell=False)
         
         while cpp_proc.poll() == None:
             buf = os.read(cpp_proc.stdout.fileno(),1)

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -61,7 +61,7 @@ def run_tests(target, source, env):
         log.write('Nosetests version is: ' + env['NOSETESTSVERSION'] + '\n')
         log.write('Nosetests command is:\n' + cmd + '\n')
         py_proc = subprocess.Popen(
-            cmd.split(),
+            ['bash', '-c', cmd],
             cwd='tests',
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,


### PR DESCRIPTION
At the DESC hack day today, we tried to install GalSim with Anaconda Python on @cwwalter's laptop.  But we ran into a new problem introduced by El Capitan, the latest MacOS.  They decided to institute a new policy called "System Integrity Protection" (SIP).  Probably, this is really important for stopping terrorists from taking over the world.  But for running SCons properly, it was a big headache.

Basically, SIP involved removing dangerous environment variables like LD_LIBRARY_PATH and DYLD_LIBRARY_PATH from system calls.  So within SCons, or when SCons calls system commands to see if things can run properly, it fails if you system is relying on these variables to find the right libraries at runtime.

The solution is twofold:
1. Add scons options to let the user explicitly give LD_LIBRARY_PATH or DYLD_LIBRARY_PATH so SCons can set them back into its own environment after SIP has stripped them out of os.environ.  
2. Wheneven SCons calls a shell command to run something, add `DYLD_LIBRARY_PATH=env['DYLD_LIBRARY_PATH']` before the command to bypass the SIP stripping that happens there.

I think all this is working properly.  We got it to work on Chris's laptop before he left for the airport.  But it would be worth people quickly checking that I haven't broken anything for other systems in the process.

Also, @cwwalter, please make sure that my cleaning up of the SConstruct file from what you sent me didn't make anything stop working for you.  You should be able to do:
```
cd /path/to/GalSim
git pull
git checkout '#721'
scons
```
and just make sure this still works for you.  Thanks!