### PR TITLE
#763 Fix a bug in the Sum and Convolution constructors when the list has only one object.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ Bug Fixes
   not quite, flat (#741)
 - Fixed a bug in chromatic parametric galaxy models based on COSMOS galaxies.
   (#745)
+- Fixed a bug in the Sum and Convolution constructors when they are only
+  adding or convolving a single element that could lead to erroneous str and
+  reprs for the resulting object if it was then transformed. (#763)
 
 
 Deprecated Features

--- a/galsim/compound.py
+++ b/galsim/compound.py
@@ -137,25 +137,19 @@ class Sum(galsim.GSObject):
         # Save the list as an attribute, so it can be inspected later if necessary.
         self._obj_list = args
 
-        if len(args) == 1 and gsparams is None:
-            # No need to make an SBAdd in this case.
-            galsim.GSObject.__init__(self, args[0])
-            if hasattr(args[0],'noise'):
-                self.noise = args[0].noise
-        else:
-            # If any of the objects have a noise attribute, then we propagate the sum of the
-            # noises (they add like variances) to the final sum.
-            noise = None
-            for obj in args:
-                if hasattr(obj,'noise'):
-                    if noise is None:
-                        noise = obj.noise
-                    else:
-                        noise += obj.noise
-            SBList = [obj.SBProfile for obj in args]
-            galsim.GSObject.__init__(self, galsim._galsim.SBAdd(SBList, gsparams))
-            if noise is not None:
-                self.noise = noise
+        # If any of the objects have a noise attribute, then we propagate the sum of the
+        # noises (they add like variances) to the final sum.
+        noise = None
+        for obj in args:
+            if hasattr(obj,'noise'):
+                if noise is None:
+                    noise = obj.noise
+                else:
+                    noise += obj.noise
+        SBList = [obj.SBProfile for obj in args]
+        galsim.GSObject.__init__(self, galsim._galsim.SBAdd(SBList, gsparams))
+        if noise is not None:
+            self.noise = noise
 
     @property
     def obj_list(self): return self._obj_list

--- a/galsim/compound.py
+++ b/galsim/compound.py
@@ -302,15 +302,6 @@ class Convolution(galsim.GSObject):
             raise TypeError(
                 "Convolution constructor got unexpected keyword argument(s): %s"%kwargs.keys())
 
-        if len(args) == 1 and gsparams is None:
-            # No need to make an SBConvolve in this case.  Can early exit.
-            galsim.GSObject.__init__(self, args[0])
-            if hasattr(args[0],'noise'):
-                self.noise = args[0].noise
-            self._real_space = real_space
-            self._obj_list = args
-            return
-
         # Check whether to perform real space convolution...
         # Start by checking if all objects have a hard edge.
         hard_edge = True

--- a/tests/test_compound.py
+++ b/tests/test_compound.py
@@ -766,45 +766,45 @@ def test_sum_transform():
     or convolve only has one element.
     """
     gal0 = galsim.Exponential(scale_radius=0.34, flux=105.).shear(g1=-0.56,g2=0.15)
-    gal1 = galsim.Sum(gal0)
-    gal2 = gal1.dilate(1)
 
-    sgal1 = eval(str(gal1))
-    rgal1 = eval(repr(gal1))
-    sgal2 = eval(str(gal2))
-    rgal2 = eval(repr(gal2))
+    for gal1 in [ galsim.Sum(gal0), galsim.Convolve(gal0) ]:
+        gal2 = gal1.dilate(1)
 
-    print 'gal1 = ',repr(gal1)
-    print 'sgal1 = ',repr(sgal1)
-    print 'rgal1 = ',repr(rgal1)
+        sgal1 = eval(str(gal1))
+        rgal1 = eval(repr(gal1))
+        sgal2 = eval(str(gal2))
+        rgal2 = eval(repr(gal2))
 
-    print 'gal2 = ',repr(gal2)
-    print 'sgal2 = ',repr(sgal2)
-    print 'rgal2 = ',repr(rgal2)
+        print 'gal1 = ',repr(gal1)
+        print 'sgal1 = ',repr(sgal1)
+        print 'rgal1 = ',repr(rgal1)
 
-    gal1_im = gal1.drawImage(nx=64, ny=64, scale=0.2)
-    sgal1_im = sgal1.drawImage(nx=64, ny=64, scale=0.2)
-    rgal1_im = rgal1.drawImage(nx=64, ny=64, scale=0.2)
+        print 'gal2 = ',repr(gal2)
+        print 'sgal2 = ',repr(sgal2)
+        print 'rgal2 = ',repr(rgal2)
 
-    gal2_im = gal2.drawImage(nx=64, ny=64, scale=0.2)
-    sgal2_im = sgal2.drawImage(nx=64, ny=64, scale=0.2)
-    rgal2_im = rgal2.drawImage(nx=64, ny=64, scale=0.2)
+        gal1_im = gal1.drawImage(nx=64, ny=64, scale=0.2)
+        sgal1_im = sgal1.drawImage(nx=64, ny=64, scale=0.2)
+        rgal1_im = rgal1.drawImage(nx=64, ny=64, scale=0.2)
 
-    # Check that the objects are equivalent, even if they may be written differently.
-    np.testing.assert_almost_equal(gal1_im.array, sgal1_im.array, decimal=8)
-    np.testing.assert_almost_equal(gal1_im.array, rgal1_im.array, decimal=8)
+        gal2_im = gal2.drawImage(nx=64, ny=64, scale=0.2)
+        sgal2_im = sgal2.drawImage(nx=64, ny=64, scale=0.2)
+        rgal2_im = rgal2.drawImage(nx=64, ny=64, scale=0.2)
 
-    # These two used to fail.
-    np.testing.assert_almost_equal(gal2_im.array, sgal2_im.array, decimal=8)
-    np.testing.assert_almost_equal(gal2_im.array, rgal2_im.array, decimal=8)
+        # Check that the objects are equivalent, even if they may be written differently.
+        np.testing.assert_almost_equal(gal1_im.array, sgal1_im.array, decimal=8)
+        np.testing.assert_almost_equal(gal1_im.array, rgal1_im.array, decimal=8)
 
-    do_pickle(gal0)
-    do_pickle(gal1)
-    do_pickle(gal2)  # And this.
+        # These two used to fail.
+        np.testing.assert_almost_equal(gal2_im.array, sgal2_im.array, decimal=8)
+        np.testing.assert_almost_equal(gal2_im.array, rgal2_im.array, decimal=8)
+
+        do_pickle(gal0)
+        do_pickle(gal1)
+        do_pickle(gal2)  # And this.
 
 
 if __name__ == "__main__":
-    test_sum_transform()
     test_convolve()
     test_convolve_flux_scaling()
     test_shearconvolve()

--- a/tests/test_compound.py
+++ b/tests/test_compound.py
@@ -754,8 +754,57 @@ def test_fourier_sqrt():
     t2 = time.time()
     print 'time for %s = %.2f'%(funcname(),t2-t1)
 
+def test_sum_transform():
+    """This test addresses a bug found by Ismael Serrano, #763, wherein some attributes 
+    got messed up for a Transform(Sum(Transform())) object.
+
+    The bug was that we didn't bother to make a new SBProfile for a Sum (or Convolve) of
+    a single object.  But if that was an SBTransform, then the next Transform operation
+    combined the two Transforms, which messed up the repr.
+    
+    The fix is to always make an SBAdd or SBConvolve object even if the list of things to add
+    or convolve only has one element.
+    """
+    gal0 = galsim.Exponential(scale_radius=0.34, flux=105.).shear(g1=-0.56,g2=0.15)
+    gal1 = galsim.Sum(gal0)
+    gal2 = gal1.dilate(1)
+
+    sgal1 = eval(str(gal1))
+    rgal1 = eval(repr(gal1))
+    sgal2 = eval(str(gal2))
+    rgal2 = eval(repr(gal2))
+
+    print 'gal1 = ',repr(gal1)
+    print 'sgal1 = ',repr(sgal1)
+    print 'rgal1 = ',repr(rgal1)
+
+    print 'gal2 = ',repr(gal2)
+    print 'sgal2 = ',repr(sgal2)
+    print 'rgal2 = ',repr(rgal2)
+
+    gal1_im = gal1.drawImage(nx=64, ny=64, scale=0.2)
+    sgal1_im = sgal1.drawImage(nx=64, ny=64, scale=0.2)
+    rgal1_im = rgal1.drawImage(nx=64, ny=64, scale=0.2)
+
+    gal2_im = gal2.drawImage(nx=64, ny=64, scale=0.2)
+    sgal2_im = sgal2.drawImage(nx=64, ny=64, scale=0.2)
+    rgal2_im = rgal2.drawImage(nx=64, ny=64, scale=0.2)
+
+    # Check that the objects are equivalent, even if they may be written differently.
+    np.testing.assert_almost_equal(gal1_im.array, sgal1_im.array, decimal=8)
+    np.testing.assert_almost_equal(gal1_im.array, rgal1_im.array, decimal=8)
+
+    # These two used to fail.
+    np.testing.assert_almost_equal(gal2_im.array, sgal2_im.array, decimal=8)
+    np.testing.assert_almost_equal(gal2_im.array, rgal2_im.array, decimal=8)
+
+    do_pickle(gal0)
+    do_pickle(gal1)
+    do_pickle(gal2)  # And this.
+
 
 if __name__ == "__main__":
+    test_sum_transform()
     test_convolve()
     test_convolve_flux_scaling()
     test_shearconvolve()
@@ -768,3 +817,4 @@ if __name__ == "__main__":
     test_autocorrelate()
     test_ne()
     test_fourier_sqrt()
+    test_sum_transform()


### PR DESCRIPTION
@ismael2395 pointed out (cf. #763) a subtle bug where the str and repr of objects that are a Transform(Sum(Transform(obj))) were messed up.  

I tracked it back to an "optimization" we do in the Sum (and Convolution) constructors to skip much of the function if the list has only a single element.  But it turns out in this case to lead to the bug he found.

Seems like the easiest solution is to just not do that.  I'm sure this is never anything close to an actual optimization, so just let them both go through the motions of the full constructor even though some of the operations are trivial when there is only a single element.