### PR TITLE
#580 Add coveralls support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
     - export PYTHONPATH=$HOME/lib/python$TRAVIS_PYTHON_VERSION/site-packages/:$PYTHONPATH
 
     # Get the des data needed for the check_des test.
-    - if ! test -d $HOME/des_data || ! test -f $HOME/des_data/DECam_00154912_01.fits.fz; then wget http://www.sas.upenn.edu/~mjarvis/des_data.tar.gz && tar xfz des_data.tar.gz -C $HOME DECam_00154912_01*; fi
+    - if ! test -d $HOME/des_data || ! test -f $HOME/des_data/DECam_00154912_01.fits.fz; then wget http://www.sas.upenn.edu/~mjarvis/des_data.tar.gz && tar xfz des_data.tar.gz -C $HOME des_data/DECam_00154912_01*; fi
     - ln -s $HOME/des_data examples/des/
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,18 @@ before_install:
     - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
     - sudo apt-get -qq update
     - sudo apt-get install -y libboost-all-dev gfortran liblapack-dev libfftw3-dev python-dev python-numpy python-scipy python-nose
+
+    # To get coverage of the WCSToolsWCS class:
+    - sudo apt-get install -y wcstools
+
+    # Only get TMV if not cached
     - pushd $HOME
-    #Only get TMV if not cached
     - if ! test -d tmv-0.73 || ! test -f tmv-0.73/Sconstruct; then wget https://github.com/rmjarvis/tmv/archive/v0.73.tar.gz && tar -xf v0.73.tar.gz ; else echo Using cached TMV; fi
-    #But always install it to /usr/local
+    # But always install it to /usr/local
     - cd tmv-0.73 && sudo scons install DEBUG=True FLAGS="-O0"
     - popd
+
+    # Add ~/bin and ~/lib to the appropriate paths where scons install will put things.
     - export PATH=$HOME/bin:$PATH
     - export LD_LIBRARY_PATH=$HOME/lib:$LD_LIBRARY_PATH
 
@@ -27,7 +33,7 @@ cache:
     - $HOME/tmv-0.73
 
 install:
-    - pip install astropy==1.1.1 pyyaml future coveralls
+    - pip install astropy==1.1.1 pyyaml future coveralls starlink-pyast
     - scons PREFIX=$HOME
     - scons install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,10 @@ script:
     - "nosetests run_examples.py --with-coverage --cover-package=galsim --with-doctest"
 
 after_success:
+    # The multiprocessing stages don't get properly incorporated into the .coverage file unless
+    # we do this command.
+    - coverage combine
+
     # If we start doing multiple python versions here, then only report coveralls for one of them.
     # Otherwise the reported results get weird.
     - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,13 @@ before_install:
     - sudo apt-get -qq update
     - sudo apt-get install -y libboost-all-dev gfortran liblapack-dev libfftw3-dev python-dev python-numpy python-scipy python-nose
 
+    # List current contents of directories that should be being cached.
+    - ls -l $HOME
+    - ls -l $HOME/tmv-0.73
+    - ls -l $HOME/des_data
+    - ls -l $HOME/share
+    - ls -l $HOME/share/galsim
+
     # To get coverage of the WcsToolsWCS class:
     #- sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) universe"
     #- sudo apt-get -qq update
@@ -63,6 +70,14 @@ script:
     - "nosetests test*.py --with-coverage --cover-package=galsim --with-doctest --cover-erase"
     # Without cover-erase, this will append to the .coverage file
     - "nosetests run_examples.py --with-coverage --cover-package=galsim --with-doctest"
+
+    # Again list current contents of directories that should be being cached.
+    - ls -l $HOME
+    - ls -l $HOME/tmv-0.73
+    - ls -l $HOME/des_data
+    - ls -l $HOME/share
+    - ls -l $HOME/share/galsim
+
 
 after_success:
     # The multiprocessing stages don't get properly incorporated into the .coverage file unless

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ before_install:
     - sudo apt-get install -y libboost-all-dev gfortran liblapack-dev libfftw3-dev python-dev python-numpy python-scipy python-nose
 
     # To get coverage of the WCSToolsWCS class:
-    - sudo add-apt-repository universe
+    - sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) universe"
+    - sudo apt-get -qq update
     - sudo apt-get install -y wcstools
 
     # Only get TMV if not cached

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,13 +37,15 @@ before_install:
     - export LD_LIBRARY_PATH=$HOME/lib:$LD_LIBRARY_PATH
 
     # Get the des data needed for the check_des test.
-    - if ! test -d examples/des/des_data || ! test -f examples/des/des_data/DECam_00154912_01.fits.fz; then wget http://www.sas.upenn.edu/~mjarvis/des_data.tar.gz && tar xfz des_data.tar.gz -C examples/des; fi
+    - if ! test -d examples/des/des_data || ! test -f examples/des/des_data/DECam_00154912_01.fits.fz; then wget http://www.sas.upenn.edu/~mjarvis/des_data.tar.gz && tar xfz des_data.tar.gz -C $HOME; fi
+    - ln -s $HOME/des_data examples/des/
 
 cache:
     pip: true
     directories:
     - $HOME/tmv-0.73
-    - examples/des/des_data
+    - $HOME/des_data
+    - $HOME/share/galsim
 
 install:
     # Note: matplotlib is only required because starlink has an `import matplotlib` in their
@@ -51,6 +53,8 @@ install:
     - pip install astropy==1.1.1 pyyaml future coveralls starlink-pyast matplotlib scipy
     - scons PREFIX=$HOME
     - scons install
+    # Download COSMOS catalog if not downloaded yet.
+    - galsim_download_cosmos
 
 script:
     - cd tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,6 @@ install:
 
 script:
     - cd tests
-    - "nosetests -vs test_wcs.py"
     # Use this rather than scons tests, so we can get the coverage options.
     - "nosetests test*.py --with-coverage --cover-package=galsim --with-doctest --cover-erase"
     # Without cover-erase, this will append to the .coverage file

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ install:
     - scons PREFIX=$HOME
     - scons install
     # Download COSMOS catalog if not downloaded yet.
-    - galsim_download_cosmos
+    - galsim_download_cosmos -q -v1
 
 script:
     - cd tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
     - sudo apt-get install -y libboost-all-dev gfortran liblapack-dev libfftw3-dev python-dev python-numpy python-scipy python-nose
 
     # To get coverage of the WCSToolsWCS class:
+    - sudo add-apt-repository universe
     - sudo apt-get install -y wcstools
 
     # Only get TMV if not cached

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,9 @@ cache:
     - $HOME/tmv-0.73
 
 install:
-    - pip install astropy==1.1.1 pyyaml future coveralls starlink-pyast
+    # Note: matplotlib is only required because starlink has an `import matplotlib` in their
+    # code, despite that not being a dependency.
+    - pip install astropy==1.1.1 pyyaml future coveralls starlink-pyast matplotlib
     - scons PREFIX=$HOME
     - scons install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,43 @@
 branches:
-  only:
-    - master
+    only:
+        - master
+
 language: python
+python:
+    - 2.7
+
 compiler:
-  - g++
+    - g++
 before_install:
-  - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
-  - sudo apt-get -qq update
-  - sudo apt-get install -y libboost-all-dev gfortran liblapack-dev libfftw3-dev python-dev python-numpy python-scipy python-nose
-  - pip install astropy==1.1.1 pyyaml future
-  - pushd $HOME
-#Only get TMV if not cached
-  - if ! test -d tmv-0.73 || ! test -f tmv-0.73/Sconstruct; then wget https://github.com/rmjarvis/tmv/archive/v0.73.tar.gz && tar -xf v0.73.tar.gz ; else echo Using cached TMV; fi
-#But always install it to /usr/local
-  - cd tmv-0.73 && sudo scons install DEBUG=True FLAGS="-O0"
-  - popd
+    - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
+    - sudo apt-get -qq update
+    - sudo apt-get install -y libboost-all-dev gfortran liblapack-dev libfftw3-dev python-dev python-numpy python-scipy python-nose
+    - pushd $HOME
+    #Only get TMV if not cached
+    - if ! test -d tmv-0.73 || ! test -f tmv-0.73/Sconstruct; then wget https://github.com/rmjarvis/tmv/archive/v0.73.tar.gz && tar -xf v0.73.tar.gz ; else echo Using cached TMV; fi
+    #But always install it to /usr/local
+    - cd tmv-0.73 && sudo scons install DEBUG=True FLAGS="-O0"
+    - popd
+
 cache:
     pip: true
     directories:
     - $HOME/tmv-0.73
 
-install: scons
-script: scons tests
+install:
+    - pip install astropy==1.1.1 pyyaml future
+    - scons
+    - sudo scons install
+
+script:
+    - cd tests
+    # Use this rather than scons tests, so we can get the coverage options.
+    - "nosetests test*.py --with-coverage --cover-package=galsim --with-doctest --cover-erase"
+    # Without cover-erase, this will append to the .coverage file
+    - "nosetests run_examples.py --with-coverage --cover-package=galsim --with-doctest"
+
+after_success:
+    # If we start doing multiple python versions here, then only report coveralls for one of them.
+    # Otherwise the reported results get weird.
+    - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then coveralls; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
     #- sudo apt-get install -y wcstools
     # Hm. This didn't work, and I can't figure out why.  I get the following error:
     #     Reading package lists... Done
-    #     Building dependency tree       
+    #     Building dependency tree
     #     Reading state information... Done
     #     E: Unable to locate package wcstools
     # Perhaps someone with more familiarity with apt-get can figure this out, but for now, we'll
@@ -34,9 +34,9 @@ before_install:
 
     # Only get TMV if not cached
     - pushd $HOME
-    - if ! test -d tmv-0.73 || ! test -f tmv-0.73/Sconstruct; then wget https://github.com/rmjarvis/tmv/archive/v0.73.tar.gz && tar -xf v0.73.tar.gz ; else echo Using cached TMV; fi
+    - if ! test -d tmv-0.73 || ! test -f tmv-0.73/SConstruct; then wget https://github.com/rmjarvis/tmv/archive/v0.73.tar.gz && tar -xf v0.73.tar.gz ; else echo Using cached TMV; fi
     # But always install it to /usr/local
-    - cd tmv-0.73 && sudo scons install DEBUG=True FLAGS="-O0"
+    - cd tmv-0.73 && sudo scons install
     - popd
 
     # Add ~/bin and ~/lib to the appropriate paths where scons install will put things.
@@ -45,7 +45,7 @@ before_install:
     - export PYTHONPATH=$HOME/lib/python$TRAVIS_PYTHON_VERSION/site-packages/:$PYTHONPATH
 
     # Get the des data needed for the check_des test.
-    - if ! test -d $HOME/des_data || ! test -f $HOME/des_data/DECam_00154912_01.fits.fz; then wget http://www.sas.upenn.edu/~mjarvis/des_data.tar.gz && tar xfz des_data.tar.gz -C $HOME; fi
+    - if ! test -d $HOME/des_data || ! test -f $HOME/des_data/DECam_00154912_01.fits.fz; then wget http://www.sas.upenn.edu/~mjarvis/des_data.tar.gz && tar xfz des_data.tar.gz -C $HOME DECam_00154912_01*; fi
     - ln -s $HOME/des_data examples/des/
 
 cache:
@@ -53,7 +53,6 @@ cache:
     directories:
     - $HOME/tmv-0.73
     - $HOME/des_data
-    - $HOME/share/galsim
 
 install:
     # Note: matplotlib is only required because starlink has an `import matplotlib` in their
@@ -61,8 +60,6 @@ install:
     - pip install astropy==1.1.1 pyyaml future coveralls starlink-pyast matplotlib scipy
     - scons PREFIX=$HOME
     - scons install
-    # Download COSMOS catalog if not downloaded yet.
-    - galsim_download_cosmos -q -v1
 
 script:
     - cd tests
@@ -75,8 +72,6 @@ script:
     - ls -l $HOME
     - ls -l $HOME/tmv-0.73
     - ls -l $HOME/des_data
-    - ls -l $HOME/share
-    - ls -l $HOME/share/galsim
 
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ install:
 
 script:
     - cd tests
+    - "nosetests -vs test_wcs.py"
     # Use this rather than scons tests, so we can get the coverage options.
     - "nosetests test*.py --with-coverage --cover-package=galsim --with-doctest --cover-erase"
     # Without cover-erase, this will append to the .coverage file

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ before_install:
     # Add ~/bin and ~/lib to the appropriate paths where scons install will put things.
     - export PATH=$HOME/bin:$PATH
     - export LD_LIBRARY_PATH=$HOME/lib:$LD_LIBRARY_PATH
+    - export PYTHONPATH=$HOME/lib/python$TRAVIS_PYTHON_VERSION/site-packages/:$PYTHONPATH
 
     # Get the des data needed for the check_des test.
     - if ! test -d examples/des/des_data || ! test -f examples/des/des_data/DECam_00154912_01.fits.fz; then wget http://www.sas.upenn.edu/~mjarvis/des_data.tar.gz && tar xfz des_data.tar.gz -C $HOME; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
     - export PYTHONPATH=$HOME/lib/python$TRAVIS_PYTHON_VERSION/site-packages/:$PYTHONPATH
 
     # Get the des data needed for the check_des test.
-    - if ! test -d $HOME/des_data || ! test -f $HOME/des_data/DECam_00154912_01.fits.fz; then wget http://www.sas.upenn.edu/~mjarvis/des_data.tar.gz && tar xfz des_data.tar.gz -C $HOME des_data/DECam_00154912_01*; fi
+    - if ! test -d $HOME/des_data || ! test -f $HOME/des_data/DECam_00154912_01.fits.fz; then wget http://www.sas.upenn.edu/~mjarvis/des_data.tar.gz && tar xfz des_data.tar.gz -C $HOME --wildcards *_01*; fi
     - ln -s $HOME/des_data examples/des/
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,17 @@ before_install:
     - sudo apt-get -qq update
     - sudo apt-get install -y libboost-all-dev gfortran liblapack-dev libfftw3-dev python-dev python-numpy python-scipy python-nose
 
-    # To get coverage of the WCSToolsWCS class:
-    - sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) universe"
-    - sudo apt-get -qq update
-    - sudo apt-get install -y wcstools
+    # To get coverage of the WcsToolsWCS class:
+    #- sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) universe"
+    #- sudo apt-get -qq update
+    #- sudo apt-get install -y wcstools
+    # Hm. This didn't work, and I can't figure out why.  I get the following error:
+    #     Reading package lists... Done
+    #     Building dependency tree       
+    #     Reading state information... Done
+    #     E: Unable to locate package wcstools
+    # Perhaps someone with more familiarity with apt-get can figure this out, but for now, we'll
+    # live with lack of coverage of WcsToolsWCS.
 
     # Only get TMV if not cached
     - pushd $HOME

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ before_install:
     - ls -l $HOME
     - ls -l $HOME/tmv-0.73
     - ls -l $HOME/des_data
