### PR TITLE
#738 - small bug in writing output truth tables

### DIFF
--- a/examples/demo9.py
+++ b/examples/demo9.py
@@ -241,11 +241,11 @@ def main(argv):
         # columns.
         names = [ 'object_id', 'halo_id',
                   'flux', 'size', 'eta1', 'eta2', 'mu', 'redshift', 
-                  'shear.g1', 'shear.g2', 'pos.x', 'pos.y', 
+                  'shear.g1', 'shear.g2', 'pos.x', 'pos.y', 'image_pos.x', 'image_pos.y',
                   'halo_mass', 'halo_conc', 'halo_redshift' ]
         types = [ int, int,
                   float, float, float, float, float, float,
-                  float, float, float, float,
+                  float, float, float, float, float, float,
                   float, float, float ]
         truth_cat = galsim.OutputCatalog(names, types)
 
@@ -398,6 +398,7 @@ def main(argv):
             row = ( (first_obj_id + k), halo_id, 
                     flux, hlr, eta1, eta2, nfw_mu, nfw_z_source,
                     total_shear.g1, total_shear.g2, pos.x, pos.y,
+                    image_pos.x, image_pos.y,
                     mass, nfw_conc, nfw_z_halo )
             truth_cat.addRow(row)
 

--- a/examples/demo9.yaml
+++ b/examples/demo9.yaml
@@ -431,6 +431,12 @@ output :
             shear : gal.shear
             pos : image.world_pos
 
+            # The world position is an explicit generated value in the config dict in this case,
+            # but image_pos and world_pos are always available values (like obj_num, file_num
+            # above), since GalSim will generate them itself if necessary.  Here, we output
+            # image_pos, which is generated from world_pos and the WCS.
+            image_pos : image_pos
+
             # Things in the input field don't change for each object, but they can 
             # still be placed in the truth catalog.  These columns will have all identical
             # values within each catalog, but different across catalogs.

--- a/examples/great3/cgc.yaml
+++ b/examples/great3/cgc.yaml
@@ -273,8 +273,8 @@ output:
             - 0
         columns:
             num: obj_num
-            x: "$(@image_pos).x"
-            y: "$(@image_pos).y"
+            x: "$image_pos.x"
+            y: "$image_pos.y"
             dx: image.offset.x
             dy: image.offset.y
             atmos_psf_e1: "$(@psf.items.0.ellip).e1"

--- a/examples/json/demo9.json
+++ b/examples/json/demo9.json
@@ -157,6 +157,7 @@
 
             "shear" : "gal.shear",
             "pos" : "image.world_pos",
+            "image_pos" : "image_pos",
 
             "halo_mass" : "input.nfw_halo.mass",
             "halo_conc" : "input.nfw_halo.conc",

--- a/galsim/config/extra_truth.py
+++ b/galsim/config/extra_truth.py
@@ -68,6 +68,9 @@ class TruthBuilder(ExtraOutputBuilder):
             elif key[0] == '$':
                 # This can also be handled by ParseValue
                 value = galsim.config.ParseValue(cols,name,base,None)[0]
+            elif key[0] == '@':
+                # Pop off an initial @ if there is one.
+                value = galsim.config.GetCurrentValue(key[1:], base)
             else:
                 value = galsim.config.GetCurrentValue(key, base)
             row.append(value)

--- a/galsim/config/value.py
+++ b/galsim/config/value.py
@@ -219,17 +219,25 @@ def GetCurrentValue(key, config, value_type=None, base=None, return_safe=False):
 
         if chain: 
             # If there are more keys, just set d to the next in the chain.
-            d = d[k]
+            try:
+                d = d[k]
+            except TypeError:
+                raise ValueError("Invalid key in GetCurrentValue = %s"%key)
 
             # One subtlety here.  Normally the normal tree traversal will keep track of the index
             # key so that all lower levels inherit an index_key specification at a higher level.
             # This can circumvent that, so we need to do it here as well.  The easiest way to
             # handle it is to watch for an index_key specification along our chain, and if there
             # is one, set that in the final dict.
-            if 'index_key' in d:
+            if isinstance(d,dict) and 'index_key' in d:
                 use_index_key = d['index_key']
                 #print 'Set use_index_key = ',use_index_key
         else:
+            try:
+                dk = d[k]
+            except TypeError:
+                raise ValueError("Invalid key in GetCurrentValue = %s"%key)
+
             if not isinstance(d[k], dict):
                 if value_type is None:
                     # If we are not given the value_type, and it's not a dict, then the
@@ -261,7 +269,7 @@ def GetCurrentValue(key, config, value_type=None, base=None, return_safe=False):
             else:
                 return val
 
-    raise ValueError("Invalid key = %s"%key)
+    raise ValueError("Invalid key in GetCurrentValue = %s"%key)
 
 
 def SetDefaultIndex(config, num):

--- a/galsim/config/value.py
+++ b/galsim/config/value.py
@@ -221,7 +221,9 @@ def GetCurrentValue(key, config, value_type=None, base=None, return_safe=False):
             # If there are more keys, just set d to the next in the chain.
             try:
                 d = d[k]
