### PR TITLE
#772

### DIFF
--- a/examples/demo13.py
+++ b/examples/demo13.py
@@ -456,7 +456,8 @@ def main(argv):
 
         # Since many people are used to viewing background-subtracted images, we provide a
         # version with the background subtracted (also rounding that to an int).
-        tot_sky_image = (sky_image.quantize() + round(dark_current))/wfirst.gain
+        sky_image.quantize()
+        tot_sky_image = (sky_image + round(dark_current))/wfirst.gain
         tot_sky_image.quantize()
         final_image -= tot_sky_image
 

--- a/examples/demo13.py
+++ b/examples/demo13.py
@@ -74,6 +74,10 @@ def main(argv):
     datapath = os.path.abspath(os.path.join(path, "data/"))
     outpath = os.path.abspath(os.path.join(path, "output/"))
 
+    # Make output directory if not already present.
+    if not os.path.isdir(outpath):
+        os.mkdir(outpath)
+
     # In non-script code, use getLogger(__name__) at module scope instead.
     logging.basicConfig(format="%(message)s", level=logging.INFO, stream=sys.stdout)
     logger = logging.getLogger("demo13")

--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -2260,8 +2260,10 @@ class ChromaticOpticalPSF(ChromaticObject):
             raise TypeError("Need to specify telescope diameter OR wavelength/diam ratio")
         if diam is not None:
             self.lam_over_diam = (1.e-9*lam/diam)*galsim.radians/self.scale_unit
+            self.diam = diam
         else:
             self.lam_over_diam = lam_over_diam
+            self.diam = (lam*1e-9/lam_over_diam)*galsim.radians/self.scale_unit
         self.lam = lam
 
         if aberrations is not None:
@@ -2318,9 +2320,9 @@ class ChromaticOpticalPSF(ChromaticObject):
         # wavelength.  Likewise, the aberrations were in units of wavelength for the fiducial
         # wavelength, so we have to convert to units of waves for *this* wavelength.
         ret = galsim.OpticalPSF(
-            lam_over_diam=self.lam_over_diam*(wave/self.lam),
-            aberrations=self.aberrations*(self.lam/wave), scale_unit=self.scale_unit,
-            **self.kwargs)
+                lam=wave, diam=self.diam,
+                aberrations=self.aberrations*(self.lam/wave), scale_unit=self.scale_unit,
+                **self.kwargs)
         return ret
 
 class ChromaticAiry(ChromaticObject):

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -304,7 +304,7 @@ class Aperture(object):
         self.npix = galsim._galsim.goodFFTSize(int(np.ceil(ratio)))
         self.pupil_plane_size = pupil_plane_size
         # Shrink scale such that size = scale * npix exactly.
-        self.pupil_plane_scale = pupil_plane_size // self.npix
+        self.pupil_plane_scale = pupil_plane_size / self.npix
         # Save params for str/repr
         self._circular_pupil = circular_pupil
         self._obscuration = obscuration

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -1289,6 +1289,17 @@ class OpticalPSF(GSObject):
     @param pupil_angle      If `pupil_plane_im` is not None, rotation angle for the pupil plane
                             (positive in the counter-clockwise direction).  Must be an Angle
                             instance. [default: 0. * galsim.degrees]
+    @param pupil_plane_scale Sampling interval in meters to use for the pupil plane array.  In
+                            most cases, it's a good idea to leave this as None, in which case
+                            GalSim will attempt to find a good value automatically.  The
+                            exception is when specifying the pupil arrangement via an image, in
+                            which case this keyword can be used to indicate the sampling of that
+                            image.  See also `pad_factor` for adjusting the pupil sampling scale.
+                            [default: None]
+    @param pupil_plane_size Size in meters to use for the pupil plane array.  In most cases, it's
+                            a good idea to leave this as None, in which case GalSim will attempt
+                            to find a good value automatically.  See also `oversampling` for
+                            adjusting the pupil size.  [default: None]
     @param scale_unit       Units to use for the sky coordinates when calculating lam/diam if these
                             are supplied separately.  Should be either a galsim.AngleUnit or a
                             string that can be used to construct one (e.g., 'arcsec', 'radians',
@@ -1325,6 +1336,8 @@ class OpticalPSF(GSObject):
         "strut_angle": galsim.Angle,
         "pupil_plane_im": str,
         "pupil_angle": galsim.Angle,
+        "pupil_plane_scale": float,
+        "pupil_plane_size": float,
         "scale_unit": str}
     _single_params = [{"lam_over_diam": float, "lam": float}]
     _takes_rng = False
