### PR TITLE
Table speedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ New Features
 - Made it possible to impose some cuts on galaxy image quality in the
   COSMOSCatalog class. (#693)
 - Added `convergence_threshold` as a parameter of HSMParams. (#709)
+- Sped up some Bandpass and SED functionality (and LookupTable class in
+  general). (#735)
 
 
 Updates to galsim executable

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -86,6 +86,9 @@ The GalSim package also requires
   is kind of a gargantuan package.  But if you are willing to install that
   too, then you can use the galsim.AstropyWCS class.
   
+* Optional dependency: Pandas.  This has a very fast function for reading ASCII
+  tables.  If this is not available (e.g. when reading in Bandpass or SED
+  files) then we fall back to the (much) slower numpy loadtxt function.
 
 These should installed onto your Python system so that they can be imported by:
 
@@ -96,6 +99,7 @@ These should installed onto your Python system so that they can be imported by:
                                   plan to parse .yaml configuration files ]
     >>> import starlink.Ast     [ if planning to use PyAstWCS class ]
     >>> import astropy.wcs      [ if planning to use AstropyWCS class ]
+    >>> import pandas           [ for faster ASCII table input ]
 
 within Python.  You can test this by loading up the Python interpreter for the
 version of Python you will be using with the GalSim toolkit. This is usually

--- a/galsim/bandpass.py
+++ b/galsim/bandpass.py
@@ -432,8 +432,8 @@ class Bandpass(object):
             tp = self.func(wave)
             if relative_throughput is not None:
                 w = (tp >= tp.max()*relative_throughput).nonzero()
-                blue_limit = max([min(wave[w]), blue_limit])
-                red_limit = min([max(wave[w]), red_limit])
+                blue_limit = max([np.min(wave[w]), blue_limit])
+                red_limit = min([np.max(wave[w]), red_limit])
             wave_list = wave_list[np.logical_and(wave_list >= blue_limit,
                                                  wave_list <= red_limit) ]
         elif relative_throughput is not None:

--- a/galsim/base.py
+++ b/galsim/base.py
@@ -702,7 +702,7 @@ class GSObject(object):
         else:
             shear = galsim.Shear(**kwargs)
 
-        new_obj = galsim.Transform(self, jac=shear.getMatrix().flatten().tolist())
+        new_obj = galsim.Transform(self, jac=shear.getMatrix().ravel().tolist())
 
         if hasattr(self,'noise'):
             new_obj.noise = self.noise.shear(shear)

--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -1340,7 +1340,7 @@ class ChromaticTransformation(ChromaticObject):
         if hasattr(self._jac, '__call__'):
             jac = self._jac
         else:
-            jac = self._jac.flatten().tolist()
+            jac = self._jac.ravel().tolist()
         if hasattr(self._offset, '__call__'):
             offset = self._offset
         else:
@@ -1353,7 +1353,7 @@ class ChromaticTransformation(ChromaticObject):
         if hasattr(self._jac, '__call__'):
             s += '.transform(%s)'%self._jac
         else:
-            dudx, dudy, dvdx, dvdy = self._jac.flatten()
+            dudx, dudy, dvdx, dvdy = self._jac.ravel()
             if dudx != 1 or dudy != 0 or dvdx != 0 or dvdy != 1:
                 # Figure out the shear/rotate/dilate calls that are equivalent.
                 jac = galsim.JacobianWCS(dudx,dudy,dvdx,dvdy)

--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -822,12 +822,12 @@ class InterpolatedChromaticObject(ChromaticObject):
         # Find the Nyquist scale for each, and to be safe, choose the minimum value to use for the
         # array of images that is being stored.
         nyquist_scale_vals = [ obj.nyquistScale() for obj in objs ]
-        scale = min(nyquist_scale_vals) / oversample_fac
+        scale = np.min(nyquist_scale_vals) / oversample_fac
 
         # Find the suggested image size for each object given the choice of scale, and use the
         # maximum just to be safe.
         possible_im_sizes = [ obj.SBProfile.getGoodImageSize(scale, 1.0) for obj in objs ]
-        im_size = max(possible_im_sizes)
+        im_size = np.max(possible_im_sizes)
 
         # Find the stepK and maxK values for each object.  These will be used later on, so that we
         # can force these values when instantiating InterpolatedImages before drawing.
@@ -860,9 +860,9 @@ class InterpolatedChromaticObject(ChromaticObject):
         @returns an Image of the object at the given wavelength.
         """
         # First, some wavelength-related sanity checks.
-        if wave < min(self.waves) or wave > max(self.waves):
+        if wave < np.min(self.waves) or wave > np.max(self.waves):
             raise RuntimeError("Requested wavelength %.1f is outside the allowed range:"
-                               " %.1f to %.1f nm"%(wave, min(self.waves), max(self.waves)))
+                               " %.1f to %.1f nm"%(wave, np.min(self.waves), np.max(self.waves)))
 
         # Figure out where the supplied wavelength is compared to the list of wavelengths on which
         # images were originally tabulated.
@@ -958,8 +958,8 @@ class InterpolatedChromaticObject(ChromaticObject):
         # weight.  This is the most conservative possible choice, since it's possible that some of
         # the images that have non-zero weights might have such tiny weights that they don't change
         # the effective stepk and maxk we should use.
-        stepk = min(np.array(self.stepK_vals)[weight_fac>0])
-        maxk = max(np.array(self.maxK_vals)[weight_fac>0])
+        stepk = np.min(np.array(self.stepK_vals)[weight_fac>0])
+        maxk = np.max(np.array(self.maxK_vals)[weight_fac>0])
 
         # Instantiate the InterpolatedImage, using these conservative stepK and maxK choices.
         return galsim.InterpolatedImage(integral, _force_stepk=stepk, _force_maxk=maxk)

--- a/galsim/fitswcs.py
+++ b/galsim/fitswcs.py
@@ -272,7 +272,7 @@ class AstropyWCS(galsim.wcs.CelestialWCS):
             # though it won't do anything, since that's how the numpy array fmod2 has to work.
             func = lambda pix: (
                     (numpy.fmod(self._wcs.all_pix2world(numpy.atleast_2d(pix),origin) - 
-                                rd + 180,360) - 180).flatten() )
+                                rd + 180,360) - 180).ravel() )
 
             # This is the main bit that the astropy function is missing.
             # The scipy.optimize.broyden1 function can't handle starting at exactly the right
@@ -710,7 +710,7 @@ class WcsToolsWCS(galsim.wcs.CelestialWCS):
         # Need this to look like 
         #    [ x1, y1, x2, y2, ... ] 
         # if input is either scalar x,y or two arrays.
-        xy = numpy.array([x, y]).transpose().flatten()
+        xy = numpy.array([x, y]).transpose().ravel()
         
         # The OS cannot handle arbitrarily long command lines, so we may need to split up
         # the list into smaller chunks.
@@ -789,7 +789,7 @@ class WcsToolsWCS(galsim.wcs.CelestialWCS):
     def _xy(self, ra, dec):
         import subprocess
         import numpy
-        rd = numpy.array([ra, dec]).transpose().flatten()
+        rd = numpy.array([ra, dec]).transpose().ravel()
         rd *= galsim.radians / galsim.degrees
         for digits in range(10,5,-1):
             rd_strs = [ str(z) for z in rd ]

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -769,9 +769,9 @@ class Image(object):
         rsq = x*x + y*y
 
         # Sort by radius
-        indx = numpy.argsort(rsq.flatten())
-        rsqf = rsq.flatten()[indx]
-        data = self.array.flatten()[indx]
+        indx = numpy.argsort(rsq.ravel())
+        rsqf = rsq.ravel()[indx]
+        data = self.array.ravel()[indx]
         cumflux = numpy.cumsum(data)
 
         # Find the first value with cumflux > 0.5 * flux
@@ -887,9 +887,9 @@ class Image(object):
         rsq = x*x + y*y
 
         # Sort by radius
-        indx = numpy.argsort(rsq.flatten())
-        rsqf = rsq.flatten()[indx]
-        data = self.array.flatten()[indx]
+        indx = numpy.argsort(rsq.ravel())
+        rsqf = rsq.ravel()[indx]
+        data = self.array.ravel()[indx]
 
         # Find the first value with I < 0.5 * Imax
         k = numpy.argmax(data < 0.5 * Imax)

--- a/galsim/sed.py
+++ b/galsim/sed.py
@@ -197,8 +197,8 @@ class SED(object):
         @returns the photon density in units of photons/nm
         """
         if hasattr(wave, '__iter__'): # Only iterables respond to min(), max()
-            wmin = min(wave)
-            wmax = max(wave)
+            wmin = np.min(wave)
+            wmax = np.max(wave)
         else: # python scalar
             wmin = wave
             wmax = wave

--- a/galsim/table.py
+++ b/galsim/table.py
@@ -134,10 +134,17 @@ class LookupTable(object):
         # as _LookupTable.
         self.table = _galsim._LookupTable(x, f, interpolant)
 
+        # Get the min/max x values, making sure to account properly for x_log.
+        self._x_min = self.table.argMin()
+        self._x_max = self.table.argMax()
+        if x_log:
+            self._x_min = np.exp(self._x_min)
+            self._x_max = np.exp(self._x_max)
+
     @property
-    def x_min(self): return self.table.argMin()
+    def x_min(self): return self._x_min
     @property
-    def x_max(self): return self.table.argMax()
+    def x_max(self): return self._x_max
     @property
     def n_x(self): return len(self.x)
 

--- a/galsim/table.py
+++ b/galsim/table.py
@@ -135,9 +135,9 @@ class LookupTable(object):
         self.table = _galsim._LookupTable(x, f, interpolant)
 
     @property
-    def x_min(self): return min(self.x)
+    def x_min(self): return self.table.argMin()
     @property
-    def x_max(self): return max(self.x)
+    def x_max(self): return self.table.argMax()
     @property
     def n_x(self): return len(self.x)
 

--- a/galsim/table.py
+++ b/galsim/table.py
@@ -179,8 +179,8 @@ class LookupTable(object):
             if dimen > 2:
                 raise ValueError("Arrays with dimension larger than 2 not allowed!")
             elif dimen == 2:
-                f = np.empty_like(x.flatten(), dtype=float)
-                self.table.interpMany(x.astype(float).flatten(),f)
+                f = np.empty_like(x.ravel(), dtype=float)
+                self.table.interpMany(x.astype(float).ravel(),f)
                 f = f.reshape(x.shape)
             else:
                 f = np.empty_like(x, dtype=float)

--- a/galsim/table.py
+++ b/galsim/table.py
@@ -95,7 +95,7 @@ class LookupTable(object):
                 import pandas
                 data = pandas.read_csv(file, comment='#', delim_whitespace=True, header=None)
                 data = data.values.transpose()
-            except ImportError:
+            except (ImportError, AttributeError):
                 data = np.loadtxt(file).transpose()
             if data.shape[0] != 2:
                 raise ValueError("File %s provided for LookupTable does not have 2 columns"%file)

--- a/galsim/table.py
+++ b/galsim/table.py
@@ -89,7 +89,7 @@ class LookupTable(object):
         if file:
             if x is not None or f is not None:
                 raise ValueError("Cannot provide both file _and_ x,f for LookupTable")
-            # We don't require pandas as a dependency, but it it's available, this is much faster.
+            # We don't require pandas as a dependency, but if it's available, this is much faster.
             # cf. http://stackoverflow.com/questions/15096269/the-fastest-way-to-read-input-in-python
             try:
                 import pandas

--- a/galsim/table.py
+++ b/galsim/table.py
@@ -89,7 +89,14 @@ class LookupTable(object):
         if file:
             if x is not None or f is not None:
                 raise ValueError("Cannot provide both file _and_ x,f for LookupTable")
-            data = np.loadtxt(file).transpose()
+            # We don't require pandas as a dependency, but it it's available, this is much faster.
+            # cf. http://stackoverflow.com/questions/15096269/the-fastest-way-to-read-input-in-python
+            try:
+                import pandas
+                data = pandas.read_csv(file, comment='#', delim_whitespace=True, header=None)
+                data = data.values.transpose()
+            except ImportError:
+                data = np.loadtxt(file).transpose()
             if data.shape[0] != 2:
                 raise ValueError("File %s provided for LookupTable does not have 2 columns"%file)
             x=data[0]

--- a/galsim/table.py
+++ b/galsim/table.py
@@ -172,18 +172,22 @@ class LookupTable(object):
             if dimen > 2:
                 raise ValueError("Arrays with dimension larger than 2 not allowed!")
             elif dimen == 2:
-                f = np.zeros_like(x)
-                for i in xrange(x.shape[0]):
-                    f[i,:] = np.fromiter((self.table(float(q)) for q in x[i,:]), dtype='float')
+                f = np.empty_like(x.flatten(), dtype=float)
+                self.table.interpMany(x.astype(float).flatten(),f)
+                f = f.reshape(x.shape)
             else:
-                f = np.fromiter((self.table(float(q)) for q in x), dtype='float')
+                f = np.empty_like(x, dtype=float)
+                self.table.interpMany(x.astype(float),f)
         # option 2: a tuple
         elif isinstance(x, tuple):
-            f = [ self.table(q) for q in x ]
+            f = np.empty_like(x, dtype=float)
+            self.table.interpMany(np.array(x, dtype=float),f)
             f = tuple(f)
         # option 3: a list
         elif isinstance(x, list):
-            f = [ self.table(q) for q in x ]
+            f = np.empty_like(x, dtype=float)
+            self.table.interpMany(np.array(x, dtype=float),f)
+            f = list(f)
         # option 4: a single value
         else:
             f = self.table(x)

--- a/galsim/transform.py
+++ b/galsim/transform.py
@@ -59,7 +59,7 @@ def Transform(obj, jac=(1.,0.,0.,1.), offset=galsim.PositionD(0.,0.), flux_ratio
         # NB. Even better, if the flux scaling is chromatic, would be to find a component
         # that is already non-separable.  But we don't bother trying to do that currently.
         elif (isinstance(obj, galsim.ChromaticConvolution or isinstance(obj, galsim.Convolution))
-              and numpy.array_equal(numpy.asarray(jac).flatten(),(1,0,0,1))
+              and numpy.array_equal(numpy.asarray(jac).ravel(),(1,0,0,1))
               and offset == galsim.PositionD(0.,0.)):
             first = Transform(obj.objlist[0],flux_ratio=flux_ratio,gsparams=gsparams)
             return galsim.ChromaticConvolution( [first] + [o for o in obj.objlist[1:]] )
@@ -106,7 +106,7 @@ class Transformation(galsim.GSObject):
     """
     def __init__(self, obj, jac=(1.,0.,0.,1.), offset=galsim.PositionD(0.,0.), flux_ratio=1.,
                  gsparams=None):
-        dudx, dudy, dvdx, dvdy = numpy.asarray(jac, dtype=float).flatten()
+        dudx, dudy, dvdx, dvdy = numpy.asarray(jac, dtype=float).ravel()
         if hasattr(obj, 'original'):
             self._original = obj.original
         else:
@@ -146,7 +146,7 @@ class Transformation(galsim.GSObject):
 
     def __str__(self):
         s = str(self.original)
-        dudx, dudy, dvdx, dvdy = self.jac.flatten()
+        dudx, dudy, dvdx, dvdy = self.jac.ravel()
         if dudx != 1 or dudy != 0 or dvdx != 0 or dvdy != 1:
             # Figure out the shear/rotate/dilate calls that are equivalent.
             jac = galsim.JacobianWCS(dudx,dudy,dvdx,dvdy)

--- a/galsim/wcs.py
+++ b/galsim/wcs.py
@@ -787,12 +787,12 @@ class EuclideanWCS(BaseWCS):
         y -= self.y0
         try:
             # First try to use the _u, _v function with the numpy arrays.
-            u = self._u(x.flatten(),y.flatten())
-            v = self._v(x.flatten(),y.flatten())
+            u = self._u(x.ravel(),y.ravel())
+            v = self._v(x.ravel(),y.ravel())
         except:
             # If that didn't work, we have to do it manually for each position. :(  (SLOW!)
-            u = numpy.array([ self._u(x1,y1) for x1,y1 in zip(x.flatten(),y.flatten()) ])
-            v = numpy.array([ self._v(x1,y1) for x1,y1 in zip(x.flatten(),y.flatten()) ])
+            u = numpy.array([ self._u(x1,y1) for x1,y1 in zip(x.ravel(),y.ravel()) ])
+            v = numpy.array([ self._v(x1,y1) for x1,y1 in zip(x.ravel(),y.ravel()) ])
         u = numpy.reshape(u, x.shape)
         v = numpy.reshape(v, x.shape)
         # Use the finite differences to estimate the derivatives.
@@ -965,10 +965,10 @@ class CelestialWCS(BaseWCS):
         y -= self.y0
         try:
             # First try to use the _radec function with the numpy arrays.
-            ra, dec = self._radec(x.flatten(),y.flatten())
+            ra, dec = self._radec(x.ravel(),y.ravel())
         except:
             # If that didn't work, we have to do it manually for each position. :(  (SLOW!)
-            rd = [ self._radec(x1,y1) for x1,y1 in zip(x.flatten(),y.flatten()) ]
+            rd = [ self._radec(x1,y1) for x1,y1 in zip(x.ravel(),y.ravel()) ]
             ra = numpy.array([ radec[0] for radec in rd ])
             dec = numpy.array([ radec[1] for radec in rd ])
         ra = numpy.reshape(ra, x.shape)

--- a/include/galsim/Table.h
+++ b/include/galsim/Table.h
@@ -135,6 +135,9 @@ namespace galsim {
         /// interp, but exception if beyond bounds
         V lookup(const A a) const;
 
+        /// interp many values at once.
+        void interpMany(const A* argvec, V* valvec, int N) const;
+
         /// size of table
         int size() const { return v.size(); }
 

--- a/pysrc/Table.cpp
+++ b/pysrc/Table.cpp
@@ -28,6 +28,7 @@
 #include <boost/python/stl_iterator.hpp>
 
 #include "Table.h"
+#include "NumpyHelper.h"
 
 namespace bp = boost::python;
 
@@ -111,6 +112,15 @@ namespace {
             return std::string("");
         }
 
+        static void interpMany(const Table<double,double>& table,
+                               const bp::object& args, const bp::object& vals)
+        {
+            const double* argvec = GetNumpyArrayData<double>(args.ptr());
+            double* valvec = GetNumpyArrayData<double>(vals.ptr());
+            int N = GetNumpyArrayDim(args.ptr(), 0);
+            table.interpMany(argvec, valvec, N);
+        }
+
         static void wrap() 
         {
             // docstrings are in galsim/table.py
@@ -128,7 +138,7 @@ namespace {
 
                 // Use version that throws expection if out of bounds
                 .def("__call__", &Table<double,double>::lookup) 
-
+                .def("interpMany", &interpMany)
                 .def("getArgs", &convertGetArgs)
                 .def("getVals", &convertGetVals)
                 .def("getInterp", &convertGetInterp)

--- a/src/Table.cpp
+++ b/src/Table.cpp
@@ -161,6 +161,16 @@ namespace galsim {
         return interpolate(a,i,v,y2);
     }
 
+    template <class V, class A>
+    void Table<V,A>::interpMany(const A* argvec, V* valvec, int N) const
+    {
+        setup();
+        for (int k=0; k<N; ++k) {
+            int i = upperIndex(argvec[k]);
+            valvec[k] = interpolate(argvec[k],i,v,y2);
+        }
+    }
+
     template<class V, class A>
     V Table<V,A>::linearInterpolate(
         A a, int i, const std::vector<Entry>& v, const std::vector<V>& )


### PR DESCRIPTION
This is a quick PR in response to @jchiang87's [Photometry Bakeoff](https://github.com/jchiang87/PhotometryBakeoff) results.  This was using the GalSim Bandpass and SED classes in a way that we never really tried to optimize for speed.  So it turned out the code wasn't terribly fast.  

Here (on branch table_speedup) I made a few simple changes to speed things up.

1. Use pandas to read in the text file if it's available, falling back to the old (and much slower) `numpy.loadtxt` function.  This wasn't actually part of Jim's timings, since he started the clock after the SED and Bandpass were both loaded.  But it makes a huge difference in the overall running time of the galsim_baker script.

2. Add a function to the C++ Table class that can interpolate many values at once.  This saves a huge overhead from the python generator that was doing the interpolation one item at a time and `numpy.fromiter` to turn the values into an array.

3. Use `numpy.min` and `numpy.max` rather than the python `min`, `max` for arrays in a couple places.  This is a standard optimization.  I guess we just failed to notice these before.

4. Use the `Table.argMin()` and `argMax()` functions for the min and max table values rather than recalculating them for the `x_min` and `x_max` properties.  This is another silly oversight, since the values are already known, so there is no point to calculating them again.

Results:

The total time for running Jim's galsim_baker.py script on my laptop with and without thinning the bandpass:

Current master branch:

Without Thinning: 50m 10s
With Thinning: 29m 59s

This branch:

Without Thinning: 3m 47s
With Thinning: 2m 54s

So an order of magnitude speed up.  Not bad for a day's work... :)