### PR TITLE
#790 Update name of boost python 3 library in SCons for Ubuntu

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1543,21 +1543,23 @@ BOOST_PYTHON_MODULE(check_bp) {
     if not result:
         ErrorExit('Unable to compile a file with #include "boost/python.hpp"')
 
+    py_version = config.env['PYTHON_VERSION']
+    # For ubuntu Python 3.  cf. #790.
+    # Also https://bugs.launchpad.net/ubuntu/+source/boost1.53/+bug/1231609
+    pyxx = 'boost_python-py%s%s'%tuple(py_version.split('.'))
+
     if config.env['PYTHON_VERSION'] >= '3.0':
         result = (
             CheckModuleLibs(config,[''],bp_source_file,'check_bp') or
             CheckModuleLibs(config,['boost_python3'],bp_source_file,'check_bp') or
             CheckModuleLibs(config,['boost_python3-mt'],bp_source_file,'check_bp') or
-            # For ubuntu Python 3.  cf. #790.
-            # Also https://bugs.launchpad.net/ubuntu/+source/boost1.53/+bug/1231609
-            CheckModuleLibs(config,['boost_python-py35'],bp_source_file,'check_bp') or
-            CheckModuleLibs(config,['boost_python-py34'],bp_source_file,'check_bp') )
+            CheckModuleLibs(config,[pyxx],bp_source_file,'check_bp') )
     else:
         result = (
             CheckModuleLibs(config,[''],bp_source_file,'check_bp') or
             CheckModuleLibs(config,['boost_python'],bp_source_file,'check_bp') or
             CheckModuleLibs(config,['boost_python-mt'],bp_source_file,'check_bp') or
-            CheckModuleLibs(config,['boost_python-py27'],bp_source_file,'check_bp') )
+            CheckModuleLibs(config,[pyxx],bp_source_file,'check_bp') )
     if not result:
         ErrorExit('Unable to build a python loadable module with Boost.Python')
 

--- a/SConstruct
+++ b/SConstruct
@@ -1547,12 +1547,17 @@ BOOST_PYTHON_MODULE(check_bp) {
         result = (
             CheckModuleLibs(config,[''],bp_source_file,'check_bp') or
             CheckModuleLibs(config,['boost_python3'],bp_source_file,'check_bp') or
-            CheckModuleLibs(config,['boost_python3-mt'],bp_source_file,'check_bp') )
+            CheckModuleLibs(config,['boost_python3-mt'],bp_source_file,'check_bp') or
+            # For ubuntu Python 3.  cf. #790.
+            # Also https://bugs.launchpad.net/ubuntu/+source/boost1.53/+bug/1231609
+            CheckModuleLibs(config,['boost_python-py35'],bp_source_file,'check_bp') or
+            CheckModuleLibs(config,['boost_python-py34'],bp_source_file,'check_bp') )
     else:
         result = (
             CheckModuleLibs(config,[''],bp_source_file,'check_bp') or
             CheckModuleLibs(config,['boost_python'],bp_source_file,'check_bp') or
-            CheckModuleLibs(config,['boost_python-mt'],bp_source_file,'check_bp') )
+            CheckModuleLibs(config,['boost_python-mt'],bp_source_file,'check_bp') or
+            CheckModuleLibs(config,['boost_python-py27'],bp_source_file,'check_bp') )
     if not result:
         ErrorExit('Unable to build a python loadable module with Boost.Python')
 


### PR DESCRIPTION
@esheldon reported in #790 that boost on Ubuntu uses a non-standard name for its Python 3 boost-python library.  This update just adds that name to the search list for when SCons is trying to figure out what the right linking command will be.

Probably there's not much to review here other than for Erin to confirm that it works on his Ubuntu system (which he already did, but then I changed things slightly, so... again please?) and for other people to make sure it doesn't break anything on their systems.