@@ -1334,6 +1347,7 @@ class OpticalPSF(GSObject):
                  aberrations=None, aper=None, circular_pupil=True, obscuration=0., interpolant=None,
                  oversampling=1.5, pad_factor=1.5, flux=1., nstruts=0, strut_thick=0.05,
                  strut_angle=0.*galsim.degrees, pupil_plane_im=None,
+                 pupil_plane_scale=None, pupil_plane_size=None,
                  pupil_angle=0.*galsim.degrees, scale_unit=galsim.arcsec, gsparams=None,
                  suppress_warning=False, max_size=None):
         if max_size is not None:
@@ -1370,6 +1384,7 @@ class OpticalPSF(GSObject):
                     nstruts=nstruts, strut_thick=strut_thick, strut_angle=strut_angle,
                     oversampling=oversampling, pad_factor=pad_factor,
                     pupil_plane_im=pupil_plane_im, pupil_angle=pupil_angle,
+                    pupil_plane_scale=pupil_plane_scale, pupil_plane_size=pupil_plane_size,
                     gsparams=gsparams)
 
         # Save for pickling

--- a/galsim/wfirst/__init__.py
+++ b/galsim/wfirst/__init__.py
@@ -93,6 +93,8 @@ Currently, the module includes the following numbers:
                        routine, users will not need to supply this filename, since the routine
                        already knows about it.
 
+    pupil_plane_scale - The pixel scale in meters per pixel for the image in pupil_plane_file.
+
     stray_light_fraction - The fraction of the sky background that is allowed to contribute as stray
                            light.  Currently this is required to be <10% of the background due to
                            zodiacal light, so its value is set to 0.1 (assuming a worst-case).  This
@@ -213,9 +215,15 @@ thermal_backgrounds = {'J129': 0.06,
                        'Z087': 0.06,
                        'H158': 0.08,
                        'W149': 0.06}
+
 pupil_plane_file = os.path.join(galsim.meta_data.share_dir,
                                 "WFIRST-AFTA_Pupil_Mask_C5_20141010_PLT.fits.gz")
+# The pupil plane image has non-zero values with a diameter of 1696 pixels.  The WFirst mirror
+# is 2.4 meters.  So the scale is 2.4 / 1696 = 0.00141509 meters/pixel.
+pupil_plane_scale = 2.4 / 1696.
+
 stray_light_fraction = 0.1
