### PR TITLE
Fix atmospheric screen size

### DIFF
--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -17,7 +17,6 @@
 #
 
 from builtins import range, zip
-from future.utils import iteritems
 
 import numpy as np
 import galsim
@@ -32,10 +31,10 @@ class AtmosphericScreen(object):
     @param screen_size   Physical extent of square phase screen in meters.  This should be large
                          enough to accommodate the desired field-of-view of the telescope as well as
                          the meta-pupil defined by the wind speed and exposure time.  Note that
-                         the screen will have periodic boundary conditions, so the code will run
-                         with a smaller sized screen, though this may introduce artifacts into PSFs
-                         or PSF correlations functions. Note that screen_size may be tweaked by the
-                         initializer to ensure screen_size is a multiple of screen_scale.
+                         the screen will have periodic boundary conditions, so while the code will
+                         still run with a small screen, this may introduce artifacts into PSFs or
+                         PSF correlations functions.  Also note that screen_size may be tweaked by
+                         the initializer to ensure `screen_size` is a multiple of `screen_scale`.
     @param screen_scale  Physical pixel scale of phase screen in meters.  An order unity multiple of
                          the Fried parameter is usually sufficiently small, but users should test
                          the effects of varying this parameter to ensure robust results.
@@ -79,7 +78,7 @@ class AtmosphericScreen(object):
             screen_scale = r0_500
         self.npix = galsim._galsim.goodFFTSize(int(np.ceil(screen_size/screen_scale)))
         self.screen_scale = screen_scale