-            except TypeError:
+            except (TypeError, KeyError):
+                # TypeError for the case where d is a float or Position2D, so d[k] is invalid.
+                # KeyError for the case where d is a dict, but k is not a valid key.
                 raise ValueError("Invalid key in GetCurrentValue = %s"%key)
 
             # One subtlety here.  Normally the normal tree traversal will keep track of the index
@@ -235,7 +237,7 @@ def GetCurrentValue(key, config, value_type=None, base=None, return_safe=False):
         else:
             try:
                 dk = d[k]
-            except TypeError:
+            except (TypeError, KeyError):
                 raise ValueError("Invalid key in GetCurrentValue = %s"%key)
 
             if not isinstance(d[k], dict):

--- a/galsim/scene.py
+++ b/galsim/scene.py
@@ -848,10 +848,8 @@ class COSMOSCatalog(object):
         # deep scaling, then it gets messed up by that.  If we have done some transformations, and
         # are also doing later transformation, it will take the `original` attribute that is already
         # there.  So having `index` doesn't help, and we also need `original.index`.
-        if not hasattr(gal, 'original'):
-            gal.index = cosmos_catalog.getOrigIndex(index)
-        else:
-            gal.index = cosmos_catalog.getOrigIndex(index)
+        gal.index = cosmos_catalog.getOrigIndex(index)
+        if hasattr(gal, 'original'):
             gal.original.index = cosmos_catalog.getOrigIndex(index)
 
         return gal

--- a/galsim/scene.py
+++ b/galsim/scene.py
@@ -549,6 +549,7 @@ class COSMOSCatalog(object):
         # So just put it in here at the end to be sure.
         for gal, index in zip(gal_list, indices):
             gal.index = self.orig_index[index]
+            if hasattr(gal, 'original'): gal.original.index = self.orig_index[index]
 
         if hasattr(index, '__iter__'):
             return gal_list

--- a/galsim/scene.py
+++ b/galsim/scene.py
@@ -219,7 +219,7 @@ class COSMOSCatalog(object):
                 # But if that doesn't work, then the name might be the name of the real catalog,
                 # so try adding _fits to it as above.
                 k = full_file_name.find('.fits')
-                param_file_name = full_file_name[:k] + '_fits' + param_file_name[k:]
+                param_file_name = full_file_name[:k] + '_fits' + full_file_name[k:]
                 self.param_cat = pyfits.getdata(param_file_name)
 
         # Check for the old-style parameter catalog
@@ -304,7 +304,7 @@ class COSMOSCatalog(object):
             # which excludes a tiny number of galaxies (of order 10 in each sample) with some sky
             # subtraction or deblending errors.  Some of these are eliminated by other cuts when
             # using exclusion_level='marginal'.
-            if hasattr(self.real_cat, 'stamp_flux'):
+            if hasattr(self,'real_cat') and hasattr(self.real_cat, 'stamp_flux'):
                 mask &= self.real_cat.stamp_flux > 0
             else:
                 import warnings

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -80,8 +80,8 @@ def test_cosmos_fluxnorm():
     # Then check that if we draw a parametric representation that is achromatic, that the flux
     # matches reasonably well (won't be exact because model isn't perfect).
     gal1_param = cat.makeGalaxy(test_ind, gal_type='parametric', chromatic=False)
-    gal1_param = galsim.Convolve(gal1_param, final_psf)
-    im1_param = gal1_param.drawImage(scale=0.05)
+    gal1_param_final = galsim.Convolve(gal1_param, final_psf)
+    im1_param = gal1_param_final.drawImage(scale=0.05)
 
     # Then check the same for a chromatic parametric representation that is drawn into the same
     # band.
@@ -95,6 +95,14 @@ def test_cosmos_fluxnorm():
     test_val = [im2.array.sum(), im1_param.array.sum(), im1_chrom.array.sum()]
     np.testing.assert_allclose(ref_val, test_val, rtol=0.1,
                                err_msg='Flux normalization problem in COSMOS galaxies')
+
+    # Finally, check that the original COSMOS info is stored properly after transformations, for
+    # both Sersic galaxies (like galaxy 0 in the catalog) and the one that is gal1_param above.
+    gal0_param = cat.makeGalaxy(0, gal_type='parametric', chromatic=False)
+    assert hasattr(gal0_param.shear(g1=0.05).original, 'index'), \
+        'Sersic galaxy does not retain index information after transformation'
+    assert hasattr(gal1_param.shear(g1=0.05).original, 'index'), \
+        'Bulge+disk galaxy does not retain index information after transformation'
 
     t2 = time.time()
     print 'time for %s = %.2f'%(funcname(),t2-t1)


### PR DESCRIPTION
As described in #738, there was a bug in tracking the original COSMOS catalog index for parametric galaxies that use the Sersic galaxy model.  If a transformation (like lensing) was later applied to those objects then the original catalog index was not retained.  On this branch:

- That bug was fixed.  I also made a unit test that would catch the issue on the python side (not the config side), but did not add the bug fix to the CHANGELOG since the truth table functionality is new in v1.4.
- Some of the demos were updated to include more information in the output truth tables (e.g., location of the galaxy within a larger image, and index in the COSMOS catalog).
- Mike made some of the error messages when using the wrong syntax for output truth tables more informative.