+
 # IPC kernel is unnormalized at first.  We will normalize it.
 ipc_kernel = numpy.array([ [0.001269938, 0.015399776, 0.001199862], \
                            [0.013800177, 1.0, 0.015600367], \

--- a/galsim/wfirst/wfirst_psfs.py
+++ b/galsim/wfirst/wfirst_psfs.py
@@ -162,12 +162,14 @@ def getPSF(SCAs=None, approximate_struts=False, n_waves=None, extra_aberrations=
             new_bounds = old_bounds.withBorder((old_bounds.xmax+1-old_bounds.xmin)/2)
             pupil_plane_im = galsim.Image(bounds=new_bounds)
             pupil_plane_im[old_bounds] = tmp_pupil_plane_im
+            pupil_plane_scale = galsim.wfirst.pupil_plane_scale
     else:
         if approximate_struts:
             oversampling = 1.5
         else:
             oversampling = 1.2
             pupil_plane_im = galsim.wfirst.pupil_plane_file
+            pupil_plane_scale = galsim.wfirst.pupil_plane_scale
 
     if wavelength is None:
         if n_waves is not None:
@@ -224,6 +226,7 @@ def getPSF(SCAs=None, approximate_struts=False, n_waves=None, extra_aberrations=
                     diam=galsim.wfirst.diameter, aberrations=use_aberrations,
                     obscuration=galsim.wfirst.obscuration,
                     pupil_plane_im=pupil_plane_im,
+                    pupil_plane_scale=pupil_plane_scale,
                     oversampling=oversampling, pad_factor=2.)
             if n_waves is not None:
                 PSF = PSF.interpolate(waves=np.linspace(blue_limit, red_limit, n_waves),
@@ -240,6 +243,7 @@ def getPSF(SCAs=None, approximate_struts=False, n_waves=None, extra_aberrations=
                                         aberrations=tmp_aberrations,
                                         obscuration=galsim.wfirst.obscuration,
                                         pupil_plane_im=pupil_plane_im,
+                                        pupil_plane_scale=pupil_plane_scale,
                                         oversampling=oversampling, pad_factor=2.)
 
         PSF_dict[SCA]=PSF

--- a/galsim/wfirst/wfirst_psfs.py
+++ b/galsim/wfirst/wfirst_psfs.py
@@ -35,7 +35,8 @@ zemax_filesuff = '.txt'
 zemax_wavelength = 1293. #nm
 
 def getPSF(SCAs=None, approximate_struts=False, n_waves=None, extra_aberrations=None,
-           wavelength_limits=None, logger=None, wavelength=None, high_accuracy=False):
+           wavelength_limits=None, logger=None, wavelength=None, high_accuracy=False,
+           gsparams=None):
     """
     Get the PSF for WFIRST observations.
 
@@ -143,6 +144,8 @@ def getPSF(SCAs=None, approximate_struts=False, n_waves=None, extra_aberrations=
                                    details).  This setting is more expensive in terms of time and
                                    RAM, and may not be necessary for many applications.
                                    [default: False]
+    @param gsparams                An optional GSParams argument.  See the docstring for GSParams
+                                   for details. [default: None]
     @returns  A dict of ChromaticOpticalPSF or OpticalPSF objects for each SCA.
     """
     # Check which SCAs are to be done using a helper routine in this module.
@@ -219,7 +222,7 @@ def getPSF(SCAs=None, approximate_struts=False, n_waves=None, extra_aberrations=
                     lam=zemax_wavelength,
                     diam=galsim.wfirst.diameter, aberrations=use_aberrations,
                     obscuration=galsim.wfirst.obscuration, nstruts=6,
-                    oversampling=oversampling)
+                    oversampling=oversampling, gsparams=gsparams)
             else:
                 PSF = galsim.ChromaticOpticalPSF(
                     lam=zemax_wavelength,
@@ -227,7 +230,7 @@ def getPSF(SCAs=None, approximate_struts=False, n_waves=None, extra_aberrations=
                     obscuration=galsim.wfirst.obscuration,
                     pupil_plane_im=pupil_plane_im,
                     pupil_plane_scale=pupil_plane_scale,
-                    oversampling=oversampling, pad_factor=2.)
+                    oversampling=oversampling, pad_factor=2., gsparams=gsparams)
             if n_waves is not None:
                 PSF = PSF.interpolate(waves=np.linspace(blue_limit, red_limit, n_waves),
                                       oversample_fac=1.5)
@@ -237,14 +240,14 @@ def getPSF(SCAs=None, approximate_struts=False, n_waves=None, extra_aberrations=
                 PSF = galsim.OpticalPSF(lam=wavelength_nm, diam=galsim.wfirst.diameter,
                                         aberrations=tmp_aberrations,
                                         obscuration=galsim.wfirst.obscuration, nstruts=6,
-                                        oversampling=oversampling)
+                                        oversampling=oversampling, gsparams=gsparams)
             else:
                 PSF = galsim.OpticalPSF(lam=wavelength_nm, diam=galsim.wfirst.diameter,
                                         aberrations=tmp_aberrations,
                                         obscuration=galsim.wfirst.obscuration,
                                         pupil_plane_im=pupil_plane_im,
                                         pupil_plane_scale=pupil_plane_scale,
-                                        oversampling=oversampling, pad_factor=2.)
+                                        oversampling=oversampling, pad_factor=2., gsparams=gsparams)
 
         PSF_dict[SCA]=PSF
 
@@ -443,4 +446,3 @@ def _find_limits(bandpasses, bandpass_dict):
         if bp.blue_limit < min_wave: min_wave = bp.blue_limit
         if bp.red_limit > max_wave: max_wave = bp.red_limit
     return min_wave, max_wave
-

--- a/tests/test_config_gsobject.py
+++ b/tests/test_config_gsobject.py
@@ -278,12 +278,11 @@ def test_opticalpsf():
                    'magnify' : 1.03, 'shear' : galsim.Shear(g1=0.03, g2=-0.05),
                    'shift' : { 'type' : 'XY', 'x' : 0.7, 'y' : -1.2 }
                  },