-    - ls -l $HOME/share
-    - ls -l $HOME/share/galsim
 
     # To get coverage of the WcsToolsWCS class:
     #- sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) universe"

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,3 +81,7 @@ after_success:
     # Otherwise the reported results get weird.
     - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then coveralls; fi
 
+before_cache: 
+    - rm -rf $HOME/.cache/pip/log
+    - rm -rf $HOME/.cache/pip/http
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
     - export PYTHONPATH=$HOME/lib/python$TRAVIS_PYTHON_VERSION/site-packages/:$PYTHONPATH
 
     # Get the des data needed for the check_des test.
-    - if ! test -d examples/des/des_data || ! test -f examples/des/des_data/DECam_00154912_01.fits.fz; then wget http://www.sas.upenn.edu/~mjarvis/des_data.tar.gz && tar xfz des_data.tar.gz -C $HOME; fi
+    - if ! test -d $HOME/des_data || ! test -f $HOME/des_data/DECam_00154912_01.fits.fz; then wget http://www.sas.upenn.edu/~mjarvis/des_data.tar.gz && tar xfz des_data.tar.gz -C $HOME; fi
     - ln -s $HOME/des_data examples/des/
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ before_install:
     #But always install it to /usr/local
     - cd tmv-0.73 && sudo scons install DEBUG=True FLAGS="-O0"
     - popd
+    - export PATH=$HOME/bin:$PATH
+    - export LD_LIBRARY_PATH=$HOME/lib:$LD_LIBRARY_PATH
 
 cache:
     pip: true
@@ -26,7 +28,7 @@ cache:
 
 install:
     - pip install astropy==1.1.1 pyyaml future
-    - scons
+    - scons PREFIX=$HOME
     - scons install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ cache:
 install:
     - pip install astropy==1.1.1 pyyaml future
     - scons
-    - sudo scons install
+    - scons install
 
 script:
     - cd tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,14 @@ before_install:
     - export PATH=$HOME/bin:$PATH
     - export LD_LIBRARY_PATH=$HOME/lib:$LD_LIBRARY_PATH
 
+    # Get the des data needed for the check_des test.
+    - if ! test -d examples/des/des_data || ! test -f examples/des/des_data/DECam_00154912_01.fits.fz; then wget http://www.sas.upenn.edu/~mjarvis/des_data.tar.gz && tar xfz des_data.tar.gz -C examples/des; fi
+
 cache:
     pip: true
     directories:
     - $HOME/tmv-0.73
+    - examples/des/des_data
 
 install:
     # Note: matplotlib is only required because starlink has an `import matplotlib` in their

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ cache:
     - $HOME/tmv-0.73
 
 install:
-    - pip install astropy==1.1.1 pyyaml future
+    - pip install astropy==1.1.1 pyyaml future coveralls
     - scons PREFIX=$HOME
     - scons install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,8 @@ script:
 
 after_success:
     # The multiprocessing stages don't get properly incorporated into the .coverage file unless
-    # we do this command.
-    - coverage combine
+    # we do this command.  (Some of the .coverage.* files are in the ../examples directory.)
+    - coverage combine . ../examples
 
     # If we start doing multiple python versions here, then only report coveralls for one of them.
     # Otherwise the reported results get weird.

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ cache:
 install:
     # Note: matplotlib is only required because starlink has an `import matplotlib` in their
     # code, despite that not being a dependency.
-    - pip install astropy==1.1.1 pyyaml future coveralls starlink-pyast matplotlib
+    - pip install astropy==1.1.1 pyyaml future coveralls starlink-pyast matplotlib scipy
     - scons PREFIX=$HOME
     - scons install
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes from v1.4 to v1.5
 API Changes
 -----------
 
