### PR TITLE
Quantizing the background image correctly in demo13

### DIFF
--- a/examples/demo13.py
+++ b/examples/demo13.py
@@ -452,7 +452,7 @@ def main(argv):
 
         # Since many people are used to viewing background-subtracted images, we provide a
         # version with the background subtracted (also rounding that to an int).
-        tot_sky_image = (sky_image + dark_current)/wfirst.gain
+        tot_sky_image = ((sky_image.quantize() + round(dark_current))/wfirst.gain)
         tot_sky_image.quantize()
         final_image -= tot_sky_image
 

--- a/examples/demo13.py
+++ b/examples/demo13.py
@@ -452,7 +452,7 @@ def main(argv):
 
         # Since many people are used to viewing background-subtracted images, we provide a
         # version with the background subtracted (also rounding that to an int).
-        tot_sky_image = ((sky_image.quantize() + round(dark_current))/wfirst.gain)
+        tot_sky_image = (sky_image.quantize() + round(dark_current))/wfirst.gain
         tot_sky_image.quantize()
         final_image -= tot_sky_image
 


### PR DESCRIPTION
This is a 1-line PR aimed to fix a minor bug in creating a background image that is subtracted from the galaxy images. The previous background image was quantized only once where as the galaxy images are quantized as multiple stages - integer photon counts, integer electron counts and quantization in ADU. Quantizing the background image only once could slightly underestimate the true background, which could have significant impact for galaxies with low flux. 