-        # This test no longer applicable.  See #772.
-        # 'gal5' : { 'type': 'OpticalPSF' , 'lam_over_diam' : 0.12, 'flux' : 1.8,
-        #            'defocus' : 0.1, 'obscuration' : 0.18,
-        #            'pupil_plane_im' : \
-        #                os.path.join(".","Optics_comparison_images","sample_pupil_rolled.fits"),
-        #            'pupil_angle' : 27.*galsim.degrees },
+        'gal5' : { 'type': 'OpticalPSF' , 'lam' : 900, 'diam' : 2.4, 'flux' : 1.8,
+                   'defocus' : 0.1, 'obscuration' : 0.18,
+                   'pupil_plane_im' :
+                       os.path.join(".","Optics_comparison_images","sample_pupil_rolled.fits"),
+                   'pupil_angle' : 27.*galsim.degrees },
         'gal6' : {'type' : 'OpticalPSF' , 'lam' : 874.0, 'diam' : 7.4, 'flux' : 70.,
                   'obscuration' : 0.1 }
     }
@@ -315,13 +314,12 @@ def test_opticalpsf():
     gal4b = gal4b.shear(g1 = 0.03, g2 = -0.05).shift(dx = 0.7, dy = -1.2)
     gsobject_compare(gal4a, gal4b)
 
-    # This test no longer applicable.  See #772.
-    # gal5a = galsim.config.BuildGSObject(config, 'gal5')[0]
-    # gal5b = galsim.OpticalPSF(
-    #     lam_over_diam=0.12, flux=1.8, defocus=0.1, obscuration=0.18,
-    #     pupil_plane_im=os.path.join(".","Optics_comparison_images","sample_pupil_rolled.fits"),
-    #     pupil_angle=27.*galsim.degrees)
-    # gsobject_compare(gal5a, gal5b)
+    gal5a = galsim.config.BuildGSObject(config, 'gal5')[0]
+    gal5b = galsim.OpticalPSF(
+        lam=900, diam=2.4, flux=1.8, defocus=0.1, obscuration=0.18,
+        pupil_plane_im=os.path.join(".","Optics_comparison_images","sample_pupil_rolled.fits"),
+        pupil_angle=27.*galsim.degrees)
+    gsobject_compare(gal5a, gal5b)
 
     gal6a = galsim.config.BuildGSObject(config, 'gal6')[0]
     gal6b = galsim.OpticalPSF(lam=874., diam=7.4, flux=70., obscuration=0.1)