+- Simplified the return value of galsim.config.ReadConfig. (#580)
 
 
 Dependency Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Dependency Changes
 Bug Fixes
 ---------
 
+- Fixed an error in the magnification calculated by NFWHalo.getLensing(). (#580)
 - Fixed bug when whitening noise in images based on COSMOS training datasets
   using the config functionality. (#792)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 @mainpage
+[![Build Status](https://travis-ci.org/GalSim-developers/GalSim.svg?branch=master)](https://travis-ci.org/GalSim-developers/GalSim)
+[![Coverage Status](https://coveralls.io/repos/github/GalSim-developers/GalSim/badge.svg?branch=releases%2F1.4)](https://coveralls.io/github/GalSim-developers/GalSim?branch=master)
+[![Paper](https://img.shields.io/badge/astro--ph.IM-1407.7676-B31B1B.svg)](https://arxiv.org/abs/1407.7676)
+[![Paper](https://img.shields.io/badge/ADS-Rowe%20et%20al%2C%202015-B31B1B.svg)
+(http://adsabs.harvard.edu/abs/2015A%26C....10..121R)
 
 GalSim: The modular galaxy image simulation toolkit
 ===================================================

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-@mainpage
+[//]: # ( @mainpage )
 [![Build Status](https://travis-ci.org/GalSim-developers/GalSim.svg?branch=master)](https://travis-ci.org/GalSim-developers/GalSim)
 [![Coverage Status](https://coveralls.io/repos/github/GalSim-developers/GalSim/badge.svg?branch=releases%2F1.4)](https://coveralls.io/github/GalSim-developers/GalSim?branch=master)
 [![Paper](https://img.shields.io/badge/astro--ph.IM-1407.7676-B31B1B.svg)](https://arxiv.org/abs/1407.7676)
-[![Paper](https://img.shields.io/badge/ADS-Rowe%20et%20al%2C%202015-B31B1B.svg)
-(http://adsabs.harvard.edu/abs/2015A%26C....10..121R)
+[![Paper](https://img.shields.io/badge/ADS-Rowe%20et%20al%2C%202015-B31B1B.svg)](http://adsabs.harvard.edu/abs/2015A%26C....10..121R)
 
 GalSim: The modular galaxy image simulation toolkit
 ===================================================

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.org/GalSim-developers/GalSim.svg?branch=master)](https://travis-ci.org/GalSim-developers/GalSim)
 [![Coverage Status](https://coveralls.io/repos/github/GalSim-developers/GalSim/badge.svg?branch=releases%2F1.4)](https://coveralls.io/github/GalSim-developers/GalSim?branch=master)
 [![Paper](https://img.shields.io/badge/astro--ph.IM-1407.7676-B31B1B.svg)](https://arxiv.org/abs/1407.7676)
-[![Paper](https://img.shields.io/badge/ADS-Rowe%20et%20al%2C%202015-B31B1B.svg)](http://adsabs.harvard.edu/abs/2015A%26C....10..121R)
+[![Paper](https://img.shields.io/badge/ADS-Rowe%20et%20al%2C%202015-blue.svg)](http://adsabs.harvard.edu/abs/2015A%26C....10..121R)
 
 GalSim: The modular galaxy image simulation toolkit
 ===================================================

--- a/bin/galsim_download_cosmos.py
+++ b/bin/galsim_download_cosmos.py
@@ -168,8 +168,9 @@ def ensure_dir(target):
         os.makedirs(d)
 
 def download(url, target, unpack_dir, args, logger):
-    logger.info('Downloading from url:\n  %s',url)
-    logger.info('Target location is:\n  %s\n',target)
+    logger.warning('Downloading from url:\n  %s',url)
+    logger.warning('Target location is:\n  %s',target)
+    logger.info('')
 
     # See how large the file to be downloaded is.
     u = urlopen(url)
@@ -200,10 +201,10 @@ def download(url, target, unpack_dir, args, logger):
                 if yn == 'no':
                     do_download = False
         else:
-            logger.warn("Target file already exists, but it seems to be either incomplete, "
-                        "corrupt, or obsolete")
+            logger.warning("Target file already exists, but it seems to be either incomplete, "
+                           "corrupt, or obsolete")
             if args.quiet:
-                logger.warn("Size of existing file = %d MBytes.  Re-downloading.",
+                logger.info("Size of existing file = %d MBytes.  Re-downloading.",
                             existing_file_size/1024**2)
             else:
                 q = "Size of existing file = %d MBytes.  Re-download?"%(existing_file_size/1024**2)
@@ -240,8 +241,8 @@ def download(url, target, unpack_dir, args, logger):
 
         if obsolete:
             if args.quiet or args.force:
-                logger.info("The version currently on disk is obsolete.  "+
-                            "Downloading new version.")
+                logger.warning("The version currently on disk is obsolete.  "+
+                               "Downloading new version.")
             else:
                 q = "The version currently on disk is obsolete.  Download new version?"
                 yn = query_yes_no(q, default='yes')
@@ -272,6 +273,7 @@ def download(url, target, unpack_dir, args, logger):
             with open(target, 'wb') as f:
                 file_size_dl = 0
                 block_sz = 32 * 1024
+                next_dot = file_size/100.  # For verbosity==1, the next size for writing a dot.
                 while True:
                     buffer = u.read(block_sz)
                     if not buffer:
@@ -285,8 +287,12 @@ def download(url, target, unpack_dir, args, logger):
                         status = r"Downloading: %5d / %d MBytes  [%3.2f%%]" % (
                             file_size_dl/1024**2, file_size/1024**2, file_size_dl*100./file_size)
                         status = status + chr(8)*(len(status)+1)
-                        print(status, end='')
+                        sys.stdout.write(status)
                         sys.stdout.flush()
+                    elif args.verbosity >= 1 and file_size_dl > next_dot:
+                        sys.stdout.write('.')
+                        sys.stdout.flush()
+                        next_dot += file_size/100.
             logger.info("Download complete.")
         except IOError as e:
             # Try to give a reasonable suggestion for some common IOErrors.
@@ -339,11 +345,11 @@ def link_target(unpack_dir, link_dir, args, logger):
             # If it is not a link, we need to figure out what to do with it.
             if os.path.isdir(link_dir):
                 # If it's a directory, probably want to keep it.
-                logger.warn("%s already exists and is a directory.",link_dir)
+                logger.warning("%s already exists and is a directory.",link_dir)
                 if args.force:
-                    logger.warn("Removing the existing files to make the link.")
+                    logger.warning("Removing the existing files to make the link.")
                 elif args.quiet:
-                    logger.warn("Link cannot be made.  (Use -f to force removal of existing dir.)")
+                    logger.warning("Link cannot be made.  (Use -f to force removal of existing dir.)")
                     return
                 else:
                     q = "Remove the existing files to make the link?"
@@ -353,9 +359,9 @@ def link_target(unpack_dir, link_dir, args, logger):
                 shutil.rmtree(link_dir)
             else:
                 # If it's not a directory, it's probably corrupt, so the default is to remove it.
-                logger.warn("%s already exists, but strangely isn't a directory.",link_dir)
+                logger.warning("%s already exists, but strangely isn't a directory.",link_dir)
                 if args.force or args.quiet:
-                    logger.warn("Removing the existing file.")
+                    logger.warning("Removing the existing file.")
                 else:
                     q = "Remove the existing file?"
                     yn = query_yes_no(q, default='yes')

--- a/examples/.coveragerc
+++ b/examples/.coveragerc
@@ -1,0 +1,1 @@
+../tests/.coveragerc

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -4,3 +4,4 @@ output
 output_yaml
 output_json
 lsst_images
+.coverage*

--- a/examples/demo13.py
+++ b/examples/demo13.py
@@ -74,6 +74,25 @@ def main(argv):
     datapath = os.path.abspath(os.path.join(path, "data/"))
     outpath = os.path.abspath(os.path.join(path, "output/"))
 
+    # Just use a few galaxies, to save time.  Note that we are going to put 4000 galaxy images into
+    # our big image, so if we have n_use=10, each galaxy will appear 400 times.  Users who want a
+    # more interesting image with greater variation in the galaxy population can change `n_use` to
+    # something larger (but it should be <=100, the number of galaxies in this small example
+    # catalog).  With 4000 galaxies in a 4k x 4k image with the WFIRST pixel scale, the effective
+    # galaxy number density is 74/arcmin^2.  This is not the number density that is expected for a
+    # sample that is so bright (I<23.5) but it makes the image more visually interesting.  One could
+    # think of it as what you'd get if you added up several images at once, making the images for a
+    # sample that is much deeper have the same S/N as that for an I<23.5 sample in a single image.
+    n_use = 10
+    n_tot = 4000
+
+    # quick and dirty command line parsing.
+    for var in argv:
+        if var.startswith('data='): datapath = var[5:]
+        if var.startswith('out='): outpath = var[4:]
+        if var.startswith('nuse='): n_use = int(var[5:])
+        if var.startswith('ntot='): n_tot = int(var[5:])
+
     # Make output directory if not already present.
     if not os.path.isdir(outpath):
         os.mkdir(outpath)
@@ -105,17 +124,6 @@ def main(argv):
     # want parametric galaxies that represent an I<23.5 sample.
     cat = galsim.COSMOSCatalog(cat_file_name, dir=dir, use_real=False)
     logger.info('Read in %d galaxies from catalog'%cat.nobjects)
-    # Just use a few galaxies, to save time.  Note that we are going to put 4000 galaxy images into
-    # our big image, so if we have n_use=10, each galaxy will appear 400 times.  Users who want a
-    # more interesting image with greater variation in the galaxy population can change `n_use` to
-    # something larger (but it should be <=100, the number of galaxies in this small example
-    # catalog).  With 4000 galaxies in a 4k x 4k image with the WFIRST pixel scale, the effective
-    # galaxy number density is 74/arcmin^2.  This is not the number density that is expected for a
-    # sample that is so bright (I<23.5) but it makes the image more visually interesting.  One could
-    # think of it as what you'd get if you added up several images at once, making the images for a
-    # sample that is much deeper have the same S/N as that for an I<23.5 sample in a single image.
-    n_use = 10
-    n_tot = 4000
 
     # Here we carry out the initial steps that are necessary to get a fully chromatic PSF.  We use
     # the getPSF() routine in the WFIRST module, which knows all about the telescope parameters

--- a/examples/demo13.py
+++ b/examples/demo13.py
@@ -86,12 +86,16 @@ def main(argv):
     n_use = 10
     n_tot = 4000
 
+    # Default is to use all filters.  Specify e.g. 'YJH' to only do Y106, J129, and H158.
+    use_filters = None
+
     # quick and dirty command line parsing.
     for var in argv:
         if var.startswith('data='): datapath = var[5:]
         if var.startswith('out='): outpath = var[4:]
         if var.startswith('nuse='): n_use = int(var[5:])
         if var.startswith('ntot='): n_tot = int(var[5:])
+        if var.startswith('filters='): use_filters = var[8:].upper()
 
     # Make output directory if not already present.
     if not os.path.isdir(outpath):
@@ -229,6 +233,10 @@ def main(argv):
     # Calculate the sky level for each filter, and draw the PSF and the galaxies through the
     # filters.
     for filter_name, filter_ in filters.items():
+        if use_filters is not None and filter_name[0] not in use_filters:
+            logger.info('Skipping filter {0}.'.format(filter_name))
+            continue
+
         logger.info('Beginning work for {0}.'.format(filter_name))
 
         # Drawing PSF.  Note that the PSF object intrinsically has a flat SED, so if we convolve it

--- a/galsim/_pyfits.py
+++ b/galsim/_pyfits.py
@@ -25,7 +25,7 @@ try:
     from astropy import version as astropy_version
     pyfits_version = str( (4 + astropy_version.major) + astropy_version.minor/10.)
     pyfits_str = 'astropy.io.fits'
-except:
+except ImportError:
     import pyfits
     pyfits_version = pyfits.__version__
     pyfits_str = 'pyfits'

--- a/galsim/bandpass.py
+++ b/galsim/bandpass.py
@@ -176,9 +176,10 @@ class Bandpass(object):
         for test_wave in test_waves:
             try:
                 self._tp(test_wave)
-            except:
+            except Exception as e:
                 raise ValueError(
-                    "Throughput function was unable to evaluate at wave = {0}.".format(test_wave))
+                    "Throughput function was unable to evaluate at wave = {0}.".format(test_wave) +
+                    "Caught error: {0}".format(e))
 
 
     def _initialize_tp(self):

--- a/galsim/base.py
+++ b/galsim/base.py
@@ -1325,7 +1325,7 @@ class GSObject(object):
                 image.added_flux = prof.SBProfile.drawShoot(
                     imview.image, n_photons, uniform_deviate, gain, max_extra_noise,
                     poisson_flux, add_to_image)
-            except RuntimeError:
+            except RuntimeError:  # pragma: no cover
                 # Give some extra explanation as a warning, then raise the original exception
                 # so the traceback shows as much detail as possible.
                 import warnings

--- a/galsim/base.py
+++ b/galsim/base.py
@@ -1245,7 +1245,7 @@ class GSObject(object):
                 raise TypeError("The rng provided is not a BaseDeviate")
 
             # Check that either n_photons is set to something or flux is set to something
-            if n_photons == 0. and self.getFlux() == 1.:
+            if n_photons == 0. and self.getFlux() == 1.: # pragma : no cover
                 import warnings
                 msg = "Warning: drawImage for object with flux == 1, but n_photons == 0.\n"
                 msg += "This will only shoot a single photon (since flux = 1)."

--- a/galsim/base.py
+++ b/galsim/base.py
@@ -1195,7 +1195,7 @@ class GSObject(object):
         @returns the drawn Image.
         """
         # Check for obsolete dx parameter
-        if dx is not None and scale is None: # pragma : no cover
+        if dx is not None and scale is None: # pragma: no cover
             from .deprecated import depr
             depr('dx', 1.1, 'scale')
             scale = dx
@@ -1245,7 +1245,7 @@ class GSObject(object):
                 raise TypeError("The rng provided is not a BaseDeviate")
 
             # Check that either n_photons is set to something or flux is set to something
-            if n_photons == 0. and self.getFlux() == 1.: # pragma : no cover
+            if n_photons == 0. and self.getFlux() == 1.: # pragma: no cover
                 import warnings
                 msg = "Warning: drawImage for object with flux == 1, but n_photons == 0.\n"
                 msg += "This will only shoot a single photon (since flux = 1)."
@@ -1385,7 +1385,7 @@ class GSObject(object):
         @returns the tuple of Image instances, `(re, im)` (created if necessary)
         """
         # Check for obsolete dk parameter
-        if dk is not None and scale is None: # pragma : no cover
+        if dk is not None and scale is None: # pragma: no cover
             from .deprecated import depr
             depr('dx', 1.1, 'scale')
             scale = dk

--- a/galsim/base.py
+++ b/galsim/base.py
@@ -1195,7 +1195,7 @@ class GSObject(object):
         @returns the drawn Image.
         """
         # Check for obsolete dx parameter
-        if dx is not None and scale is None:
+        if dx is not None and scale is None: # pragma : no cover
             from .deprecated import depr
             depr('dx', 1.1, 'scale')
             scale = dx
@@ -1385,7 +1385,7 @@ class GSObject(object):
         @returns the tuple of Image instances, `(re, im)` (created if necessary)
         """
         # Check for obsolete dk parameter
-        if dk is not None and scale is None:
+        if dk is not None and scale is None: # pragma : no cover
             from .deprecated import depr
             depr('dx', 1.1, 'scale')
             scale = dk

--- a/galsim/catalog.py
+++ b/galsim/catalog.py
@@ -577,7 +577,7 @@ class OutputCatalog(object):
         # Depending on the version of pyfits, one of these should work:
         try:
             tbhdu = pyfits.BinTableHDU.from_columns(cols)
-        except:
+        except:  # pragma: no cover
             tbhdu = pyfits.new_table(cols)
         return tbhdu
 

--- a/galsim/catalog.py
+++ b/galsim/catalog.py
@@ -536,7 +536,7 @@ class OutputCatalog(object):
 
         try:
             np.savetxt(file_name, data, fmt=fmt, header=header)
-        except (AttributeError, TypeError):
+        except (AttributeError, TypeError):  # pragma : no cover
             # header was added with version 1.7, so do it by hand if not available.
             with open(file_name, 'w') as fid:
                 fid.write('#' + header + '\n')

--- a/galsim/catalog.py
+++ b/galsim/catalog.py
@@ -275,7 +275,7 @@ class Dict(object):
         if file_type == 'PICKLE':
             try:
                 import cPickle as pickle
-            except:
+            except ImportError:
                 import pickle
             with open(self.file_name, 'rb') as f:
                 self.dict = pickle.load(f)

--- a/galsim/catalog.py
+++ b/galsim/catalog.py
@@ -536,7 +536,7 @@ class OutputCatalog(object):
 
         try:
             np.savetxt(file_name, data, fmt=fmt, header=header)
-        except (AttributeError, TypeError):  # pragma : no cover
+        except (AttributeError, TypeError):  # pragma: no cover
             # header was added with version 1.7, so do it by hand if not available.
             with open(file_name, 'w') as fid:
                 fid.write('#' + header + '\n')

--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -1770,7 +1770,7 @@ class ChromaticConvolution(ChromaticObject):
         for obj in self.objlist:
             if not obj.separable and not isinstance(obj, galsim.ChromaticSum): n_nonsep += 1
             if isinstance(obj, InterpolatedChromaticObject): n_interp += 1
-        if n_nonsep>1 and n_interp>0:
+        if n_nonsep>1 and n_interp>0: # pragma : no cover
             import warnings
             warnings.warn(
                 "Image rendering for this convolution cannot take advantage of " +

--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -1770,7 +1770,7 @@ class ChromaticConvolution(ChromaticObject):
         for obj in self.objlist:
             if not obj.separable and not isinstance(obj, galsim.ChromaticSum): n_nonsep += 1
             if isinstance(obj, InterpolatedChromaticObject): n_interp += 1
-        if n_nonsep>1 and n_interp>0: # pragma : no cover
+        if n_nonsep>1 and n_interp>0: # pragma: no cover
             import warnings
             warnings.warn(
                 "Image rendering for this convolution cannot take advantage of " +

--- a/galsim/config/extra_truth.py
+++ b/galsim/config/extra_truth.py
@@ -40,7 +40,7 @@ class TruthBuilder(ExtraOutputBuilder):
         super(self.__class__,self).initialize(data,scratch,config,base,logger)
 
         # Warn if the config dict isn't an OrderedDict.
-        if logger and not hasattr(config, '__reversed__') and not hasattr(self,'warned'):
+        if logger and not hasattr(config, '__reversed__') and not hasattr(self,'warned'): # pragma : no cover
             # If config doesn't have a __reversed__ attribute, then it's not an OrderedDict.
             # Probably it's just a regular dict.  So warn the user that the columns are in
             # arbitrary order.
@@ -80,7 +80,7 @@ class TruthBuilder(ExtraOutputBuilder):
             types.append(type(value))
         if 'types' not in self.scratch:
             self.scratch['types'] = types
-        elif self.scratch['types'] != types:
+        elif self.scratch['types'] != types: # pragma : no cover
             if logger:
                 logger.error("Type mismatch found when building truth catalog at object %d",
                     base['obj_num'])

--- a/galsim/config/extra_truth.py
+++ b/galsim/config/extra_truth.py
@@ -40,7 +40,7 @@ class TruthBuilder(ExtraOutputBuilder):
         super(self.__class__,self).initialize(data,scratch,config,base,logger)
 
         # Warn if the config dict isn't an OrderedDict.
-        if logger and not hasattr(config, '__reversed__') and not hasattr(self,'warned'): # pragma : no cover
+        if logger and not hasattr(config, '__reversed__') and not hasattr(self,'warned'): # pragma: no cover
             # If config doesn't have a __reversed__ attribute, then it's not an OrderedDict.
             # Probably it's just a regular dict.  So warn the user that the columns are in
             # arbitrary order.
@@ -80,7 +80,7 @@ class TruthBuilder(ExtraOutputBuilder):
             types.append(type(value))
         if 'types' not in self.scratch:
             self.scratch['types'] = types
-        elif self.scratch['types'] != types: # pragma : no cover
+        elif self.scratch['types'] != types: # pragma: no cover
             if logger:
                 logger.error("Type mismatch found when building truth catalog at object %d",
                     base['obj_num'])

--- a/galsim/config/gsobject.py
+++ b/galsim/config/gsobject.py
@@ -181,7 +181,7 @@ def BuildGSObject(config, key, base=None, gsparams={}, logger=None):
         if issubclass(galsim.__dict__[type_name], galsim.GSObject):
             gsobject, safe = _BuildSimple(param, base, ignore, gsparams, logger)
         else:
-            TypeError("Input config type = %s is not a GSObject."%type_name)
+            raise TypeError("Input config type = %s is not a GSObject."%type_name)
     # Otherwise, it's not a valid type.
     else:
         raise NotImplementedError("Unrecognised config type = %s"%type_name)

--- a/galsim/config/image.py
+++ b/galsim/config/image.py
@@ -81,7 +81,7 @@ def BuildImages(nimages, config, image_num=0, obj_num=0, logger=None):
             else: s0 = '%s: '%proc
             image_num = jobs[k]['image_num']
             logger.error(s0 + 'Exception caught when building image %d', image_num)
-            #logger.error('%s',tr)
+            logger.warning('%s',tr)
             logger.error('Aborting the rest of this file')
 
     # Convert to the tasks structure we need for MultiProcess

--- a/galsim/config/image.py
+++ b/galsim/config/image.py
@@ -76,7 +76,7 @@ def BuildImages(nimages, config, image_num=0, obj_num=0, logger=None):
             logger.info(s0 + 'Image %d: size = %d x %d, time = %f sec', image_num, xs, ys, t)
 
     def except_func(logger, proc, k, e, tr):
-        if logger:
+        if logger: # pragma: no cover
             if proc is None: s0 = ''
             else: s0 = '%s: '%proc
             image_num = jobs[k]['image_num']

--- a/galsim/config/noise.py
+++ b/galsim/config/noise.py
@@ -222,7 +222,7 @@ class NoiseBuilder(object):
         @param draw_method      The method that was used to draw the objects on the image.
         @param logger           If given, a logger object to log progress.
         """
-        raise NotImplemented("The %s class has not overridden addNoise"%self.__class__)
+        raise NotImplementedError("The %s class has not overridden addNoise"%self.__class__)
 
     def getNoiseVariance(self, config, base):
         """Read the noise parameters from the config dict and return the variance.
@@ -232,7 +232,7 @@ class NoiseBuilder(object):
 
         @returns the variance of the noise model
         """
-        raise NotImplemented("The %s class has not overridden addNoise"%self.__class__)
+        raise NotImplementedError("The %s class has not overridden addNoise"%self.__class__)
 
     def addNoiseVariance(self, config, base, im, include_obj_var, logger):
         """Read the noise parameters from the config dict and add the appropriate noise variance

--- a/galsim/config/output.py
+++ b/galsim/config/output.py
@@ -116,7 +116,7 @@ def BuildFiles(nfiles, config, file_num=0, logger=None):
             logger.warning(s0 + 'File %d = %s: time = %f sec', file_num, file_name, t)
 
     def except_func(logger, proc, k, e, tr):
-        if logger:
+        if logger:  # pragma: no cover
             file_num, file_name = info[k]
             if proc is None: s0 = ''
             else: s0 = '%s: '%proc
@@ -134,13 +134,13 @@ def BuildFiles(nfiles, config, file_num=0, logger=None):
                                          except_abort = False)
     t2 = time.time()
 
-    if not results:
+    if not results:  # pragma: no cover
         nfiles_written = 0
     else:
         fnames, times = zip(*results)
         nfiles_written = sum([ t!=0 for t in times])
 
-    if nfiles_written == 0:
+    if nfiles_written == 0:  # pragma: no cover
         if logger:
             logger.error('No files were written.  All were either skipped or had errors.')
     else:

--- a/galsim/config/process.py
+++ b/galsim/config/process.py
@@ -317,7 +317,7 @@ class LoggerWrapper(object):
             self.logger.info(*args, **kwargs)
 
     def warning(self, *args, **kwargs):
-        if self.logger and self.logger.isEnabledFor(logging.WARN):
+        if self.logger and self.logger.isEnabledFor(logging.WARNING):
             self.logger.warning(*args, **kwargs)
 
     def error(self, *args, **kwargs):

--- a/galsim/config/process.py
+++ b/galsim/config/process.py
@@ -642,6 +642,14 @@ def Process(config, logger=None, njobs=1, job=1, new_params=None):
         import pprint
         logger.debug("Final config dict to be processed: \n%s", pprint.pformat(config))
 
+    # Warn about any unexpected fields.
+    expected = [ 'psf', 'gal', 'stamp', 'image', 'input', 'output',
+                      'eval_variables', 'root' ]
+    unexpected = [ k for k in config if k not in expected ]
+    if len(unexpected) > 0 and logger:
+        logger.warning("Warning: config dict contains the following unexpected fields: %s."%unexpected)
+        logger.warning("         These fields are not (directly) processed by the config processing.")
+
     # Make config['output'] exist if it doesn't yet.
     if 'output' not in config:
         config['output'] = {}

--- a/galsim/config/process.py
+++ b/galsim/config/process.py
@@ -821,7 +821,7 @@ def MultiProcess(nproc, config, job_func, tasks, item, logger=None,
                 # k is the index for the job that failed
                 if except_func is not None:
                     except_func(logger, proc, k, res, t)
-                if except_abort:
+                if except_abort or isinstance(res,KeyboardInterrupt):
                     for j in range(nproc):
                         p_list[j].terminate()
                     raise res
@@ -868,7 +868,8 @@ def MultiProcess(nproc, config, job_func, tasks, item, logger=None,
                     tr = traceback.format_exc()
                     if except_func is not None:
                         except_func(logger, None, k, e, tr)
-                    if except_abort: raise
+                    if except_abort or isinstance(e,KeyboardInterrupt):
+                        raise
 
     # If there are any failures, then there will still be some Nones in the results list.
     # Remove them.

--- a/galsim/config/process.py
+++ b/galsim/config/process.py
@@ -67,14 +67,11 @@ def ReadYaml(config_file):
     (usually small) modifications to the base dict for each job.  See demo6.yaml, demo8.yaml and
     demo9.yaml in the GalSim/examples directory for example usage.
 
-    On output, base_config is the dict for the first document if there are multiple documents.
-    Then all_config is a list of all the other documents that should be joined with base_dict
-    for each job to be processed.  If there is only one document defined, base_dict will be
-    empty, and all_config will be a list of one dict, which is the one to use.
+    The return value will be a list of dicts, one dict for each job to be done.
 
     @param config_file      The name of the configuration file to read.
 
-    @returns (base_config, all_config)
+    @returns list of config dicts
     """
     import yaml
 
@@ -117,12 +114,11 @@ def ReadJson(config_file):
     """Read in a JSON configuration file and return the corresponding dicts.
 
     A JSON file only defines a single dict.  However to be parallel to the functionality of
-    ReadYaml, the output is base_config, all_config, where base_config is an empty dict,
-    and all_config is a list with a single item, which is the dict defined by the JSON file.
+    ReadYaml, the output is a list with a single item, which is the dict defined by the JSON file.
 
     @param config_file      The name of the configuration file to read.
 
-    @returns (base_config, all_config)
+    @returns [config_dict]
     """
     import json
 
@@ -563,8 +559,8 @@ def ProcessTemplate(config, logger=None):
         else:
             config_file = template_string
             field = None
-        base, all_config = ReadConfig(config_file, logger=logger)
-        if base != {} or len(all_config) != 1:
+        all_config = ReadConfig(config_file, logger=logger)
+        if len(all_config) != 1:
             raise RuntimeError("Template config file %s is not allowed to have multiple documents.",
                                config_file)
         # Copy over the template config into this one.

--- a/galsim/config/process.py
+++ b/galsim/config/process.py
@@ -266,8 +266,6 @@ def CopyConfig(config):
         config1['gal'] = copy.deepcopy(config['gal'])
     if 'psf' in config:
         config1['psf'] = copy.deepcopy(config['psf'])
-    if 'pix' in config:
-        config1['pix'] = copy.deepcopy(config['pix'])
     if 'image' in config:
         config1['image'] = copy.deepcopy(config['image'])
     if 'input' in config:

--- a/galsim/config/process.py
+++ b/galsim/config/process.py
@@ -130,7 +130,7 @@ def ReadJson(config_file):
         try:
             # cf. http://stackoverflow.com/questions/6921699/can-i-get-json-to-load-into-an-ordereddict-in-python
             config = json.load(f, object_pairs_hook=OrderedDict)
-        except TypeError:
+        except TypeError:  # pragma: no cover
             # for python2.6, json doesn't come with the object_pairs_hook, so
             # try using simplejson, and if that doesn't work, just use a regular dict.
             # Also, it seems that if the above line raises an exception, the file handle
@@ -821,7 +821,7 @@ def MultiProcess(nproc, config, job_func, tasks, item, logger=None,
         results = [ None for k in range(njobs) ]
         for kk in range(njobs):
             res, k, t, proc = results_queue.get()
-            if isinstance(res,Exception):
+            if isinstance(res,Exception):  # pragma: no cover
                 # res is really the exception, e
                 # t is really the traceback
                 # k is the index for the job that failed

--- a/galsim/config/process.py
+++ b/galsim/config/process.py
@@ -358,9 +358,10 @@ def UpdateNProc(nproc, ntot, config, logger=None):
                 logger.debug("ncpu = %d.",nproc)
         except KeyboardInterrupt:
             raise
-        except:
+        except Exception as e:
             if logger:
                 logger.warning("nproc <= 0, but unable to determine number of cpus.")
+                logger.warning("Caught error: %s",e)
                 logger.warning("Using single process")
             nproc = 1
 

--- a/galsim/config/process.py
+++ b/galsim/config/process.py
@@ -493,6 +493,8 @@ def ParseExtendedKey(config, key):
         k = chain.pop(0)
         try: k = int(k)
         except ValueError: pass
+        if k not in d:
+            raise ValueError("Unable to parse extended key %s.  Field %s is invalid."%(key,k))
         d = d[k]
     return d, chain[0]
 

--- a/galsim/config/stamp.py
+++ b/galsim/config/stamp.py
@@ -87,7 +87,7 @@ def BuildStamps(nobjects, config, obj_num=0,
             logger.info(s0 + 'Stamp %d: size = %d x %d, time = %f sec', obj_num, xs, ys, t)
 
     def except_func(logger, proc, k, e, tr):
-        if logger:
+        if logger: # pragma: no cover
             if proc is None: s0 = ''
             else: s0 = '%s: '%proc
             obj_num = jobs[k]['obj_num']
@@ -103,7 +103,7 @@ def BuildStamps(nobjects, config, obj_num=0,
                                          done_func = done_func,
                                          except_func = except_func)
 
-    if not results:
+    if not results:  # pragma: no cover
         images, current_vars = [], []
         if logger:
             logger.error('No images were built.  All were either skipped or had errors.')

--- a/galsim/config/stamp.py
+++ b/galsim/config/stamp.py
@@ -261,7 +261,7 @@ def BuildStamp(config, obj_num=0, xsize=0, ysize=0, do_noise=True, logger=None):
     stamp = config['stamp']
     stamp_type = stamp['type']
     if stamp_type not in valid_stamp_types:
-        raise AttributeErro("Invalid stamp.type=%s."%stamp_type)
+        raise AttributeError("Invalid stamp.type=%s."%stamp_type)
     builder = valid_stamp_types[stamp_type]
 
     # Add 1 to the seed here so the first object has a different rng than the file or image.

--- a/galsim/config/stamp.py
+++ b/galsim/config/stamp.py
@@ -92,7 +92,7 @@ def BuildStamps(nobjects, config, obj_num=0,
             else: s0 = '%s: '%proc
             obj_num = jobs[k]['obj_num']
             logger.error(s0 + 'Exception caught when building stamp %d', obj_num)
-            #logger.error('%s',tr)
+            logger.warning('%s',tr)
             logger.error('Aborting the rest of this image')
 
     # Convert to the tasks structure we need for MultiProcess.

--- a/galsim/config/value.py
+++ b/galsim/config/value.py
@@ -149,7 +149,7 @@ def ParseValue(config, key, base, value_type):
         #print('returned val, safe = ',val_safe)
         if isinstance(val_safe, tuple):
             val, safe = val_safe
-        else:
+        else:  # pragma: no cover
             # If a user-defined type forgot to return safe, just assume safe = False
             # It's an easy mistake to make and the TypeError that gets emitted isn't
             # terribly informative about what the error is.
@@ -228,7 +228,7 @@ def GetCurrentValue(key, config, value_type=None, base=None, return_safe=False):
             # If there are more keys, just set d to the next in the chain.
             try:
                 d = d[k]
-            except (TypeError, KeyError):
+            except (TypeError, KeyError):  # pragma: no cover
                 # TypeError for the case where d is a float or Position2D, so d[k] is invalid.
                 # KeyError for the case where d is a dict, but k is not a valid key.
                 raise ValueError("Invalid key in GetCurrentValue = %s"%key)
@@ -244,7 +244,7 @@ def GetCurrentValue(key, config, value_type=None, base=None, return_safe=False):
         else:
             try:
                 dk = d[k]
-            except (TypeError, KeyError):
+            except (TypeError, KeyError):  # pragma: no cover
                 raise ValueError("Invalid key in GetCurrentValue = %s"%key)
 
             if not isinstance(d[k], dict):
@@ -354,7 +354,7 @@ def CheckAllParams(config, req={}, opt={}, single=[], ignore=[]):
     for (key, value_type) in req.items():
         if key in config:
             get[key] = value_type
-        else:
+        else:  # pragma: no cover
             if 'type' in config:
                 raise AttributeError("Attribute %s is required for type = %s"%(key,config['type']))
             else:
@@ -374,7 +374,7 @@ def CheckAllParams(config, req={}, opt={}, single=[], ignore=[]):
         for (key, value_type) in s.items():
             if key in config:
                 count += 1
-                if count > 1:
+                if count > 1:  # pragma: no cover
                     if 'type' in config:
                         raise AttributeError(
                             "Only one of the attributes %s is allowed for type = %s"%(
@@ -382,7 +382,7 @@ def CheckAllParams(config, req={}, opt={}, single=[], ignore=[]):
                     else:
                         raise AttributeError("Only one of the attributes %s is allowed"%s.keys())
                 get[key] = value_type
-        if count == 0:
+        if count == 0:  # pragma: no cover
             if 'type' in config:
                 raise AttributeError(
                     "One of the attributes %s is required for type = %s"%(s.keys(),config['type']))
@@ -471,7 +471,7 @@ def _GetAngleValue(param):
     except KeyboardInterrupt:
         raise
     except Exception as e:
-        raise AttributeError("Unable to parse %s as an Angle."%param)
+        raise AttributeError("Unable to parse %s as an Angle.  Caught %s"%(param,e))
 
 
 def _GetPositionValue(param):
@@ -489,8 +489,8 @@ def _GetPositionValue(param):
             y = float(y.strip())
         except KeyboardInterrupt:
             raise
-        except:
-            raise AttributeError("Unable to parse %s as a PositionD."%param)
+        except Exception as e:
+            raise AttributeError("Unable to parse %s as a PositionD.  Caught %s"%(param,e))
     return galsim.PositionD(x,y)
 
 
@@ -508,16 +508,16 @@ def _GetBoolValue(param):
                 return val
             except KeyboardInterrupt:
                 raise
-            except:
-                raise AttributeError("Unable to parse %s as a bool."%param)
+            except Exception as e:
+                raise AttributeError("Unable to parse %s as a bool.  Caught %s"%(param,e))
     else:
         try:
             val = bool(param)
             return val
         except KeyboardInterrupt:
             raise
-        except:
-            raise AttributeError("Unable to parse %s as a bool."%param)
+        except Exception as e:
+            raise AttributeError("Unable to parse %s as a bool.  Caught %s"%(param,e))
 
 
 

--- a/galsim/config/value_eval.py
+++ b/galsim/config/value_eval.py
@@ -18,6 +18,7 @@
 from __future__ import print_function
 
 import galsim
+import numpy as np
 
 # This file handles the parsing for the special Eval type.
 

--- a/galsim/config/wcs.py
+++ b/galsim/config/wcs.py
@@ -77,7 +77,7 @@ class WCSBuilder(object):
 
         @returns the constructed WCS object.
         """
-        raise NotImplemented("The %s class has not overridden buildWCS"%self.__class__)
+        raise NotImplementedError("The %s class has not overridden buildWCS"%self.__class__)
 
 
 class SimpleWCSBuilder(WCSBuilder):

--- a/galsim/correlatednoise.py
+++ b/galsim/correlatednoise.py
@@ -656,7 +656,7 @@ class _BaseCorrelatedNoise(object):
         @returns an Image of the correlation function.
         """
         # Check for obsolete dx parameter
-        if dx is not None and scale is None: # pragma : no cover
+        if dx is not None and scale is None: # pragma: no cover
             from galsim.deprecated import depr
             depr('dx', 1.1, 'scale')
             scale = dx
@@ -1118,7 +1118,7 @@ class CorrelatedNoise(_BaseCorrelatedNoise):
     def __init__(self, image, rng=None, scale=None, wcs=None, x_interpolant=None,
         correct_periodicity=True, subtract_mean=False, gsparams=None, dx=None):
         # Check for obsolete dx parameter
-        if dx is not None and scale==0.: # pragma : no cover
+        if dx is not None and scale==0.: # pragma: no cover
             from galsim.deprecated import depr
             depr('dx', 1.1, 'scale')
             scale = dx
@@ -1356,7 +1356,7 @@ def getCOSMOSNoise(file_name=None, rng=None, cosmos_scale=0.03, variance=0., x_i
     The FITS file `out.fits` should then contain an image of randomly-generated, COSMOS-like noise.
     """
     # Check for obsolete dx_cosmos parameter
-    if dx_cosmos is not None and cosmos_scale==0.03: # pragma : no cover
+    if dx_cosmos is not None and cosmos_scale==0.03: # pragma: no cover
         from galsim.deprecated import depr
         depr('dx_cosmos', 1.1, 'cosmos_scale')
         cosmos_scale = dx_cosmos

--- a/galsim/correlatednoise.py
+++ b/galsim/correlatednoise.py
@@ -656,7 +656,7 @@ class _BaseCorrelatedNoise(object):
         @returns an Image of the correlation function.
         """
         # Check for obsolete dx parameter
-        if dx is not None and scale is None:
+        if dx is not None and scale is None: # pragma : no cover
             from galsim.deprecated import depr
             depr('dx', 1.1, 'scale')
             scale = dx
@@ -1118,7 +1118,7 @@ class CorrelatedNoise(_BaseCorrelatedNoise):
     def __init__(self, image, rng=None, scale=None, wcs=None, x_interpolant=None,
         correct_periodicity=True, subtract_mean=False, gsparams=None, dx=None):
         # Check for obsolete dx parameter
-        if dx is not None and scale==0.:
+        if dx is not None and scale==0.: # pragma : no cover
             from galsim.deprecated import depr
             depr('dx', 1.1, 'scale')
             scale = dx
@@ -1356,7 +1356,7 @@ def getCOSMOSNoise(file_name=None, rng=None, cosmos_scale=0.03, variance=0., x_i
     The FITS file `out.fits` should then contain an image of randomly-generated, COSMOS-like noise.
     """
     # Check for obsolete dx_cosmos parameter
-    if dx_cosmos is not None and cosmos_scale==0.03:
+    if dx_cosmos is not None and cosmos_scale==0.03: # pragma : no cover
         from galsim.deprecated import depr
         depr('dx_cosmos', 1.1, 'cosmos_scale')
         cosmos_scale = dx_cosmos

--- a/galsim/des/des_meds.py
+++ b/galsim/des/des_meds.py
@@ -331,7 +331,7 @@ def WriteMEDS(obj_list, file_name, clobber=True):
     try:
         object_data = pyfits.BinTableHDU.from_columns(cols)
         object_data.name = 'object_data'
-    except:
+    except:  # pragma: no cover
         object_data = pyfits.new_table(pyfits.ColDefs(cols))
         object_data.update_ext_name('object_data')
 
@@ -356,7 +356,7 @@ def WriteMEDS(obj_list, file_name, clobber=True):
     try:
         image_info = pyfits.BinTableHDU.from_columns(cols)
         image_info.name = 'image_info'
-    except:
+    except:  # pragma: no cover
         image_info = pyfits.new_table(pyfits.ColDefs(cols))
         image_info.update_ext_name('image_info')
 
@@ -388,7 +388,7 @@ def WriteMEDS(obj_list, file_name, clobber=True):
     try:
         metadata = pyfits.BinTableHDU.from_columns(cols)
         metadata.name = 'metadata'
-    except:
+    except:  # pragma: no cover
         metadata = pyfits.new_table(pyfits.ColDefs(cols))
         metadata.update_ext_name('metadata')
 

--- a/galsim/des/des_psfex.py
+++ b/galsim/des/des_psfex.py
@@ -269,7 +269,7 @@ class DES_PSFEx(object):
         # This brings if from image coordinates to world coordinates.
         if self.wcs:
             psf = self.wcs.toWorld(psf, image_pos=image_pos)
-        elif pixel_scale:
+        elif pixel_scale:  # pragma: no cover
             depr('pixel_scale',1.1,'wcs=PixelScale(pixel_scale) in the constructor for DES_PSFEx')
             psf = galsim.PixelScale(pixel_scale).toWorld(psf)
 

--- a/galsim/des/des_shapelet.py
+++ b/galsim/des/des_shapelet.py
@@ -90,10 +90,11 @@ class DES_Shapelet(object):
 
         if file_type == 'FITS':
             self.read_fits()
-        else:
+        else:  # pragma: no cover
             self.read_ascii()
 
-    def read_ascii(self):
+    # We haven't used these for a long time, so this is at best of historical interest...
+    def read_ascii(self):  # pragma: no cover
         """Read in a DES_Shapelet stored using the the ASCII-file version.
         """
         fin = open(self.file_name, 'r')

--- a/galsim/fits.py
+++ b/galsim/fits.py
@@ -94,7 +94,9 @@ class _ReadFile:
         # done with hdu_list.
         return hdu_list, fin
 
-    def pyfits_open(self, file):
+    # Note: the above gzip_in_mem function succeeds on travis, so the rest don't get run.
+    # Omit them from the coverage test.
+    def pyfits_open(self, file):  # pragma: no cover
         from galsim._pyfits import pyfits
         # This usually works, although pyfits internally may (depending on the version)
         # use a temporary file, which is why we prefer the above in-memory code if it works.
@@ -102,7 +104,7 @@ class _ReadFile:
         hdu_list = pyfits.open(file, 'readonly')
         return hdu_list, None
 
-    def gzip_tmp(self, file):
+    def gzip_tmp(self, file):  # pragma: no cover
         import gzip
         from galsim._pyfits import pyfits
         # Finally, just in case, if everything else failed, here is an implementation that 
@@ -140,7 +142,7 @@ class _ReadFile:
         hdu = hdu_list[0]
         return hdu_list, fin
 
-    def bz2_tmp(self, file):
+    def bz2_tmp(self, file):  # pragma: no cover
         import bz2
         from galsim._pyfits import pyfits
         fin = bz2.BZ2File(file, 'rb')
@@ -222,7 +224,7 @@ _read_file = _ReadFile()
 class _WriteFile:
 
     # There are several methods available for each of gzip and bzip2.  Each is its own function.
-    def gzip_call2(self, hdu_list, file):
+    def gzip_call2(self, hdu_list, file):  # pragma: no cover
         root, ext = os.path.splitext(file)
         import subprocess
         if os.path.isfile(root):
@@ -248,7 +250,7 @@ class _WriteFile:
             p.communicate()
             assert p.returncode == 0
  
-    def gzip_in_mem(self, hdu_list, file):
+    def gzip_in_mem(self, hdu_list, file):  # pragma: no cover
         import gzip
         import io
         # The compression routines work better if we first write to an internal buffer
@@ -261,7 +263,7 @@ class _WriteFile:
         with gzip.open(file, 'wb') as fout:
             fout.write(data)
 
-    def gzip_tmp(self, hdu_list, file):
+    def gzip_tmp(self, hdu_list, file):  # pragma: no cover
         import gzip
         # However, pyfits versions before 2.3 do not support writing to a buffer, so the
         # above code will fail.  We need to use a temporary in that case.
@@ -276,7 +278,7 @@ class _WriteFile:
         with gzip.open(file, 'wb') as fout:
             fout.write(data)
 
-    def bzip2_call2(self, hdu_list, file):
+    def bzip2_call2(self, hdu_list, file):  # pragma: no cover
         root, ext = os.path.splitext(file)
         import subprocess
         if os.path.isfile(root) or ext != '.bz2':
@@ -302,7 +304,7 @@ class _WriteFile:
             p.communicate()
             assert p.returncode == 0
  
-    def bz2_in_mem(self, hdu_list, file):
+    def bz2_in_mem(self, hdu_list, file):  # pragma: no cover
         import bz2
         import io
         buf = io.BytesIO()
@@ -311,7 +313,7 @@ class _WriteFile:
         with bz2.BZ2File(file, 'wb') as fout:
             fout.write(data)
 
-    def bz2_tmp(self, hdu_list, file):
+    def bz2_tmp(self, hdu_list, file):  # pragma: no cover
         import bz2
         tmp = file + '.tmp'
         while os.path.isfile(tmp):
@@ -360,7 +362,7 @@ class _WriteFile:
             while self.gz_index < len(self.gz_methods):
                 try:
                     return self.gz(hdu_list, file)
-                except:
+                except Exception:
                     self.gz_index += 1
                     self.gz = self.gz_methods[self.gz_index]
             raise RuntimeError("None of the options for gunzipping were successful.")
@@ -368,7 +370,7 @@ class _WriteFile:
             while self.bz2_index < len(self.bz2_methods):
                 try:
                     return self.bz2(hdu_list, file)
-                except:
+                except Exception:
                     self.bz2_index += 1
                     self.bz2 = self.bz2_methods[self.bz2_index]
             raise RuntimeError("None of the options for bunzipping were successful.")
@@ -433,7 +435,7 @@ def _check_hdu(hdu, pyfits_compress):
 
     # Check that the specified compression is right for the given hdu type.
     if pyfits_compress:
-        if not isinstance(hdu, pyfits.CompImageHDU):
+        if not isinstance(hdu, pyfits.CompImageHDU):  # pragma: no cover
             if isinstance(hdu, pyfits.BinTableHDU):
                 raise IOError('Expecting a CompImageHDU, but got a BinTableHDU\n' +
                     'Probably your pyfits installation does not have the pyfitsComp module '+

--- a/galsim/fitswcs.py
+++ b/galsim/fitswcs.py
@@ -650,7 +650,9 @@ class PyAstWCS(galsim.wcs.CelestialWCS):
             galsim.fits.closeHDUList(hdu_list, fin)
 
 
-class WcsToolsWCS(galsim.wcs.CelestialWCS):
+# I can't figure out how to get wcstools installed in the travis environment (cf. .travis.yml).
+# So until that gets resolved, we omit this class from the coverage report.
+class WcsToolsWCS(galsim.wcs.CelestialWCS): # pragma : no cover
     """This WCS uses wcstools executables to perform the appropriate WCS transformations
     for a given FITS file.  It requires wcstools command line functions to be installed.
 

--- a/galsim/fitswcs.py
+++ b/galsim/fitswcs.py
@@ -201,7 +201,7 @@ class AstropyWCS(galsim.wcs.CelestialWCS):
         if astropy.__version__ < '1.0.1':
             ctype1 = header.get('CTYPE1', 'RA---')
             ctype2 = header.get('CTYPE2', 'DEC--')
-            if ctype1.startswith('DEC--') and ctype2.startswith('RA---'):
+            if ctype1.startswith('DEC--') and ctype2.startswith('RA---'): # pragma: no cover
                 for key1, key2 in [ ('CTYPE1', 'CTYPE2'),
                                     ('CRVAL1', 'CRVAL2'),
                                     ('CDELT1', 'CDELT2'),
@@ -257,7 +257,7 @@ class AstropyWCS(galsim.wcs.CelestialWCS):
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
                 xy = self._wcs.all_world2pix(rd, 1, ra_dec_order=True)[0]
-        else:
+        else: # pragma: no cover
             # This section is basically a copy of astropy.wcs's _all_world2pix function, but
             # simplified a bit to remove some features we don't need, and with corrections
             # to make it work correctly.
@@ -652,7 +652,7 @@ class PyAstWCS(galsim.wcs.CelestialWCS):
 
 # I can't figure out how to get wcstools installed in the travis environment (cf. .travis.yml).
 # So until that gets resolved, we omit this class from the coverage report.
-class WcsToolsWCS(galsim.wcs.CelestialWCS): # pragma : no cover
+class WcsToolsWCS(galsim.wcs.CelestialWCS): # pragma: no cover
     """This WCS uses wcstools executables to perform the appropriate WCS transformations
     for a given FITS file.  It requires wcstools command line functions to be installed.
 

--- a/galsim/fitswcs.py
+++ b/galsim/fitswcs.py
@@ -198,10 +198,10 @@ class AstropyWCS(galsim.wcs.CelestialWCS):
         # Older versions of astropy had trouble with files where the axes were swapped.
         # So fix them if necessary.  I know >= 1.0.1 works.  0.2.4 and 0.3.1 both fail.
         import astropy
-        if astropy.__version__ < '1.0.1':
+        if astropy.__version__ < '1.0.1':  # pragma: no cover
             ctype1 = header.get('CTYPE1', 'RA---')
             ctype2 = header.get('CTYPE2', 'DEC--')
-            if ctype1.startswith('DEC--') and ctype2.startswith('RA---'): # pragma: no cover
+            if ctype1.startswith('DEC--') and ctype2.startswith('RA---'):
                 for key1, key2 in [ ('CTYPE1', 'CTYPE2'),
                                     ('CRVAL1', 'CRVAL2'),
                                     ('CDELT1', 'CDELT2'),
@@ -222,7 +222,7 @@ class AstropyWCS(galsim.wcs.CelestialWCS):
             # cf. https://github.com/astropy/astropy/pull/1463
             # This has been fixed for a while now, but leave in this workaround for old versions.
             ra, dec = self._wcs.all_pix2world(x1, y1, 1, ra_dec_order=True)
-        except AttributeError:
+        except AttributeError:  # pragma: no cover
             # If that failed, then we should be on version < 1.0.1, and the header should have
             # been fixed above by _fix_header.  So this should work correctly.
             ra, dec = self._wcs.all_pix2world(x1, y1, 1)

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -317,7 +317,7 @@ class Image(with_metaclass(MetaImage, object)):
             try:
                 ncol = int(ncol)
                 nrow = int(nrow)
-            except:
+            except Exception:
                 raise TypeError("Cannot parse ncol, nrow as integers")
             self.image = _galsim.ImageAlloc[self.dtype](ncol, nrow)
             if init_value is not None:

--- a/galsim/interpolatedimage.py
+++ b/galsim/interpolatedimage.py
@@ -260,7 +260,7 @@ class InterpolatedImage(GSObject):
                  hdu=None):
 
         # Check for obsolete dx parameter
-        if dx is not None and scale is None:
+        if dx is not None and scale is None: # pragma : no cover
             from galsim.deprecated import depr
             depr('dx', 1.1, 'scale')
             scale = dx

--- a/galsim/interpolatedimage.py
+++ b/galsim/interpolatedimage.py
@@ -260,7 +260,7 @@ class InterpolatedImage(GSObject):
                  hdu=None):
 
         # Check for obsolete dx parameter
-        if dx is not None and scale is None: # pragma : no cover
+        if dx is not None and scale is None: # pragma: no cover
             from galsim.deprecated import depr
             depr('dx', 1.1, 'scale')
             scale = dx

--- a/galsim/nfw_halo.py
+++ b/galsim/nfw_halo.py
@@ -478,8 +478,8 @@ class NFWHalo(object):
         g = self.__gamma(r, ks)
         kappa = self.__kappa(r, ks)
 
-        g /= 1 - kappa
         mu = 1. / ( (1.-kappa)**2 - g**2 )
+        g /= 1 - kappa
         # Get the tangential shear (no x component)
         dx = pos_x - self.halo_pos.x
         dy = pos_y - self.halo_pos.y

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -1351,7 +1351,7 @@ class OpticalPSF(GSObject):
                  pupil_plane_scale=None, pupil_plane_size=None,
                  pupil_angle=0.*galsim.degrees, scale_unit=galsim.arcsec, gsparams=None,
                  suppress_warning=False, max_size=None):
-        if max_size is not None: # pragma : no cover
+        if max_size is not None: # pragma: no cover
             from .deprecated import depr
             depr('max_size', 1.4, '',
                  "The max_size keyword has been removed.  In its place, the pad_factor keyword can"

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -259,7 +259,7 @@ class Aperture(object):
         else:  # Use geometric parameters.
             if pupil_plane_scale is not None:
                 # Check input scale and warn if looks suspicious.
-                if pupil_plane_scale > good_pupil_scale:
+                if pupil_plane_scale > good_pupil_scale:  # pragma: no cover
                     import warnings
                     ratio = good_pupil_scale / pupil_plane_scale
                     warnings.warn("Input pupil_plane_scale may be too large for good sampling.\n"
@@ -270,7 +270,7 @@ class Aperture(object):
                 pupil_plane_scale = good_pupil_scale
             if pupil_plane_size is not None:
                 # Check input size and warn if looks suspicious
-                if pupil_plane_size < good_pupil_size:
+                if pupil_plane_size < good_pupil_size:  # pragma: no cover
                     import warnings
                     ratio = good_pupil_size / pupil_plane_size
                     warnings.warn("Input pupil_plane_size may be too small for good focal-plane"
@@ -397,7 +397,7 @@ class Aperture(object):
             self.pupil_plane_size = self.pupil_plane_scale * self.npix
 
         # Check sampling interval and warn if it's not good enough.
-        if self.pupil_plane_scale > good_pupil_scale:
+        if self.pupil_plane_scale > good_pupil_scale:  # pragma: no cover
             import warnings
             ratio = self.pupil_plane_scale / good_pupil_scale
             warnings.warn("Input pupil plane image may not be sampled well enough!\n"
@@ -675,7 +675,7 @@ class PhaseScreenList(object):
             return cls(self._layers[index])
         elif isinstance(index, numbers.Integral):
             return self._layers[index]
-        else:
+        else:  # pragma: no cover
             msg = "{cls.__name__} indices must be integers"
             raise TypeError(msg.format(cls=cls))
 

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -1351,7 +1351,7 @@ class OpticalPSF(GSObject):
                  pupil_plane_scale=None, pupil_plane_size=None,
                  pupil_angle=0.*galsim.degrees, scale_unit=galsim.arcsec, gsparams=None,
                  suppress_warning=False, max_size=None):
-        if max_size is not None:
+        if max_size is not None: # pragma : no cover
             from .deprecated import depr
             depr('max_size', 1.4, '',
                  "The max_size keyword has been removed.  In its place, the pad_factor keyword can"

--- a/galsim/random.py
+++ b/galsim/random.py
@@ -251,7 +251,7 @@ class DistDeviate(_galsim.BaseDeviate):
         # lseed is an obsolete synonym for seed
         # I think this was the only place that the name lseed was actually used in the docs.
         # so we keep it for now for backwards compatibility.
-        if lseed is not None:
+        if lseed is not None: # pragma : no cover
             from galsim.deprecated import depr
             depr('lseed', 1.1, 'seed')
             seed = lseed

--- a/galsim/random.py
+++ b/galsim/random.py
@@ -251,7 +251,7 @@ class DistDeviate(_galsim.BaseDeviate):
         # lseed is an obsolete synonym for seed
         # I think this was the only place that the name lseed was actually used in the docs.
         # so we keep it for now for backwards compatibility.
-        if lseed is not None: # pragma : no cover
+        if lseed is not None: # pragma: no cover
             from galsim.deprecated import depr
             depr('lseed', 1.1, 'seed')
             seed = lseed

--- a/galsim/real.py
+++ b/galsim/real.py
@@ -546,7 +546,7 @@ class RealGalaxyCatalog(object):
         else:
             self.loaded_lock.acquire()
             # Check again in case two processes both hit the else at the same time.
-            if file_name in self.loaded_files:
+            if file_name in self.loaded_files: # pragma : no cover
                 if self.logger:
                     self.logger.debug('RealGalaxyCatalog: File %s is already open',file_name)
                 f = self.loaded_files[file_name]

--- a/galsim/real.py
+++ b/galsim/real.py
@@ -766,7 +766,7 @@ def simReal(real_galaxy, target_PSF, target_pixel_scale, g1=0.0, g2=0.0, rotatio
     return image
 
 def _parse_files_dirs(file_name, image_dir, dir, noise_dir, sample):
-    if image_dir is not None or noise_dir is not None:
+    if image_dir is not None or noise_dir is not None:  # pragma : no cover
         from .deprecated import depr
         if image_dir is not None:
             depr('image_dir', 1.4, 'dir')

--- a/galsim/real.py
+++ b/galsim/real.py
@@ -546,7 +546,7 @@ class RealGalaxyCatalog(object):
         else:
             self.loaded_lock.acquire()
             # Check again in case two processes both hit the else at the same time.
-            if file_name in self.loaded_files: # pragma : no cover
+            if file_name in self.loaded_files: # pragma: no cover
                 if self.logger:
                     self.logger.debug('RealGalaxyCatalog: File %s is already open',file_name)
                 f = self.loaded_files[file_name]
@@ -766,7 +766,7 @@ def simReal(real_galaxy, target_PSF, target_pixel_scale, g1=0.0, g2=0.0, rotatio
     return image
 
 def _parse_files_dirs(file_name, image_dir, dir, noise_dir, sample):
-    if image_dir is not None or noise_dir is not None:  # pragma : no cover
+    if image_dir is not None or noise_dir is not None:  # pragma: no cover
         from .deprecated import depr
         if image_dir is not None:
             depr('image_dir', 1.4, 'dir')

--- a/galsim/scene.py
+++ b/galsim/scene.py
@@ -168,7 +168,7 @@ class COSMOSCatalog(object):
             raise ValueError("Cannot specify both the sample and file_name!")
 
         # Check for deprecated exclude_bad or exclude_fail args.
-        if exclude_bad is not None or exclude_fail is not None: # pragma : no cover
+        if exclude_bad is not None or exclude_fail is not None: # pragma: no cover
             from .deprecated import depr
             if exclude_bad is not None:
                 depr('exclude_bad', 1.4, 'exclusion_level')

--- a/galsim/scene.py
+++ b/galsim/scene.py
@@ -215,7 +215,7 @@ class COSMOSCatalog(object):
                     self.param_cat = fits[1].data
                 # Check if this was the right file.  It should have a 'fit_status' column.
                 self.param_cat['fit_status']
-            except KeyError:
+            except KeyError:  # pragma: no cover
                 # But if that doesn't work, then the name might be the name of the real catalog,
                 # so try adding _fits to it as above.
                 k = full_file_name.find('.fits')
@@ -224,7 +224,7 @@ class COSMOSCatalog(object):
                     self.param_cat = fits[1].data
 
         # Check for the old-style parameter catalog
-        if 'fit_dvc_btt' not in self.param_cat.dtype.names:
+        if 'fit_dvc_btt' not in self.param_cat.dtype.names:  # pragma: no cover
             # This will fail if they try to make a parametric galaxy.
             # Don't raise an exception here, since they might not care about that.
             # But give them some guidance about the error they will get if they
@@ -344,7 +344,7 @@ class COSMOSCatalog(object):
 
             # Some fit parameters can indicate a likely sky subtraction error: very high sersic n
             # AND abnormally large half-light radius (>1 arcsec).
-            if 'hlr' not in self.param_cat.dtype.names:
+            if 'hlr' not in self.param_cat.dtype.names:  # pragma: no cover
                 # This is the circularized HLR in arcsec, which we have to compute from the stored
                 # parametric fits.
                 hlr = cosmos_pix_scale * self.param_cat['sersicfit'][:,1] * \
@@ -361,7 +361,7 @@ class COSMOSCatalog(object):
                 mask &= ( np.abs(self.selection_cat['dmag']) < 0.8)
 
         if min_hlr > 0. or max_hlr > 0. or min_flux > 0. or max_flux > 0.:
-            if 'hlr' not in self.param_cat.dtype.names:
+            if 'hlr' not in self.param_cat.dtype.names:  # pragma: no cover
                 # Check if they have a new version of the selection catalog that has precomputed
                 # fluxes etc.  If not, do the calculations, which include some approximations in
                 # getting the flux.
@@ -524,7 +524,7 @@ class COSMOSCatalog(object):
             # whether we're using the old or new catalog (the latter of which has a lot of
             # precomputations done).  Just in case, let's check here, though it does seem like a bit
             # of overkill to emit this warning each time.
-            if 'hlr' not in self.param_cat.dtype.names:
+            if 'hlr' not in self.param_cat.dtype.names:  # pragma: no cover
                 import warnings
                 warnings.warn(
                     'You seem to have an old version of the COSMOS parameter file. '+
@@ -639,7 +639,7 @@ class COSMOSCatalog(object):
         # the last 8 are for the bulge, with n=4.
         bparams = record['bulgefit']
         sparams = record['sersicfit']
-        if 'hlr' not in record:
+        if 'hlr' not in record:  # pragma: no cover
             # This code is here for backwards compatibility; if they have an old version of the
             # catalog, then we have to do all calculations.
             #
@@ -688,7 +688,7 @@ class COSMOSCatalog(object):
             bulge_beta = bparams[15]*galsim.radians
             disk_q = bparams[3]
             disk_beta = bparams[7]*galsim.radians
-            if 'hlr' not in record:
+            if 'hlr' not in record:  # pragma: no cover
                 # If we're supposed to use the 2-component fits, get all the parameters.
                 # We have to convert from the stored half-light radius along the major axis, to an
                 # azimuthally averaged one (multiplying by sqrt(bulge_q)).  We also have to convert
@@ -755,7 +755,7 @@ class COSMOSCatalog(object):
             gal_q = sparams[3]
             gal_beta = sparams[7]*galsim.radians
 
-            if 'hlr' not in record:
+            if 'hlr' not in record:  # pragma: no cover
                 gal_hlr = cosmos_pix_scale*np.sqrt(gal_q)*sparams[1]
                 # Below is the calculation of the full Sersic n-dependent quantity that goes into
                 # the conversion from surface brightness to flux, which here we're calling

--- a/galsim/scene.py
+++ b/galsim/scene.py
@@ -168,7 +168,7 @@ class COSMOSCatalog(object):
             raise ValueError("Cannot specify both the sample and file_name!")
 
         # Check for deprecated exclude_bad or exclude_fail args.
-        if exclude_bad is not None or exclude_fail is not None:
+        if exclude_bad is not None or exclude_fail is not None: # pragma : no cover
             from .deprecated import depr
             if exclude_bad is not None:
                 depr('exclude_bad', 1.4, 'exclusion_level')

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -179,7 +179,7 @@ class SimpleGenerator:
     def __init__(self, obj): self._obj = obj
     def __call__(self): return self._obj
 
-class AttributeDict(object): # pragma : no cover
+class AttributeDict(object): # pragma: no cover
     """Dictionary class that allows for easy initialization and refs to key values via attributes.
 
     NOTE: Modified a little from Jim's bot.git AttributeDict class so that tab completion now works
@@ -460,7 +460,7 @@ def thin_tabulated_values(x, f, rel_err=1.e-4, trim_zeros=True, preserve_range=T
 # algorithm, since it keeps fewer sample locations for a given rel_err than the old algorithm.
 # On the other hand, the old algorithm can be quite a bit faster, being O(N), not O(N^2), so
 # we retain the old algorithm here in case we want to re-enable it for certain applications.
-def old_thin_tabulated_values(x, f, rel_err=1.e-4, preserve_range=False): # pragma : no cover
+def old_thin_tabulated_values(x, f, rel_err=1.e-4, preserve_range=False): # pragma: no cover
     """
     Remove items from a set of tabulated f(x) values so that the error in the integral is still
     accurate to a given relative accuracy.
@@ -565,7 +565,7 @@ def old_thin_tabulated_values(x, f, rel_err=1.e-4, preserve_range=False): # prag
     return newx, newf
 
 
-def _gammafn(x):  # pragma : no cover
+def _gammafn(x):  # pragma: no cover
     """
     This code is not currently used, but in case we need a gamma function at some point, it will be
     here in the utilities module.

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -872,7 +872,7 @@ def interleaveImages(im_list, N, offsets, add_flux=True, suppress_warnings=False
     orig = im_list[0].origin()
     img.setOrigin(orig)
     for im in im_list[1:]:
-        if not im.origin()==orig:
+        if not im.origin()==orig:  # pragma: no cover
             import warnings
             warnings.warn("Images in `im_list' have multiple values for origin. Assigning the \
             origin of the first Image instance in 'im_list' to the interleaved image.")
@@ -1015,7 +1015,7 @@ def lod_to_dol(lod, N=None):
                 out[k] = v[0]
             except TypeError:  # Value is not list-like, so broadcast it in its entirety.
                 out[k] = v
-            except:
+            except Exception:
                 raise "Cannot broadcast kwarg {0}={1}".format(k, v)
         yield out
 

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -179,7 +179,7 @@ class SimpleGenerator:
     def __init__(self, obj): self._obj = obj
     def __call__(self): return self._obj
 
-class AttributeDict(object):
+class AttributeDict(object): # pragma : no cover
     """Dictionary class that allows for easy initialization and refs to key values via attributes.
 
     NOTE: Modified a little from Jim's bot.git AttributeDict class so that tab completion now works
@@ -460,7 +460,7 @@ def thin_tabulated_values(x, f, rel_err=1.e-4, trim_zeros=True, preserve_range=T
 # algorithm, since it keeps fewer sample locations for a given rel_err than the old algorithm.
 # On the other hand, the old algorithm can be quite a bit faster, being O(N), not O(N^2), so
 # we retain the old algorithm here in case we want to re-enable it for certain applications.
-def old_thin_tabulated_values(x, f, rel_err=1.e-4, preserve_range=False):
+def old_thin_tabulated_values(x, f, rel_err=1.e-4, preserve_range=False): # pragma : no cover
     """
     Remove items from a set of tabulated f(x) values so that the error in the integral is still
     accurate to a given relative accuracy.
@@ -565,7 +565,7 @@ def old_thin_tabulated_values(x, f, rel_err=1.e-4, preserve_range=False):
     return newx, newf
 
 
-def _gammafn(x):
+def _gammafn(x):  # pragma : no cover
     """
     This code is not currently used, but in case we need a gamma function at some point, it will be
     here in the utilities module.

--- a/galsim/wcs.py
+++ b/galsim/wcs.py
@@ -616,7 +616,7 @@ def readFromFitsHeader(header):
     elif 'CTYPE1' in header:
         try:
             wcs = galsim.FitsWCS(header=header, suppress_warning=True)
-        except:
+        except:  # pragma: no cover
             # This shouldn't ever happen, but just in case...
             wcs = galsim.PixelScale(1.)
     else:
@@ -1874,18 +1874,18 @@ def _writeFuncToHeader(func, letter, header):
         # In particular, marshal can serialize arbitrary code. (!)
         try:
             import cPickle as pickle
-        except:
+        except ImportError:
             import pickle
         import types, marshal, base64
         if type(func) == types.FunctionType:
             try:
-                # Python3
+                # Python3 and usually Python2
                 code = marshal.dumps(func.__code__)
                 name = func.__name__
                 defaults = func.__defaults__
                 closure = func.__closure__
-            except:
-                # Python2
+            except:  # pragma: no cover
+                # Older Python2 syntax, just in case.
                 code = marshal.dumps(func.func_code)
                 name = func.func_name
                 defaults = func.func_defaults
@@ -1953,7 +1953,7 @@ def _readFuncFromHeader(letter, header):
     # This undoes the process of _writeFuncToHeader.  See the comments in that code for details.
     try:
         import cPickle as pickle
-    except:
+    except ImportError:
         import pickle
     import types, marshal, base64, types
     if 'GS_'+letter+'_STR' in header:

--- a/galsim/wfirst/wfirst_psfs.py
+++ b/galsim/wfirst/wfirst_psfs.py
@@ -368,7 +368,7 @@ def loadPSFImages(filename):
     try:
         # In python3, convert from bytes to str
         bp_list = [ str(bp.decode()) for bp in bp_list ]
-    except:
+    except:  # pragma: no cover
         pass
     SCA_list = list(metadata_hdu.data.SCA)
     galsim.fits.closeHDUList(hdu_list, fin)

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -1,6 +1,8 @@
 [run]
 branch = True
 
+include = *galsim/*
+
 omit =
     # Tests here require the DM stack, so don't include them in travis coverage tests.
     *lsst/*
@@ -37,4 +39,3 @@ exclude_lines =
     if __name__ == .__main__.:
     except KeyboardInterrupt:
 
-show_missing = True

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -20,13 +20,21 @@ exclude_lines =
     # Don't complain about missing debug-only code:
     def __repr__
     if self\.debug
+    logger.debug
 
-    # Don't complain if tests don't hit defensive assertion code:
+    # Don't complain if tests don't hit defensive checks of user input
     raise AssertionError
     raise NotImplementedError
+    raise ValueError
+    raise RuntimeError
+    raise TypeError
+    raise AttributeError
+    raise IndexError
 
     # Don't complain if non-runnable code isn't run:
     if False:
     if 0:
     if __name__ == .__main__.:
+    except KeyboardInterrupt:
 
+show_missing = True

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -32,10 +32,28 @@ exclude_lines =
     raise TypeError
     raise AttributeError
     raise IndexError
+    raise IOError
+    raise KeyError
+
+    # Don't complain about not hitting warning code
+    if suppress_warnings is False:
+    import warnings
+    warnings.warn
 
     # Don't complain if non-runnable code isn't run:
     if False:
     if 0:
     if __name__ == .__main__.:
+
+    # Don't complain about exceptional circumstances not under control of the test suite
     except KeyboardInterrupt:
+    except IOError:
+    except OSError:
+
+    # Or code for special cases of older versions of things.
+    except ImportError:
+    if pyfits_version
+
+    # These are usually for dealing with bad user input, so skip them too.
+    except Exception
 

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -46,12 +46,12 @@ exclude_lines =
     if __name__ == .__main__.:
 
     # Don't complain about exceptional circumstances not under control of the test suite
-    except KeyboardInterrupt:
-    except IOError:
-    except OSError:
+    except KeyboardInterrupt
+    except IOError
+    except OSError
 
     # Or code for special cases of older versions of things.
-    except ImportError:
+    except ImportError
     if .*pyfits_version
 
     # These are usually for dealing with bad user input, so skip them too.

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -1,0 +1,32 @@
+[run]
+branch = True
+
+omit =
+    # Tests here require the DM stack, so don't include them in travis coverage tests.
+    *lsst/*
+
+    # These are mostly still tested, but we don't really care if the tests are complete.
+    *deprecated/*
+
+# Without this, coverage misses anything that is only run in multiprocessing mode.
+concurrency = multiprocessing
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # If you put this in a comment, you can manually exclude code from being covered.
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if False:
+    if 0:
+    if __name__ == .__main__.:
+

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -34,6 +34,7 @@ exclude_lines =
     raise IndexError
     raise IOError
     raise KeyError
+    raise MemoryError
 
     # Don't complain about not hitting warning code
     if suppress_warnings is False:

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -52,7 +52,7 @@ exclude_lines =
 
     # Or code for special cases of older versions of things.
     except ImportError:
-    if pyfits_version
+    if .*pyfits_version
 
     # These are usually for dealing with bad user input, so skip them too.
     except Exception

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,1 +1,2 @@
 tests.log
+.coverage

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -40,7 +40,7 @@ def run_tests(target, source, env):
     # We only run nosetests if we found nosetests in the path.
     if env['NOSETESTS']:
         print 'Using nosetests from: ',env['NOSETESTS']
-        cmd = env['NOSETESTS']
+        cmd = env['NOSETESTS'] + ' test*.py'
         # Account for SIP on El Capitan
         cmd = PrependLibraryPaths(cmd,env)
         if env['NOSETESTSVERSION'] >= '1.1' and env.GetOption('num_jobs') > 1:

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -40,7 +40,7 @@ def run_tests(target, source, env):
     # We only run nosetests if we found nosetests in the path.
     if env['NOSETESTS']:
         print 'Using nosetests from: ',env['NOSETESTS']
-        cmd = env['NOSETESTS'] + ' test*.py'
+        cmd = env['NOSETESTS']
         # Account for SIP on El Capitan
         cmd = PrependLibraryPaths(cmd,env)
         if env['NOSETESTSVERSION'] >= '1.1' and env.GetOption('num_jobs') > 1:
@@ -57,6 +57,7 @@ def run_tests(target, source, env):
             print '    scons tests -j1'
         else:
             print 'nosetests is version %s'%env['NOSETESTSVERSION']
+        cmd += ' test*.py'
         print '\nStarting python tests...'
         log.write('Nosetests version is: ' + env['NOSETESTSVERSION'] + '\n')
         log.write('Nosetests command is:\n' + cmd + '\n')

--- a/tests/run_examples.py
+++ b/tests/run_examples.py
@@ -289,7 +289,7 @@ def test_demo13():
     import demo13
     import check_diff
     print('Running demo13.py')
-    demo13.main(['nuse=3','ntot=100'])
+    demo13.main(['nuse=3','ntot=100','filters=YJH'])
     # There is no demo13.yaml yet, so all this does is check for syntax errors in demo13.py.
 
 @timer

--- a/tests/run_examples.py
+++ b/tests/run_examples.py
@@ -328,12 +328,14 @@ def test_des():
         config['gal']['items'][0]['gal_type'] = 'parametric'
         config['input']['cosmos_catalog']['file_name'] = '../data/real_galaxy_catalog_23.5_example.fits'
         del config['input']['cosmos_catalog']['sample']
+        config['input']['des_wcs']['bad_ccds'] = range(2,63)  # All but CCD 1
         galsim.config.Process(config, logger=logger)
         input_cosmos = config['input']['cosmos_catalog'] # Save example COSMOS catalog spec.
         config = galsim.config.ReadConfig('blend.yaml', logger=logger)[0]
         galsim.config.Process(config, logger=logger)
         config = galsim.config.ReadConfig('blendset.yaml', logger=logger)[0]
         config['input']['cosmos_catalog'] = input_cosmos
+        config['input']['des_psfex']['file_name']['num'] = 1
         galsim.config.Process(config, logger=logger)
 
     finally:

--- a/tests/run_examples.py
+++ b/tests/run_examples.py
@@ -57,6 +57,23 @@ def in_examples(f):
 
 @timer
 @in_examples
+def test_demo1():
+    """Check that demo1 runs properly.
+    """
+    import demo1
+    import check_diff
+    print('Running demo1.py')
+    demo1.main([])
+    logging.basicConfig(format="%(message)s", level=logging.INFO, stream=sys.stdout)
+    logger = logging.getLogger('galsim')
+    config = galsim.config.ReadConfig('demo1.yaml', logger=logger)[0]
+    print('Running demo1.yaml')
+    galsim.config.Process(config, logger=logger)
+    # There is no assert at the end of this one, since they are not expected to be identical
+    # due to the lack of a specified seed.  This just checks for syntax errors.
+
+@timer
+@in_examples
 def test_demo2():
     """Check that demo2 makes the same image using demo2.py and demo2.yaml.
     """
@@ -70,7 +87,6 @@ def test_demo2():
     print('Running demo2.yaml')
     galsim.config.Process(config, logger=logger)
     assert check_diff.same('output/demo2.fits', 'output_yaml/demo2.fits')
-
 
 @timer
 @in_examples
@@ -246,11 +262,34 @@ def test_demo11():
     assert check_diff.same('output/tabulated_power_spectrum.fits.fz',
                            'output_yaml/tabulated_power_spectrum.fits.fz')
 
+@timer
+@in_examples
+def test_demo12():
+    """Check that demo12 runs properly.
+    """
+    import demo12
+    import check_diff
+    print('Running demo12.py')
+    demo12.main([])
+    # There is no demo12.yaml yet, so all this does is check for syntax errors in demo12.py.
+
+@timer
+@in_examples
+def test_demo13():
+    """Check that demo13 runs properly.
+    """
+    import demo13
+    import check_diff
+    print('Running demo13.py')
+    demo13.main([])
+    # There is no demo13.yaml yet, so all this does is check for syntax errors in demo13.py.
+
 
 if __name__ == "__main__":
     shutil.rmtree('../examples/output')
     shutil.rmtree('../examples/output_yaml')
     shutil.rmtree('../examples/output_json')
+    test_demo1()
     test_demo2()
     test_demo3()
     test_demo4()
@@ -261,3 +300,5 @@ if __name__ == "__main__":
     test_demo9()
     test_demo10()
     test_demo11()
+    test_demo12()
+    test_demo13()

--- a/tests/run_examples.py
+++ b/tests/run_examples.py
@@ -289,7 +289,7 @@ def test_demo13():
     import demo13
     import check_diff
     print('Running demo13.py')
-    demo13.main([])
+    demo13.main(['nuse=3','ntot=100'])
     # There is no demo13.yaml yet, so all this does is check for syntax errors in demo13.py.
 
 @timer

--- a/tests/run_examples.py
+++ b/tests/run_examples.py
@@ -335,6 +335,30 @@ def test_des():
     finally:
         os.chdir(original_dir)
 
+@timer
+@in_examples
+def test_great3():
+    """Check that the great3 config files run properly.
+    """
+    import check_diff
+    original_dir = os.getcwd()
+    try:
+        os.chdir('great3')
+        new_dir = os.getcwd()
+        if new_dir not in sys.path:
+            sys.path.append(new_dir)
+        logging.basicConfig(format="%(message)s", level=logging.WARNING, stream=sys.stdout)
+        logger = logging.getLogger('galsim')
+        new_params = { 'output.nfiles' : 1, 'output.noclobber' : False, 'image.nx_tiles' : 1 }
+        for file_name in ['cgc.yaml', 'cgc_psf.yaml', 'cgc_faint.yaml',
+                          'rgc.yaml', 'rgc_psf.yaml']:
+            configs = galsim.config.ReadConfig(file_name, logger=logger)
+            print('Running ',file_name)
+            for config in configs:
+                galsim.config.Process(config, logger=logger, new_params=new_params)
+    finally:
+        os.chdir(original_dir)
+
 
 if __name__ == "__main__":
     remove_dir('output')
@@ -354,3 +378,4 @@ if __name__ == "__main__":
     test_demo12()
     test_demo13()
     test_des()
+    test_great3()

--- a/tests/run_examples.py
+++ b/tests/run_examples.py
@@ -1,0 +1,263 @@
+# Copyright (c) 2012-2016 by the GalSim developers team on GitHub
+# https://github.com/GalSim-developers
+#
+# This file is part of GalSim: The modular galaxy image simulation toolkit.
+# https://github.com/GalSim-developers/GalSim
+#
+# GalSim is free software: redistribution and use in source and binary forms,
+# with or without modification, are permitted provided that the following
+# conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions, and the disclaimer given in the accompanying LICENSE
+#    file.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions, and the disclaimer given in the documentation
+#    and/or other materials provided with the distribution.
+#
+
+# This file does the equivalent of check_yaml in the examples directory.
+# We don't name it test_*.py, since it's not really unit tests per se, but it
+# does test the config code.  Therefore, we exclude this file from being
+# run in scons tests, but we let it run in Travis to accurately report the
+# coverage of the config files, which otherwise come out rather low.
+
+from __future__ import print_function
+import numpy as np
+import os
+import sys
+import logging
+import shutil
+
+from galsim_test_helpers import *
+
+try:
+    import galsim
+except ImportError:
+    path, filename = os.path.split(__file__)
+    sys.path.append(os.path.abspath(os.path.join(path, "..")))
+    import galsim
+
+def in_examples(f):
+    """A decorator that lets the code run as though it were run in the examples directory.
+    """
+    import functools
+    @functools.wraps(f)
+    def f2(*args, **kwargs):
+        original_dir = os.getcwd()
+        try:
+            os.chdir('../examples')
+            new_dir = os.getcwd()
+            if new_dir not in sys.path:
+                sys.path.append(new_dir)
+            return f(*args, **kwargs)
+        finally:
+            os.chdir(original_dir)
+    return f2
+
+@timer
+@in_examples
+def test_demo2():
+    """Check that demo2 makes the same image using demo2.py and demo2.yaml.
+    """
+    import demo2
+    import check_diff
+    print('Running demo2.py')
+    demo2.main([])
+    logging.basicConfig(format="%(message)s", level=logging.INFO, stream=sys.stdout)
+    logger = logging.getLogger('galsim')
+    config = galsim.config.ReadConfig('demo2.yaml', logger=logger)[0]
+    print('Running demo2.yaml')
+    galsim.config.Process(config, logger=logger)
+    assert check_diff.same('output/demo2.fits', 'output_yaml/demo2.fits')
+
+
+@timer
+@in_examples
+def test_demo3():
+    """Check that demo3 makes the same image using demo3.py and demo3.yaml.
+    """
+    import demo3
+    import check_diff
+    print('Running demo3.py')
+    demo3.main([])
+    logging.basicConfig(format="%(message)s", level=logging.INFO, stream=sys.stdout)
+    logger = logging.getLogger('galsim')
+    config = galsim.config.ReadConfig('demo3.yaml', logger=logger)[0]
+    print('Running demo3.yaml')
+    galsim.config.Process(config, logger=logger)
+    assert check_diff.same('output/demo3.fits', 'output_yaml/demo3.fits')
+    assert check_diff.same('output/demo3_epsf.fits', 'output_yaml/demo3_epsf.fits')
+
+@timer
+@in_examples
+def test_demo4():
+    """Check that demo4 makes the same image using demo4.py and demo4.yaml.
+    """
+    import demo4
+    import check_diff
+    print('Running demo4.py')
+    demo4.main([])
+    logging.basicConfig(format="%(message)s", level=logging.INFO, stream=sys.stdout)
+    logger = logging.getLogger('galsim')
+    config = galsim.config.ReadConfig('demo4.yaml', logger=logger)[0]
+    print('Running demo4.yaml')
+    galsim.config.Process(config, logger=logger)
+    assert check_diff.same('output/multi.fits', 'output_yaml/multi.fits')
+
+@timer
+@in_examples
+def test_demo5():
+    """Check that demo5 makes the same image using demo5.py and demo5.yaml.
+    """
+    import demo5
+    import check_diff
+    print('Running demo5.py')
+    demo5.main([])
+    logging.basicConfig(format="%(message)s", level=logging.INFO, stream=sys.stdout)
+    logger = logging.getLogger('galsim')
+    config = galsim.config.ReadConfig('demo5.yaml', logger=logger)[0]
+    print('Running demo5.yaml')
+    galsim.config.Process(config, logger=logger)
+    assert check_diff.same('output/g08_psf.fits', 'output_yaml/g08_psf.fits')
+    assert check_diff.same('output/g08_gal.fits', 'output_yaml/g08_gal.fits')
+
+@timer
+@in_examples
+def test_demo6():
+    """Check that demo6 makes the same image using demo6.py and demo6.yaml.
+    """
+    import demo6
+    import check_diff
+    print('Running demo6.py')
+    demo6.main([])
+    logging.basicConfig(format="%(message)s", level=logging.INFO, stream=sys.stdout)
+    logger = logging.getLogger('galsim')
+    configs = galsim.config.ReadConfig('demo6.yaml', logger=logger)
+    print('Running demo6.yaml pass #1')
+    galsim.config.Process(configs[0], logger=logger)
+    print('Running demo6.yaml pass #2')
+    galsim.config.Process(configs[1], logger=logger)
+    assert check_diff.same('output/psf_real.fits', 'output_yaml/psf_real.fits')
+    assert check_diff.same('output/cube_real.fits', 'output_yaml/cube_real.fits')
+
+@timer
+@in_examples
+def test_demo7():
+    """Check that demo7 makes the same image using demo7.py and demo7.yaml.
+    """
+    import demo7
+    import check_diff
+    import gzip
+    import shutil
+    print('Running demo7.py')
+    demo7.main([])
+    logging.basicConfig(format="%(message)s", level=logging.INFO, stream=sys.stdout)
+    logger = logging.getLogger('galsim')
+    config = galsim.config.ReadConfig('demo7.yaml', logger=logger)[0]
+    print('Running demo7.yaml')
+    galsim.config.Process(config, logger=logger)
+    with gzip.open('output/cube_phot.fits.gz', 'rb') as f_in, \
+         open('output/cube_phot.fits', 'wb') as f_out:
+        shutil.copyfileobj(f_in, f_out)
+    with gzip.open('output_yaml/cube_phot.fits.gz', 'rb') as f_in, \
+         open('output_yaml/cube_phot.fits', 'wb') as f_out:
+        shutil.copyfileobj(f_in, f_out)
+    assert check_diff.same('output/cube_phot.fits', 'output_yaml/cube_phot.fits')
+
+@timer
+@in_examples
+def test_demo8():
+    """Check that demo8 makes the same image using demo8.py and demo8.yaml.
+    """
+    import demo8
+    import check_diff
+    print('Running demo8.py')
+    demo8.main([])
+    logging.basicConfig(format="%(message)s", level=logging.INFO, stream=sys.stdout)
+    logger = logging.getLogger('galsim')
+    configs = galsim.config.ReadConfig('demo8.yaml', logger=logger)
+    print('Running demo8.yaml pass #1')
+    galsim.config.Process(configs[0], logger=logger)
+    print('Running demo8.yaml pass #2')
+    galsim.config.Process(configs[1], logger=logger)
+    assert check_diff.same('output/bpd_single.fits', 'output_yaml/bpd_single.fits')
+    assert check_diff.same('output/bpd_multi.fits', 'output_yaml/bpd_multi.fits')
+
+@timer
+@in_examples
+def test_demo9():
+    """Check that demo9 makes the same image using demo9.py and demo9.yaml.
+    """
+    # For this one, we'll use the json file instead, partly just to get coverage of the
+    # JSON parsing functionality, but also because the changes to the base config
+    # are pretty minor, so we can effect them with the new_params option.
+    import demo9
+    import check_diff
+    print('Running demo9.py')
+    demo9.main([])
+    logging.basicConfig(format="%(message)s", level=logging.INFO, stream=sys.stdout)
+    logger = logging.getLogger('galsim')
+    config = galsim.config.ReadConfig('json/demo9.json', logger=logger)[0]
+    print('Running demo9.json')
+    new_params = { 'output.skip' : { 'type' : 'List', 'items' : [0,0,0,0,0,1] } }
+    galsim.config.Process(config, logger=logger, new_params=new_params, njobs=3, job=1)
+    galsim.config.Process(config, logger=logger, new_params=new_params, njobs=3, job=2)
+    galsim.config.Process(config, logger=logger, new_params=new_params, njobs=3, job=3)
+    new_params = { 'output.noclobber' : True }
+    galsim.config.Process(config, logger=logger, new_params=new_params)
+    for dir_num in range(1,5):
+        for file_num in range(5):
+            file_name = 'nfw%d/cluster%04d.fits'%(dir_num, file_num)
+            truth_name = 'nfw%d/truth%04d.dat'%(dir_num, file_num)
+            assert check_diff.same('output/'+file_name , 'output_json/'+file_name)
+            assert check_diff.same('output/'+truth_name , 'output_json/'+truth_name)
+
+@timer
+@in_examples
+def test_demo10():
+    """Check that demo10 makes the same image using demo10.py and demo10.yaml.
+    """
+    import demo10
+    import check_diff
+    print('Running demo10.py')
+    demo10.main([])
+    logging.basicConfig(format="%(message)s", level=logging.INFO, stream=sys.stdout)
+    logger = logging.getLogger('galsim')
+    config = galsim.config.ReadConfig('demo10.yaml', logger=logger)[0]
+    print('Running demo10.yaml')
+    galsim.config.Process(config, logger=logger)
+    assert check_diff.same('output/power_spectrum.fits', 'output_yaml/power_spectrum.fits')
+
+@timer
+@in_examples
+def test_demo11():
+    """Check that demo11 makes the same image using demo11.py and demo11.yaml.
+    """
+    import demo11
+    import check_diff
+    print('Running demo11.py')
+    demo11.main([])
+    logging.basicConfig(format="%(message)s", level=logging.INFO, stream=sys.stdout)
+    logger = logging.getLogger('galsim')
+    config = galsim.config.ReadConfig('demo11.yaml', logger=logger)[0]
+    print('Running demo11.yaml')
+    galsim.config.Process(config, logger=logger)
+    assert check_diff.same('output/tabulated_power_spectrum.fits.fz',
+                           'output_yaml/tabulated_power_spectrum.fits.fz')
+
+
+if __name__ == "__main__":
+    shutil.rmtree('../examples/output')
+    shutil.rmtree('../examples/output_yaml')
+    shutil.rmtree('../examples/output_json')
+    test_demo2()
+    test_demo3()
+    test_demo4()
+    test_demo5()
+    test_demo6()
+    test_demo7()
+    test_demo8()
+    test_demo9()
+    test_demo10()
+    test_demo11()

--- a/tests/run_examples.py
+++ b/tests/run_examples.py
@@ -328,8 +328,10 @@ def test_des():
         galsim.config.Process(config, logger=logger)
         config = galsim.config.ReadConfig('meds.yaml', logger=logger)[0]
         config['output']['nfiles'] = 1
-        config['output']['nobjects'] = 1000
+        config['output']['nobjects'] = 100
         config['gal']['items'][0]['gal_type'] = 'parametric'
+        config['input']['cosmos_catalog']['file_name'] = '../data/real_galaxy_catalog_23.5_example.fits'
+        del config['input']['cosmos_catalog']['sample']
         galsim.config.Process(config, logger=logger)
 
     finally:
@@ -349,11 +351,21 @@ def test_great3():
             sys.path.append(new_dir)
         logging.basicConfig(format="%(message)s", level=logging.WARNING, stream=sys.stdout)
         logger = logging.getLogger('galsim')
-        new_params = { 'output.nfiles' : 1, 'output.noclobber' : False, 'image.nx_tiles' : 1 }
-        for file_name in ['cgc.yaml', 'cgc_psf.yaml', 'cgc_faint.yaml',
+        # Some changes to speed up the run, since we mostly just want to check that all the
+        # template and reject features work properly, which doesn't require many galaxies.
+        p1 = { 'output.nfiles' : 1, 'output.noclobber' : False,
+               'image.nx_tiles' : 1, 'image.ny_tiles' : 20 }
+        p2 = p1.copy()
+        p2['input.cosmos_catalog.file_name'] = '../data/real_galaxy_catalog_23.5_example.fits'
+        p2['input.cosmos_catalog.sample']  = ''
+        for file_name in ['cgc.yaml', 'cgc_psf.yaml',
                           'rgc.yaml', 'rgc_psf.yaml']:
             configs = galsim.config.ReadConfig(file_name, logger=logger)
             print('Running ',file_name)
+            if 'psf' in file_name:
+                new_params = p1
+            else:
+                new_params = p2
             for config in configs:
                 galsim.config.Process(config, logger=logger, new_params=new_params)
     finally:

--- a/tests/run_examples.py
+++ b/tests/run_examples.py
@@ -322,16 +322,18 @@ def test_des():
         assert check_diff.same('output/DECam_00154912_01_fitpsf_image.fits',
                                'output_yaml/DECam_00154912_01_fitpsf_image.fits')
 
-        config = galsim.config.ReadConfig('blend.yaml', logger=logger)[0]
-        galsim.config.Process(config, logger=logger)
-        config = galsim.config.ReadConfig('blendset.yaml', logger=logger)[0]
-        galsim.config.Process(config, logger=logger)
         config = galsim.config.ReadConfig('meds.yaml', logger=logger)[0]
         config['output']['nfiles'] = 1
         config['output']['nobjects'] = 100
         config['gal']['items'][0]['gal_type'] = 'parametric'
         config['input']['cosmos_catalog']['file_name'] = '../data/real_galaxy_catalog_23.5_example.fits'
         del config['input']['cosmos_catalog']['sample']
+        galsim.config.Process(config, logger=logger)
+        input_cosmos = config['input']['cosmos_catalog'] # Save example COSMOS catalog spec.
+        config = galsim.config.ReadConfig('blend.yaml', logger=logger)[0]
+        galsim.config.Process(config, logger=logger)
+        config = galsim.config.ReadConfig('blendset.yaml', logger=logger)[0]
+        config['input']['cosmos_catalog'] = input_cosmos
         galsim.config.Process(config, logger=logger)
 
     finally:

--- a/tests/run_examples.py
+++ b/tests/run_examples.py
@@ -38,6 +38,14 @@ except ImportError:
     sys.path.append(os.path.abspath(os.path.join(path, "..")))
     import galsim
 
+def remove_dir(dir_name):
+    """Remove a directory in ../examples
+    """
+    test_dir = os.path.dirname(__file__)
+    full_dir_name = os.path.join(test_dir, '../examples', dir_name)
+    if os.path.exists(full_dir_name):
+        shutil.rmtree(full_dir_name)
+
 def in_examples(f):
     """A decorator that lets the code run as though it were run in the examples directory.
     """
@@ -286,9 +294,9 @@ def test_demo13():
 
 
 if __name__ == "__main__":
-    shutil.rmtree('../examples/output')
-    shutil.rmtree('../examples/output_yaml')
-    shutil.rmtree('../examples/output_json')
+    remove_dir('output')
+    remove_dir('output_yaml')
+    remove_dir('output_json')
     test_demo1()
     test_demo2()
     test_demo3()

--- a/tests/test_config_image.py
+++ b/tests/test_config_image.py
@@ -364,8 +364,6 @@ def test_cosmosnoise():
             cosmos_scale=pix_scale)
     noise -= galsim.UncorrelatedNoise(current_var, rng=rng, wcs=image4.wcs)
     image4.addNoise(noise)
-    image3.write('image3.fits')
-    image4.write('image4.fits')
     np.testing.assert_equal(
         image3.array, image4.array,
         err_msg='Config COSMOS noise with whiting does not reproduce manually drawn image')

--- a/tests/test_lensing.py
+++ b/tests/test_lensing.py
@@ -103,13 +103,23 @@ def test_nfwhalo():
     kappa = halo.getConvergence((pos_x, pos_y), z_s)
     gamma1, gamma2 = halo.getShear((pos_x, pos_y), z_s, reduced=False)
     g1, g2 = halo.getShear((pos_x, pos_y), z_s, reduced=True)
+    mu = halo.getMagnification((pos_x, pos_y), z_s)
+    alt_g1, alt_g2, alt_mu = halo.getLensing((pos_x, pos_y), z_s)
 
     # check internal correctness:
     # g1 = gamma1/(1-kappa), and g2 = 0
-    np.testing.assert_array_equal(g1, gamma1/(1-np.array(kappa)),
+    np.testing.assert_array_equal(g1, gamma1/(1-kappa),
                                   err_msg="Computation of reduced shear g incorrect.")
     np.testing.assert_array_equal(g2, np.zeros_like(g2),
                                   err_msg="Computation of reduced shear g2 incorrect.")
+    np.testing.assert_array_equal(mu, 1./( (1-kappa)**2 - gamma1**2 - gamma2**2 ),
+                                  err_msg="Computation of magnification mu incorrect.")
+    np.testing.assert_array_equal(alt_g1, g1,
+                                  err_msg="getLensing returned wrong g1")
+    np.testing.assert_array_equal(alt_g2, g2,
+                                  err_msg="getLensing returned wrong g2")
+    np.testing.assert_array_equal(alt_mu, mu,
+                                  err_msg="getLensing returned wrong mu")
 
     do_pickle(halo)
 

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -1519,8 +1519,9 @@ def test_astropywcs():
             warnings.filterwarnings("ignore",category=RuntimeWarning)
             import astropy.wcs
             import scipy  # AstropyWCS constructor will do this, so check now.
-    except ImportError:
+    except ImportError as e:
         print('Unable to import astropy.wcs.  Skipping AstropyWCS tests.')
+        print('Caught ',e)
         return
 
     # These all work, but it is quite slow, so only test one of them for the regular unit tests.

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -1628,12 +1628,9 @@ def test_gsfitswcs():
     """Test the GSFitsWCS class
     """
     # These are all relatively fast (total time for all 7 and the TanWCS stuff below is about
-    # 1.6 seconds), but longer than my arbitrary 1 second goal for any unit test, so only do the
-    # three most important ones as part of the regular test suite runs.
-    if __name__ == "__main__":
-        test_tags = [ 'TAN', 'STG', 'ZEA', 'ARC', 'TPV', 'TAN-PV', 'TAN-FLIP', 'TNX', 'SIP' ]
-    else:
-        test_tags = [ 'TAN', 'TPV', 'SIP' ]
+    # 1.6 seconds), and (relatively) full unit test coverage requires all of them, so we always
+    # do these despite violating my usual upper limit of 1 second per unit test.
+    test_tags = [ 'TAN', 'STG', 'ZEA', 'ARC', 'TPV', 'TAN-PV', 'TAN-FLIP', 'TNX', 'SIP' ]
 
     dir = 'fits_files'
 

--- a/tests/test_wfirst.py
+++ b/tests/test_wfirst.py
@@ -442,9 +442,10 @@ def test_wfirst_psfs():
         err_msg='PSF at a given wavelength and interpolated chromatic one evaluated at that '
         'wavelength disagree.')
 
-    # Below are some more expensive tests that will run only when running test_wfirst.py directly,
-    # but not when doing "scons tests"
-    if __name__ == "__main__":
+    # This is a little slow, but we do want to run this as part of normal unit testing
+    # to cover the storePSFImage and loadPSFImages functions.
+    if True:
+    #if __name__ == '__main__':
         # Check that if we store and reload, what we get back is consistent with what we put in.
         test_file = 'tmp_store.fits'
         # Make sure we clear out any old versions
@@ -485,7 +486,7 @@ def test_wfirst_psfs():
         os.remove(test_file)
 
     # Test the construction of PSFs with high_accuracy and/or not approximate_struts
-    # But only if we're runnign from the command line.
+    # But only if we're running from the command line.
     if __name__ == '__main__':
         for kwargs in [
             { 'approximate_struts':True, 'high_accuracy':False },  # This is a repeat of the above


### PR DESCRIPTION
I've added coverage testing and reporting via coveralls to the travis config file.  I also added a program that does the equivalent of `check_yaml` for Travis to run, so it can check those as well, and also count the config lines that are run there for the coverage.

I don't know whether this should close #580 or not.  The coveralls report seems most likely to induce people to expand the coverage of the unit tests than an old issue sitting on the second page of the issues list.  So I'm inclined to close it after this.  But if people think it's useful to have an issue that explicitly requests more unit test coverage, we can leave it open.