-        self.screen_size = screen_size
+        self.screen_size = screen_scale * self.npix
         self.altitude = altitude
         self.time_step = time_step
         self.r0_500 = r0_500

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -1051,6 +1051,9 @@ def structure_function(image):
     """
     array = image.array
     nx, ny = array.shape
+    scale = image.scale
+    if scale is None:
+        scale = 1.0
 
     # The structure function can be derived from the correlation function B(r) as:
     # D(r) = 2 * [B(0) - B(r)]
@@ -1061,8 +1064,8 @@ def structure_function(image):
     assert (corr[0, 0] / np.var(array) - 1.0) < 1e-6
     corr = np.fft.ifftshift(corr)
 
-    x = image.scale * (np.arange(nx) - nx//2)
-    y = image.scale * (np.arange(ny) - ny//2)
+    x = scale * (np.arange(nx) - nx//2)
+    y = scale * (np.arange(ny) - ny//2)
     tab = galsim.LookupTable2D(x, y, corr)
     thetas = np.arange(0., 2*np.pi, 100)  # Average over these angles.
 

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -1033,3 +1033,37 @@ def set_func_doc(func, doc):
         func.__doc__ = doc
     except:
         func.__func__.__doc__ = doc
+
+
+def structure_function(image):
+    """Estimate the angularly-averaged structure function of a 2D random field.
+
+    The angularly-averaged structure function D(r) of the 2D field phi is defined as:
+
+    D(|r|) = <|phi(x) - phi(x+r)|^2>
+
+    where the x and r on the RHS are 2D vectors, but the |r| on the LHS is just a scalar length.
+
+    @param image  Image containing random field realization.  The `.scale` attribute here *is* used
+                  in the calculation.  If it's `None`, then the code will use 1.0 for the scale.
+    @returns      A python callable mapping a separation length r to the estimate of the structure
+                  function D(r).
+    """
+    array = image.array
+    nx, ny = array.shape
+
+    # The structure function can be derived from the correlation function B(r) as:
+    # D(r) = 2 * [B(0) - B(r)]
+
+    corr = np.fft.ifft2(np.abs(np.fft.fft2(np.fft.fftshift(array)))**2).real / (nx * ny)
+    # Check that the zero-lag correlation function is equal to the variance before doing the
+    # ifftshift.
+    assert (corr[0, 0] / np.var(array) - 1.0) < 1e-6
+    corr = np.fft.ifftshift(corr)
+
+    x = image.scale * (np.arange(nx) - nx//2)
+    y = image.scale * (np.arange(ny) - ny//2)
+    tab = galsim.LookupTable2D(x, y, corr)
+    thetas = np.arange(0., 2*np.pi, 100)  # Average over these angles.
+
+    return lambda r: 2*(tab(0.0, 0.0) - np.mean(tab(r*np.cos(thetas), r*np.sin(thetas))))

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -37,6 +37,7 @@ pp_file = 'sample_pupil_rolled.fits'
 
 @timer
 def test_aperture():
+    """Test various ways to construct Apertures."""
     # Simple tests for constructing and pickling Apertures.
     aper1 = galsim.Aperture(diam=1.0)
     im = galsim.fits.read(os.path.join(imgdir, pp_file))
@@ -52,8 +53,22 @@ def test_aperture():
 
 
 @timer
+def test_atm_screen_size():
+    """Test for consistent AtmosphericScreen size and scale."""
+    screen_size = 10.0
+    screen_scale = 0.1
+    atm = galsim.AtmosphericScreen(screen_size=screen_size, screen_scale=screen_scale)
+    # AtmosphericScreen will preserve screen_scale, but will adjust screen_size as necessary to get
+    # a good FFT size.
+    assert atm.screen_scale == screen_scale
+    assert atm.screen_size != screen_size
+    np.testing.assert_equal(atm.screen_size, atm.npix * atm.screen_scale,
+                            "Inconsistent atmospheric screen size and scale.")
+
+
+@timer
 def test_phase_screen_list():
-    # Check list-like behaviors of PhaseScreenList
+    """Test list-like behaviors of PhaseScreenList."""
     rng = galsim.BaseDeviate(1234)
     rng2 = galsim.BaseDeviate(123)
 
@@ -175,7 +190,7 @@ def test_phase_screen_list():
 
 @timer
 def test_frozen_flow():
-    # Check frozen flow: phase(x=0, t=0) == phase(x=v*t, t=t)
+    """Test that frozen flow screen really is frozen, i.e., phase(x=0, t=0) == phase(x=v*t, t=t)."""
     rng = galsim.BaseDeviate(1234)
     vx = 1.0  # m/s
     dt = 0.01  # s
@@ -198,6 +213,7 @@ def test_frozen_flow():
 
 @timer
 def test_phase_psf_reset():
+    """Test that phase screen reset() method correctly resets the screen to t=0."""
     rng = galsim.BaseDeviate(1234)
     # Test frozen AtmosphericScreen first
     atm = galsim.Atmosphere(screen_size=30.0, altitude=10.0, speed=0.1, alpha=1.0, rng=rng)
@@ -213,7 +229,7 @@ def test_phase_psf_reset():
     wf3 = atm.wavefront(aper)
     np.testing.assert_array_equal(wf1, wf3, "Phase screen didn't reset")
 
-    # Now check with boilin, but no wind.
+    # Now check with boiling, but no wind.
     atm = galsim.Atmosphere(screen_size=30.0, altitude=10.0, alpha=0.997, rng=rng)
     wf1 = atm.wavefront(aper)
     atm.advance()
@@ -229,7 +245,7 @@ def test_phase_psf_reset():
 
 @timer
 def test_phase_psf_batch():
-    # Check that PSFs generated serially match those generated in batch.
+    """Test that PSFs generated serially match those generated in batch."""
     import time
     NPSFs = 10
     exptime = 0.06
@@ -258,6 +274,7 @@ def test_phase_psf_batch():
 
 @timer
 def test_opt_indiv_aberrations():
+    """Test that aberrations specified by name match those specified in `aberrations` list."""
     screen1 = galsim.OpticalScreen(tip=0.2, tilt=0.3, defocus=0.4, astig1=0.5, astig2=0.6,
                                    coma1=0.7, coma2=0.8, trefoil1=0.9, trefoil2=1.0, spher=1.1)
     screen2 = galsim.OpticalScreen(aberrations=[0.0, 0.0, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9,
@@ -273,6 +290,7 @@ def test_opt_indiv_aberrations():
 
 @timer
 def test_scale_unit():
+    """Test that `scale_unit` keyword correctly sets the units for PhaseScreenPSF."""
     aper = galsim.Aperture(diam=1.0)
     rng = galsim.BaseDeviate(1234)
     # Test frozen AtmosphericScreen first
@@ -289,6 +307,7 @@ def test_scale_unit():
 
 @timer
 def test_ne():
+    """Test Apertures, PhaseScreens, PhaseScreenLists, and PhaseScreenPSFs for not-equals."""
     import copy
     pupil_plane_im = galsim.fits.read(os.path.join(imgdir, pp_file))
 
@@ -367,6 +386,7 @@ def test_ne():
 
 if __name__ == "__main__":
     test_aperture()
+    test_atm_screen_size()
     test_phase_screen_list()
     test_frozen_flow()
     test_phase_psf_reset()

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -61,7 +61,7 @@ def test_atm_screen_size():
     # AtmosphericScreen will preserve screen_scale, but will adjust screen_size as necessary to get
     # a good FFT size.
     assert atm.screen_scale == screen_scale
-    assert atm.screen_size != screen_size
+    assert screen_size < atm.screen_size < 1.5*screen_size
     np.testing.assert_equal(atm.screen_size, atm.npix * atm.screen_scale,
                             "Inconsistent atmospheric screen size and scale.")
 

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -87,10 +87,17 @@ def test_structure_function():
     im = galsim.Image(phase, scale=screen_scale)
     D_sim = galsim.utilities.structure_function(im)
 
+    print("r   D_kolm   D_sim")
     for r in [0.5, 2.0, 5.0]:  # Only check values far from the screen size and scale.
         # We're only attempting to verify that we haven't missed a factor of 2 or pi or
         # something like that here, so set the rtol below to be *very* forgiving.  Since the
         # structure function varies quite quickly as r**(5./3), this is still a useful test.
+        # For the parameters above (including the random seed), D_kolm(r) and D_sim(r) are actually
+        # consistent at about the 15% level in the test below.  It's difficult to predict how
+        # consistent they *should* be though, since the simulated structure function estimate is
+        # sensitive to resolution and edge effects, as well as the particular realization of the
+        # field.
+        print(r, D_kolm(r), D_sim(r))
         np.testing.assert_allclose(D_kolm(r), D_sim(r), rtol=0.5,
                                    err_msg="Simulated structure function not close to prediction.")
 


### PR DESCRIPTION
I finally got around to comparing the simulated phase screen structure function out of AtmosphericScreen to an analytic prediction (as recommended by George Angeli and Bo Xin some weeks ago).  This turned up a small but important bug in the AtmosphericScreen constructor, where the screen size was tweaked to yield a good FFT size, but this wasn't properly reflected in the `.screen_size` attribute.  So I fixed that and added a couple of unit tests.

Also, here's the theory vs. simulated structure functions (D(r) = <|phi(x) - phi(x+r)|^2>) now:

![unknown](https://cloud.githubusercontent.com/assets/3650485/16512455/55775056-3f10-11e6-8385-a658aefd7bd2.png)

Pretty decent agreement I think at scales far from the screen sampling interval (0.05 m) and screen size (100.0 m).