--- a/tests/test_config_gsobject.py
+++ b/tests/test_config_gsobject.py
@@ -278,11 +278,12 @@ def test_opticalpsf():
                    'magnify' : 1.03, 'shear' : galsim.Shear(g1=0.03, g2=-0.05),
                    'shift' : { 'type' : 'XY', 'x' : 0.7, 'y' : -1.2 }
                  },
-        'gal5' : { 'type': 'OpticalPSF' , 'lam_over_diam' : 0.12, 'flux' : 1.8,
-                   'defocus' : 0.1, 'obscuration' : 0.18,
-                   'pupil_plane_im' : \
-                       os.path.join(".","Optics_comparison_images","sample_pupil_rolled.fits"),
-                   'pupil_angle' : 27.*galsim.degrees },
+        # This test no longer applicable.  See #772.
+        # 'gal5' : { 'type': 'OpticalPSF' , 'lam_over_diam' : 0.12, 'flux' : 1.8,
+        #            'defocus' : 0.1, 'obscuration' : 0.18,
+        #            'pupil_plane_im' : \
+        #                os.path.join(".","Optics_comparison_images","sample_pupil_rolled.fits"),
+        #            'pupil_angle' : 27.*galsim.degrees },
         'gal6' : {'type' : 'OpticalPSF' , 'lam' : 874.0, 'diam' : 7.4, 'flux' : 70.,
                   'obscuration' : 0.1 }
     }
@@ -314,12 +315,13 @@ def test_opticalpsf():
     gal4b = gal4b.shear(g1 = 0.03, g2 = -0.05).shift(dx = 0.7, dy = -1.2)
     gsobject_compare(gal4a, gal4b)
 
-    gal5a = galsim.config.BuildGSObject(config, 'gal5')[0]
-    gal5b = galsim.OpticalPSF(
-        lam_over_diam=0.12, flux=1.8, defocus=0.1, obscuration=0.18,
-        pupil_plane_im=os.path.join(".","Optics_comparison_images","sample_pupil_rolled.fits"),
-        pupil_angle=27.*galsim.degrees)
-    gsobject_compare(gal5a, gal5b)
+    # This test no longer applicable.  See #772.
+    # gal5a = galsim.config.BuildGSObject(config, 'gal5')[0]
+    # gal5b = galsim.OpticalPSF(
+    #     lam_over_diam=0.12, flux=1.8, defocus=0.1, obscuration=0.18,
+    #     pupil_plane_im=os.path.join(".","Optics_comparison_images","sample_pupil_rolled.fits"),
+    #     pupil_angle=27.*galsim.degrees)
+    # gsobject_compare(gal5a, gal5b)
 
     gal6a = galsim.config.BuildGSObject(config, 'gal6')[0]
     gal6b = galsim.OpticalPSF(lam=874., diam=7.4, flux=70., obscuration=0.1)

--- a/tests/test_wfirst.py
+++ b/tests/test_wfirst.py
@@ -491,8 +491,11 @@ def test_wfirst_psfs():
             { 'approximate_struts':True, 'high_accuracy':False },  # This is a repeat of the above
             { 'approximate_struts':True, 'high_accuracy':True },   # These three are all new.
             { 'approximate_struts':False, 'high_accuracy':False },
-            { 'approximate_struts':False, 'high_accuracy':True,
-              'gsparams':galsim.GSParams(maximum_fft_size=8192) } ]:
+            # This last test works, but it takes ~10 min to run.  So even in the slow tests,
+            # this is a bit too extreme.
+            #{ 'approximate_struts':False, 'high_accuracy':True,
+            #  'gsparams':galsim.GSParams(maximum_fft_size=8192) }
+            ]:
 
             psf = galsim.wfirst.getPSF(SCAs=use_sca, **kwargs)[use_sca]
             psf_achrom = galsim.wfirst.getPSF(SCAs=use_sca, wavelength=use_lam, **kwargs)[use_sca]

