### PR TITLE
Fix bug in Deconvolve drawK with non-rectilinear steps

### DIFF
--- a/src/SBDeconvolve.cpp
+++ b/src/SBDeconvolve.cpp
@@ -127,10 +127,10 @@ namespace galsim {
         int skip = im.getNSkip();
         assert(im.getStep() == 1);
 
-        for (int j=0; j<n; ++j,ky0+=dky,ptr+=skip) {
+        for (int j=0; j<n; ++j,kx0+=dkxy,ky0+=dky,ptr+=skip) {
             double kx = kx0;
             double ky = ky0;
-            for (int i=0; i<m; ++i,kx+=dkx,++ptr) {
+            for (int i=0; i<m; ++i,kx+=dkx,ky+=dkyx,++ptr) {
                 double ksq = kx*kx + ky*ky;
                 if (ksq > _maxksq) *ptr = 0.;
                 else {

--- a/tests/test_compound.py
+++ b/tests/test_compound.py
@@ -731,11 +731,39 @@ def test_deconvolve():
     np.testing.assert_almost_equal(inv_obj.flux, 1./obj.flux)
     np.testing.assert_almost_equal(inv_obj.maxSB(), -obj.maxSB() / obj.flux**2)
 
-    check_basic(inv_psf, "Deconvolve(asym)", do_x=False)
+    check_basic(inv_obj, "Deconvolve(asym)", do_x=False)
 
     # Check picklability
     do_pickle(inv_obj)
     do_pickle(inv_obj.SBProfile)
+
+    # And a significantly transformed deconvolve object
+    jac = (0.3, -0.8, -0.7, 0.4)
+    transformed_obj = obj.transform(*jac)
+    transformed_inv_obj = inv_obj.transform(*jac)
+    # Fix the flux -- most of the transformation commutes with deconvolution, but not flux scaling
+    transformed_inv_obj /= transformed_obj.flux * transformed_inv_obj.flux
+    check_basic(transformed_inv_obj, "transformed Deconvolve(asym)", do_x=False)
+    conv = galsim.Convolve([transformed_inv_obj, transformed_obj, obj])
+    conv.drawImage(myImg1, method='no_pixel')
+    myImg1.write('junk1.fits')
+    myImg2.write('junk2.fits')
+    printval(myImg1, myImg2)
+    np.testing.assert_array_almost_equal(
+            myImg1.array, myImg2.array, 4,
+            err_msg="Transformed Deconvolve didn't cancel transformed original")
+
+    np.testing.assert_equal(transformed_inv_obj.centroid(), -transformed_obj.centroid())
+    np.testing.assert_almost_equal(transformed_inv_obj.getFlux(), 1./transformed_obj.flux)
+    np.testing.assert_almost_equal(transformed_inv_obj.flux, 1./transformed_obj.flux)
+    np.testing.assert_almost_equal(transformed_inv_obj.maxSB(),
+                                   -transformed_obj.maxSB() / transformed_obj.flux**2)
+
+    check_basic(transformed_inv_obj, "transformed Deconvolve(asym)", do_x=False)
+
+    # Check picklability
+    do_pickle(transformed_inv_obj)
+    do_pickle(transformed_inv_obj.SBProfile)
 
     # Should raise an exception for invalid arguments
     try:

--- a/tests/test_compound.py
+++ b/tests/test_compound.py
@@ -746,8 +746,6 @@ def test_deconvolve():
     check_basic(transformed_inv_obj, "transformed Deconvolve(asym)", do_x=False)
     conv = galsim.Convolve([transformed_inv_obj, transformed_obj, obj])
     conv.drawImage(myImg1, method='no_pixel')
-    myImg1.write('junk1.fits')
-    myImg2.write('junk2.fits')
     printval(myImg1, myImg2)
     np.testing.assert_array_almost_equal(
             myImg1.array, myImg2.array, 4,

--- a/tests/test_metacal.py
+++ b/tests/test_metacal.py
@@ -389,6 +389,35 @@ def test_metacal_tracking():
         check_symm_noise(final_image2, 'using alternate reverse shear does not work')
         print('Time for alternate reverse shear method = ',t4-t3)
 
+@timer
+def test_wcs():
+    """Reproduce an error Erin found and reported in #834.  This was never an error in a released
+    version, just temporarily on master, but the mistake hadn't been caught by any of our unit
+    tests, so this test catches the error.
+    """
+    wcs = galsim.JacobianWCS(0.01, -0.26, -0.28, -0.03)
+    gal = galsim.Exponential(half_light_radius=1.1, flux=237)
+    psf = galsim.Moffat(beta=3.5, half_light_radius=0.9)
+    obs = galsim.Convolve(gal,psf)
+
+    obs_im = obs.drawImage(nx=32, ny=32, offset=(0.3,-0.2), wcs=wcs)
+    psf_im = psf.drawImage(nx=32, ny=32, wcs=wcs)
+
+    ii = galsim.InterpolatedImage(obs_im)
+    psf_ii = galsim.InterpolatedImage(psf_im)
+    psf_inv = galsim.Deconvolve(psf_ii)
+
+    ii_nopsf = galsim.Convolve(ii, psf_inv)
+
+    newpsf=galsim.Moffat(beta=3.5, half_light_radius=0.95)
+    newpsf=newpsf.dilate(1.02)
+
+    new_ii = ii_nopsf.shear(g1=0.01,g2=0.0)
+    new_ii = galsim.Convolve(new_ii, newpsf)
+
+    new_im = new_ii.drawImage(image=obs_im.copy(), method='no_pixel')
+    np.testing.assert_almost_equal(new_im.array.sum()/237, obs_im.array.sum()/237, decimal=1)
 
 if __name__ == "__main__":
     test_metacal_tracking()
+    test_wcs()


### PR DESCRIPTION
This fixes a bug identified by @esheldon in issue #834 that I accidentally introduced in #799.

I added two new unit tests.  The one in test_metacal.py is pretty close to what Erin posted in the bug report.  The other (in test_compound.py) is a bit closer to the proximate source of the error and tests that a transform commutes with a deconvolve.  (Other than the flux scaling, which isn't expected to commute.)