### PR TITLE
Add a Travis-CI YAML file for continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: python
+compiler:
+  - g++
+before_install:
+  - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
+  - sudo apt-get -qq update
+  - sudo apt-get install -y libboost-all-dev gfortran liblapack-dev libfftw3-dev python-dev python-numpy python-scipy python-nose
+  - pip install astropy pyyaml
+  - pushd $HOME
+#Only get TMV if not cached
+  - if ! test -d tmv-0.73; then wget https://github.com/rmjarvis/tmv/archive/v0.73.tar.gz && tar -xf v0.73.tar.gz ; else echo Using cached TMV; fi
+#But always install it to /usr/local
+  - cd tmv-0.73 && sudo scons install DEBUG=True FLAGS="-O0"
+  - popd
+cache:
+    pip: true
+    directories:
+    - $HOME/tmv-0.73
+
+install: scons
+script: scons tests
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+branches:
+  only:
+    - master
 language: python
 compiler:
   - g++

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - pip install astropy pyyaml
   - pushd $HOME
 #Only get TMV if not cached
-  - if ! test -d tmv-0.73; then wget https://github.com/rmjarvis/tmv/archive/v0.73.tar.gz && tar -xf v0.73.tar.gz ; else echo Using cached TMV; fi
+  - if ! test -d tmv-0.73 || ! test -f tmv-0.73/Sconstruct; then wget https://github.com/rmjarvis/tmv/archive/v0.73.tar.gz && tar -xf v0.73.tar.gz ; else echo Using cached TMV; fi
 #But always install it to /usr/local
   - cd tmv-0.73 && sudo scons install DEBUG=True FLAGS="-O0"
   - popd


### PR DESCRIPTION
This PR adds a .travis.yml file, which enables integration with the Travis-CI continuous integration service. It replaces the Jarvis CI system, which has not been working for a while since I've been unable to get galsim properly installed there, among other problems.

An example run on this fork can be seen at:
https://travis-ci.org/joezuntz/GalSim/builds/132622083
there are currently no errors but there are some warnings that it might be worth looking into!

If this PR is okay then there are a few more steps to enabling Travis for main GalSim repository:

 - Sign up at travis-ci.org with the GalSim-developers account and accept the github permissions
 - Go to https://travis-ci.org/profile/Galsim-developers and enable CI for galsim

All the best,
Joe