--- a/tests/test_wfirst.py
+++ b/tests/test_wfirst.py
@@ -438,7 +438,7 @@ def test_wfirst_psfs():
     # in 2 pixels!).
     diff_im = 0.5*(im_int.array-im_achrom.array)
     np.testing.assert_array_almost_equal(
-        diff_im, np.zeros_like(diff_im), decimal=3, 
+        diff_im, np.zeros_like(diff_im), decimal=3,
         err_msg='PSF at a given wavelength and interpolated chromatic one evaluated at that '
         'wavelength disagree.')
 
@@ -491,7 +491,8 @@ def test_wfirst_psfs():
             { 'approximate_struts':True, 'high_accuracy':False },  # This is a repeat of the above
             { 'approximate_struts':True, 'high_accuracy':True },   # These three are all new.
             { 'approximate_struts':False, 'high_accuracy':False },
-            { 'approximate_struts':False, 'high_accuracy':True } ]:
+            { 'approximate_struts':False, 'high_accuracy':True,
+              'gsparams':galsim.GSParams(maximum_fft_size=8192) } ]:
 
             psf = galsim.wfirst.getPSF(SCAs=use_sca, **kwargs)[use_sca]
             psf_achrom = galsim.wfirst.getPSF(SCAs=use_sca, wavelength=use_lam, **kwargs)[use_sca]

--- a/tests/test_wfirst.py
+++ b/tests/test_wfirst.py
@@ -484,6 +484,29 @@ def test_wfirst_psfs():
         # Delete test files when done.
         os.remove(test_file)
 
+    # Test the construction of PSFs with high_accuracy and/or not approximate_struts
+    # But only if we're runnign from the command line.
+    if __name__ == '__main__':
+        for kwargs in [
+            { 'approximate_struts':True, 'high_accuracy':False },  # This is a repeat of the above
+            { 'approximate_struts':True, 'high_accuracy':True },   # These three are all new.
+            { 'approximate_struts':False, 'high_accuracy':False },
+            { 'approximate_struts':False, 'high_accuracy':True } ]:
+
+            psf = galsim.wfirst.getPSF(SCAs=use_sca, **kwargs)[use_sca]
+            psf_achrom = galsim.wfirst.getPSF(SCAs=use_sca, wavelength=use_lam, **kwargs)[use_sca]
+            psf_chrom = psf.evaluateAtWavelength(use_lam)
+            im_achrom = psf_achrom.drawImage(scale=galsim.wfirst.pixel_scale)
+            im_chrom = psf_chrom.drawImage(image=im_achrom.copy())
+            im_achrom.write('im_achrom.fits')
+            im_chrom.write('im_chrom.fits')
+            print("chrom, achrom fluxes = ", im_chrom.array.sum(), im_achrom.array.sum())
+            im_chrom *= im_achrom.array.sum()/im_chrom.array.sum()
+            print("max diff = ",np.max(np.abs(im_chrom.array - im_achrom.array)))
+            np.testing.assert_array_almost_equal(
+                im_chrom.array, im_achrom.array, decimal=8,
+                err_msg='getPSF with %s has discrepency for chrom/achrom'%kwargs)
+
     # Check for exceptions if we:
     # (1) Include optional aberrations in an unacceptable form.
     # (2) Invalid SCA numbers.


### PR DESCRIPTION
This PR fixes an issue @arunkannawadi noted regarding the generation of WFIRST PSFs under the new optics framework.  The new framework uses the `.scale` attribute of `galsim.Image`s used to create a pupil plane to set the scale of the pupil plane in meters.  The old framework simply ignored this keyword.  During the course of fixing this, @rmjarvis realized that the combination of `pupil_plane_im` and `lam_over_diam` was annoying (and imprecise) to get right, so we're disallowing it now unless someone raises an issue.  Probably most of the time when someone has a `pupil_plane_im` with definite scale, they also know the telescope diameter, and can therefore just use the `lam` and `diam` kwargs separately, which is still allowed.