### PR TITLE
#835 force_stepk, force_maxk, and ii_pad_factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@ New Features
   doing so are `im.calculate_fft()` and `im.calculate_inverse_fft()`.  There
   is also `im.wrap()` which can be used to wrap an image prior to doing the
   FFT to properly alias the data if necessary. (#799)
-- Added new profile `galsim.RandomWalk`, a class for generating a set of 
+- Added new profile `galsim.RandomWalk`, a class for generating a set of
   point sources distributed using a random walk.  Uses of this profile include
   representing an "irregular" galaxy, or adding this profile to an Exponential
   to represent knots of star formation. (#819)
@@ -101,6 +101,8 @@ New Features
 - Added `surface_ops` option to `drawImage` function, which applies a list of
   surface operations to the photon array before accumulating on the image.
   (#827)
+- Added `ii_pad_factor` kwarg to PhaseScreenPSF and OpticalPSF to control the
+  zero-padding of the underlying InterpolatedImage. (#835)
 
 
 New config features

--- a/galsim/compound.py
+++ b/galsim/compound.py
@@ -526,7 +526,7 @@ class Deconvolution(galsim.GSObject):
 _galsim.SBDeconvolve.__getinitargs__ = lambda self: (self.getObj(), self.getGSParams())
 _galsim.SBDeconvolve.__getstate__ = lambda self: None
 _galsim.SBDeconvolve.__repr__ = lambda self: \
-        'galsim._galsim.SBDeConvolve(%r, %r)'%self.__getinitargs__()
+        'galsim._galsim.SBDeconvolve(%r, %r)'%self.__getinitargs__()
 
 
 def AutoConvolve(obj, real_space=None, gsparams=None):
@@ -944,7 +944,7 @@ class RandomWalk(Sum):
     -------
 
     This class inherits from galsim.Sum. Additional methods are
-    
+
         calculateHLR:
             Calculate the actual half light radius of the generated points
 
@@ -1065,7 +1065,7 @@ class RandomWalk(Sum):
         sigma=self._gaussian_sigma
         gsparams=self._input_gsparams
         fluxper=self._flux/self._npoints
-        
+
         for p in points:
             g = galsim._galsim.SBGaussian(
                 sigma=sigma,
@@ -1159,5 +1159,3 @@ class RandomWalk(Sum):
             gsparams=repr(self._input_gsparams),
         )
         return rep
-
-

--- a/galsim/fits.py
+++ b/galsim/fits.py
@@ -1355,7 +1355,7 @@ class FitsHeader(object):
     def __repr__(self):
         from galsim._pyfits import pyfits_str
         if self._tag is None:
-            return "galsim.FitsHeader(header=%r)"%self.items()
+            return "galsim.FitsHeader(header=%r)"%list(self.items())
         else:
             return "galsim.FitsHeader(%s)"%self._tag
 

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -426,7 +426,10 @@ class Image(with_metaclass(MetaImage, object)):
         return array, xmin, ymin
 
     def __repr__(self):
-        s = 'galsim.Image(bounds=%r, array=\n%r, wcs=%r'%(self.bounds, self.array, self.wcs)
+        s = 'galsim.Image(bounds=%r' % self.bounds
+        if self.bounds.isDefined():
+            s += ', array=\n%r' % self.array
+        s += ', wcs=%r' % self.wcs
         if self.isconst:
             s += ', make_const=True'
         s += ')'
@@ -1702,6 +1705,8 @@ galsim._galsim.ImageAllocF.__repr__ = lambda self: 'galsim._galsim.ImageAllocF(%
         self.bounds, self.array)
 galsim._galsim.ImageAllocD.__repr__ = lambda self: 'galsim._galsim.ImageAllocD(%r,%r)'%(
         self.bounds, self.array)
+galsim._galsim.ImageAllocC.__repr__ = lambda self: 'galsim._galsim.ImageAllocC(%r,%r)'%(
+        self.bounds, self.array)
 
 galsim._galsim.ImageViewUS.__repr__ = lambda self: 'galsim._galsim.ImageViewUS(%r,%r,%r)'%(
         self.array, self.xmin, self.ymin)
@@ -1715,6 +1720,8 @@ galsim._galsim.ImageViewF.__repr__ = lambda self: 'galsim._galsim.ImageViewF(%r,
         self.array, self.xmin, self.ymin)
 galsim._galsim.ImageViewD.__repr__ = lambda self: 'galsim._galsim.ImageViewD(%r,%r,%r)'%(
         self.array, self.xmin, self.ymin)
+galsim._galsim.ImageViewC.__repr__ = lambda self: 'galsim._galsim.ImageViewC(%r,%r,%r)'%(
+        self.array, self.xmin, self.ymin)
 
 galsim._galsim.ConstImageViewUS.__repr__ = lambda self: 'galsim._galsim.ConstImageViewUS(%r,%r,%r)'%(
         self.array, self.xmin, self.ymin)
@@ -1727,4 +1734,6 @@ galsim._galsim.ConstImageViewI.__repr__ = lambda self: 'galsim._galsim.ConstImag
 galsim._galsim.ConstImageViewF.__repr__ = lambda self: 'galsim._galsim.ConstImageViewF(%r,%r,%r)'%(
         self.array, self.xmin, self.ymin)
 galsim._galsim.ConstImageViewD.__repr__ = lambda self: 'galsim._galsim.ConstImageViewD(%r,%r,%r)'%(
+        self.array, self.xmin, self.ymin)
+galsim._galsim.ConstImageViewC.__repr__ = lambda self: 'galsim._galsim.ConstImageViewC(%r,%r,%r)'%(
         self.array, self.xmin, self.ymin)

--- a/galsim/interpolatedimage.py
+++ b/galsim/interpolatedimage.py
@@ -795,7 +795,7 @@ class InterpolatedKImage(GSObject):
             self._kimage.image, self._kimage.scale, self._stepk, self.k_interpolant, self._gsparams)
 
 _galsim.SBInterpolatedImage.__getinitargs__ = lambda self: (
-        self.getImage(), self.getXInterp(), self.getKInterp(), 1.0,
+        self.getImage(), self.getXInterp(), self.getKInterp(), self.getPadFactor(),
         self.stepK(), self.maxK(), self.getGSParams())
 _galsim.SBInterpolatedImage.__getstate__ = lambda self: None
 _galsim.SBInterpolatedImage.__repr__ = lambda self: \

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -957,6 +957,9 @@ class PhaseScreenPSF(GSObject):
                                to use.  [default: galsim.Quintic()]
     @param scale_unit          Units to use for the sky coordinates of the output profile.
                                [default: galsim.arcsec]
+    @param ii_pad_factor       Zero-padding factor by which to extend the image of the PSF when
+                               creating the `InterpolatedImage`.  See the `InterpolatedImage`
+                               docstring for more details.  [default: 4.]
     @param suppress_warning    If `pad_factor` is too small, the code will emit a warning telling
                                you its best guess about how high you might want to raise it.
                                However, you can suppress this warning by using
@@ -1005,7 +1008,7 @@ class PhaseScreenPSF(GSObject):
     """
     def __init__(self, screen_list, lam, exptime=0.0, flux=1.0, aper=None,
                  theta=(0.0*galsim.arcmin, 0.0*galsim.arcmin), interpolant=None,
-                 scale_unit=galsim.arcsec, suppress_warning=False, gsparams=None,
+                 scale_unit=galsim.arcsec, suppress_warning=False, ii_pad_factor=4., gsparams=None,
                  _eval_now=True, _bar=None, _force_stepk=None, _force_maxk=None, **kwargs):
         # Hidden `_bar` kwarg can be used with astropy.console.utils.ProgressBar to print out a
         # progress bar during long calculations.
@@ -1053,6 +1056,8 @@ class PhaseScreenPSF(GSObject):
         if self._nstep == 0:
             self._nstep = 1
 
+        self._ii_pad_factor = ii_pad_factor
+
         # PhaseScreenList.makePSFs() optimizes multiple PSF evaluation by iterating over PSFs inside
         # of the normal iterate over time loop.  So only do the time loop here and now if we're not
         # doing a makePSFs().
@@ -1060,8 +1065,8 @@ class PhaseScreenPSF(GSObject):
             for i in range(self._nstep):
                 self._step()
                 self.screen_list.advance()
-                if _bar is not None:
-                    _bar.update()  # pragma: nocover
+                if _bar is not None:  # pragma: nocover
+                    _bar.update()
             self._finalize(flux, suppress_warning)
 
         self._flux = flux
@@ -1075,17 +1080,18 @@ class PhaseScreenPSF(GSObject):
 
     def __repr__(self):
         outstr = ("galsim.PhaseScreenPSF(%r, lam=%r, exptime=%r, flux=%r, aper=%r, theta=%r, " +
-                  "scale_unit=%r, interpolant=%r, gsparams=%r)")
+                  "interpolant=%r, scale_unit=%r, gsparams=%r)")
         return outstr % (self.screen_list, self.lam, self.exptime, self.flux, self.aper, self.theta,
                          self.scale_unit, self.interpolant, self.gsparams)
 
     def __eq__(self, other):
         # Even if two PSFs were generated with different sets of parameters, they will act
-        # identically if their img, interpolant, stepk, maxk, and gsparams match.
+        # identically if their img, interpolant, stepk, maxk, pad_factor, and gsparams match.
         return (self.img == other.img and
                 self.interpolant == other.interpolant and
                 self._serialize_stepk == other._serialize_stepk and
                 self._serialize_maxk == other._serialize_maxk and
+                self._ii_pad_factor == other._ii_pad_factor and
                 self.gsparams == other.gsparams)
 
     def __hash__(self):
@@ -1113,6 +1119,7 @@ class PhaseScreenPSF(GSObject):
                 self.img, x_interpolant=self.interpolant,
                 _serialize_stepk=self._serialize_stepk, _serialize_maxk=self._serialize_maxk,
                 calculate_stepk=calculate_stepk, calculate_maxk=calculate_maxk,
+                pad_factor=self._ii_pad_factor,
                 use_true_center=False, normalization='sb', gsparams=self._gsparams)
 
         GSObject.__init__(self, self.ii)
@@ -1141,6 +1148,7 @@ class PhaseScreenPSF(GSObject):
         self.__dict__ = d
         self.ii =  galsim.InterpolatedImage(self.img, x_interpolant=self.interpolant,
                                        use_true_center=False, normalization='sb',
+                                       pad_factor=self._ii_pad_factor,
                                        _serialize_stepk=self._serialize_stepk,
                                        _serialize_maxk=self._serialize_maxk,
                                        gsparams=self._gsparams)
@@ -1283,6 +1291,9 @@ class OpticalPSF(GSObject):
                             compared to what would be employed for a simple Airy.  Note that
                             `pad_factor` may need to be increased for stronger aberrations, i.e.
                             those larger than order unity.  [default: 1.5]
+    @param ii_pad_factor    Zero-padding factor by which to extend the image of the PSF when
+                            creating the `InterpolatedImage`.  See the `InterpolatedImage` docstring
+                            for more details.  [default: 4.]
     @param suppress_warning If `pad_factor` is too small, the code will emit a warning telling you
                             its best guess about how high you might want to raise it.  However,
                             you can suppress this warning by using `suppress_warning=True`.
@@ -1361,9 +1372,9 @@ class OpticalPSF(GSObject):
                  astig1=0., astig2=0., coma1=0., coma2=0., trefoil1=0., trefoil2=0., spher=0.,
                  aberrations=None, annular_zernike=False,
                  aper=None, circular_pupil=True, obscuration=0., interpolant=None,
-                 oversampling=1.5, pad_factor=1.5, flux=1., nstruts=0, strut_thick=0.05,
-                 strut_angle=0.*galsim.degrees, pupil_plane_im=None,
-                 pupil_plane_scale=None, pupil_plane_size=None,
+                 oversampling=1.5, pad_factor=1.5, ii_pad_factor=4., flux=1.,
+                 nstruts=0, strut_thick=0.05, strut_angle=0.*galsim.degrees,
+                 pupil_plane_im=None, pupil_plane_scale=None, pupil_plane_size=None,
                  pupil_angle=0.*galsim.degrees, scale_unit=galsim.arcsec, gsparams=None,
                  _force_maxk=None, _force_stepk=None,
                  suppress_warning=False, max_size=None):
@@ -1435,13 +1446,15 @@ class OpticalPSF(GSObject):
         self._aper = aper
         self._force_maxk = _force_maxk
         self._force_stepk = _force_stepk
+        self._ii_pad_factor = ii_pad_factor
 
         # Finally, put together to make the PSF.
         self._psf = galsim.PhaseScreenPSF(self._screens, lam=self._lam, flux=self._flux,
                                           aper=aper, interpolant=self._interpolant,
                                           scale_unit=self._scale_unit, gsparams=self._gsparams,
                                           suppress_warning=self._suppress_warning,
-                                          _force_maxk=_force_maxk, _force_stepk=_force_stepk)
+                                          _force_maxk=_force_maxk, _force_stepk=_force_stepk,
+                                          ii_pad_factor=ii_pad_factor)
         GSObject.__init__(self, self._psf)
 
     def getFlux(self):
@@ -1477,6 +1490,8 @@ class OpticalPSF(GSObject):
             s += ", _force_maxk=%r" % self._force_maxk
         if self._force_stepk is not None:
             s += ", _force_stepk=%r" % self._force_stepk
+        if self._ii_pad_factor is not None:
+            s += ", ii_pad_factor=%r" % self._ii_pad_factor
         s += ")"
         return s
 
@@ -1506,5 +1521,6 @@ class OpticalPSF(GSObject):
                                           scale_unit=self._scale_unit, gsparams=self._gsparams,
                                           suppress_warning=self._suppress_warning,
                                           _force_maxk=self._force_maxk,
-                                          _force_stepk=self._force_stepk)
+                                          _force_stepk=self._force_stepk,
+                                          ii_pad_factor=self._ii_pad_factor)
         GSObject.__init__(self, self._psf)

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -1082,7 +1082,7 @@ class PhaseScreenPSF(GSObject):
         outstr = ("galsim.PhaseScreenPSF(%r, lam=%r, exptime=%r, flux=%r, aper=%r, theta=%r, " +
                   "interpolant=%r, scale_unit=%r, gsparams=%r)")
         return outstr % (self.screen_list, self.lam, self.exptime, self.flux, self.aper, self.theta,
-                         self.scale_unit, self.interpolant, self.gsparams)
+                         self.interpolant, self.scale_unit, self.gsparams)
 
     def __eq__(self, other):
         # Even if two PSFs were generated with different sets of parameters, they will act

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -1065,7 +1065,7 @@ class PhaseScreenPSF(GSObject):
             for i in range(self._nstep):
                 self._step()
                 self.screen_list.advance()
-                if _bar is not None:  # pragma: nocover
+                if _bar is not None:  # pragma: no cover
                     _bar.update()
             self._finalize(flux, suppress_warning)
 

--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -121,8 +121,8 @@ class AtmosphericScreen(object):
                 self.L0, self.vx, self.vy, self.alpha, self.rng, self.origin, self.orig_rng,
                 self.tab2d)
         if self.alpha != 1.0:
-            s += ", _screen=array(%r, dtype=%s)" % (self.screen.to_list(), self.screen.dtype)
-            s += ", _psi=array(%r, dtype=%s)" % (self.screen.to_list(), self.screen.dtype)
+            s += ", _screen=array(%r, dtype=%s)" % (self.screen.tolist(), self.screen.dtype)
+            s += ", _psi=array(%r, dtype=%s)" % (self.screen.tolist(), self.screen.dtype)
         s += ")"
         return s
 

--- a/galsim/sed.py
+++ b/galsim/sed.py
@@ -842,10 +842,10 @@ class SED(object):
         a bandpass.
 
         @param nphotons  Number of samples (photons) to randomly draw.
-        @param bandpass  A Bandpass object representing a filter, or None to sample over the full 
+        @param bandpass  A Bandpass object representing a filter, or None to sample over the full
                          SED wavelength range.
-        @param rng       If provided, a random number generator that is any kind of BaseDeviate 
-                         object. If `rng` is None, one will be automatically created, using the 
+        @param rng       If provided, a random number generator that is any kind of BaseDeviate
+                         object. If `rng` is None, one will be automatically created, using the
                          time as a seed. [default: None]
         @param npoints   Number of points DistDeviate should use for its internal interpolation
                          tables. [default: 256]
@@ -905,9 +905,12 @@ class SED(object):
         return self._hash
 
     def __repr__(self):
-        outstr = ('galsim.SED(%r, wave_type=%r, flux_type=%r, redshift=%r, fast=%r' +
+        # For some reason, the dimensionless astropy unit, Unit(), doesn't eval/repr roundtrip, so
+        # we use a custom repr for this case.
+        flux_type = "Unit(1)" if self.dimensionless else repr(self.flux_type)
+        outstr = ('galsim.SED(%r, wave_type=%r, flux_type=%s, redshift=%r, fast=%r,' +
                   ' _wave_list=%r, _blue_limit=%r, _red_limit=%r)')%(
-                      self._orig_spec, self.wave_type, self.flux_type, self.redshift, self.fast,
+                      self._orig_spec, self.wave_type, flux_type, self.redshift, self.fast,
                       self.wave_list, self.blue_limit, self.red_limit)
         return outstr
 

--- a/galsim/table.py
+++ b/galsim/table.py
@@ -535,5 +535,5 @@ _galsim._LookupTable2D.__hash__ = lambda self: \
               tuple(np.array(self.getVals()).ravel()), self.getInterp()))
 _galsim._LookupTable2D.__str__ = _LookupTable2D_str
 _galsim._LookupTable2D.__repr__ = lambda self: \
-        'galsim._galsim._LookupTable(array(%r), array(%r), array(%r), %r)'%(
+        'galsim._galsim._LookupTable2D(array(%r), array(%r), %r, %r)'%(
         self.getXArgs().tolist(), self.getYArgs().tolist(), self.getVals(), self.getInterp())

--- a/include/galsim/SBInterpolatedImage.h
+++ b/include/galsim/SBInterpolatedImage.h
@@ -104,6 +104,7 @@ namespace galsim {
 
         boost::shared_ptr<Interpolant> getXInterp() const;
         boost::shared_ptr<Interpolant> getKInterp() const;
+        double getPadFactor() const;
 
         /**
          * @brief Refine the value of stepK if the input image was larger than necessary.

--- a/include/galsim/SBInterpolatedImageImpl.h
+++ b/include/galsim/SBInterpolatedImageImpl.h
@@ -107,6 +107,7 @@ namespace galsim {
 
         boost::shared_ptr<Interpolant> getXInterp() const;
         boost::shared_ptr<Interpolant> getKInterp() const;
+        double getPadFactor() const { return _pad_factor; }
         ConstImageView<double> getImage() const;
         ConstImageView<double> getPaddedImage() const;
 
@@ -127,6 +128,7 @@ namespace galsim {
         boost::shared_ptr<Interpolant2d> _kInterp; ///< Interpolant used in k space.
         boost::shared_ptr<XTable> _xtab; ///< Final padded real-space image.
         mutable boost::shared_ptr<KTable> _ktab; ///< Final k-space image.
+        const double _pad_factor;
         mutable double _stepk;
         mutable double _maxk;
         double _flux;

--- a/pysrc/SBInterpolatedImage.cpp
+++ b/pysrc/SBInterpolatedImage.cpp
@@ -60,6 +60,7 @@ namespace galsim {
                 .def("getPaddedImage", &SBInterpolatedImage::getPaddedImage)
                 .def("getXInterp", &SBInterpolatedImage::getXInterp)
                 .def("getKInterp", &SBInterpolatedImage::getKInterp)
+                .def("getPadFactor", &SBInterpolatedImage::getPadFactor)
                 ;
             wrapTemplates<float>(pySBInterpolatedImage);
             wrapTemplates<double>(pySBInterpolatedImage);

--- a/src/SBInterpolatedImage.cpp
+++ b/src/SBInterpolatedImage.cpp
@@ -67,6 +67,12 @@ namespace galsim {
         return static_cast<const SBInterpolatedImageImpl&>(*_pimpl).getKInterp();
     }
 
+    double SBInterpolatedImage::getPadFactor() const
+    {
+        assert(dynamic_cast<const SBInterpolatedImageImpl*>(_pimpl.get()));
+        return static_cast<const SBInterpolatedImageImpl&>(*_pimpl).getPadFactor();
+    }
+
     void SBInterpolatedImage::calculateStepK(double max_stepk) const
     {
         assert(dynamic_cast<const SBInterpolatedImageImpl*>(_pimpl.get()));
@@ -100,11 +106,11 @@ namespace galsim {
         boost::shared_ptr<Interpolant2d> xInterp, boost::shared_ptr<Interpolant2d> kInterp,
         double pad_factor, double stepk, double maxk, const GSParamsPtr& gsparams) :
         SBProfileImpl(gsparams),
-        _xInterp(xInterp), _kInterp(kInterp), _stepk(stepk), _maxk(maxk),
+        _xInterp(xInterp), _kInterp(kInterp), _pad_factor(pad_factor), _stepk(stepk), _maxk(maxk),
         _readyToShoot(false)
     {
         dbg<<"image bounds = "<<image.getBounds()<<std::endl;
-        dbg<<"pad_factor = "<<pad_factor<<std::endl;
+        dbg<<"pad_factor = "<<_pad_factor<<std::endl;
         assert(_xInterp.get());
         assert(_kInterp.get());
 
@@ -114,7 +120,7 @@ namespace galsim {
         _init_bounds = image.getBounds();
         dbg<<"Ninitial = "<<_Ninitial<<std::endl;
         assert(pad_factor > 0.);
-        _Nk = goodFFTSize(int(pad_factor*_Ninitial));
+        _Nk = goodFFTSize(int(_pad_factor*_Ninitial));
         dbg<<"_Nk = "<<_Nk<<std::endl;
         double sum = 0.;
         double sumx = 0.;
@@ -438,7 +444,7 @@ namespace galsim {
         oss << "galsim.Interpolant('"<<xinterp->makeStr()<<"', "<<xinterp->getTolerance()<<"), ";
         oss << "galsim.Interpolant('"<<kinterp->makeStr()<<"', "<<kinterp->getTolerance()<<"), ";
 
-        oss << "1., "<<stepK()<<", "<<maxK()<<", galsim.GSParams("<<*gsparams<<"))";
+        oss << _pad_factor << ", "<<stepK()<<", "<<maxK()<<", galsim.GSParams("<<*gsparams<<"))";
         return oss.str();
     }
 

--- a/tests/galsim_test_helpers.py
+++ b/tests/galsim_test_helpers.py
@@ -323,6 +323,8 @@ def do_pickle(obj1, func = lambda x : x, irreprable=False):
     import copy
     # In case the repr uses these:
     from numpy import array, uint16, uint32, int16, int32, float32, float64, ndarray
+    from astropy.units import Unit
+
     try:
         import astropy.io.fits
         from distutils.version import LooseVersion
@@ -370,33 +372,22 @@ def do_pickle(obj1, func = lambda x : x, irreprable=False):
 
     # Also test that the repr is an accurate representation of the object.
     # The gold standard is that eval(repr(obj)) == obj.  So check that here as well.
-    # A few objects we don't expect to work this way in GalSim, either because their repr strings
-    # are truncated or because they include floating point numbers with truncated precision.  For
-    # these, we just exit here.
-    if irreprable: return
+    # A few objects we don't expect to work this way in GalSim; when testing these, we set the
+    # `irreprable` kwarg to true.  Also, we skip anything with random deviates since these don't
+    # respect the eval/repr roundtrip.
 
-    try:
-        # It turns out that random deviates will still be successfully constructed even with a
-        # truncated repr string.  They will just be the 'wrong' random deviates.  So look for that
-        # here and just raise an exception to skip this test and get out of the try block.
-        if random:
-            raise TypeError
-        # A further complication is that the default numpy print options do not have sufficient
-        # precision for the eval string to exactly reproduce the original object.  So we temporarily
-        # bump up the numpy print precision.
-        with galsim.utilities.printoptions(precision=18):
-            #print('repr = ',repr(obj1))
+    if not random and not irreprable:
+        # A further complication is that the default numpy print options do not lead to sufficient
+        # precision for the eval string to exactly reproduce the original object, and start
+        # truncating the output for relatively small size arrays.  So we temporarily bump up the
+        # precision and truncation threshold for testing.
+        with galsim.utilities.printoptions(precision=18, threshold=1e6):
             obj5 = eval(repr(obj1))
-    except:
-        pass
-    else:
-        #print('obj1 = ',repr(obj1))
-        #print('obj5 = ',repr(obj5))
         f5 = func(obj5)
-        if random: f1 = func(obj1)
-        #print('func(obj1) = ',repr(f1))
-        #print('func(obj5) = ',repr(f5))
         assert f5 == f1, "func(obj1) = %r\nfunc(obj5) = %r"%(f1, f5)
+    else:
+        # Even if we're not actually doing the test, still make the repr to check for syntax errors.
+        repr(obj1)
 
     # Try perturbing obj1 pickling arguments and verify that inequality results.
     # Generally, only objects pickled with __getinitargs__, i.e. old-style classes, reveal

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -140,7 +140,7 @@ def test_gaussian():
     do_pickle(gauss, lambda x: x.drawImage(method='no_pixel'))
     do_pickle(gauss)
     do_pickle(gauss.SBProfile)
-    do_pickle(galsim.GSObject(gauss))
+    do_pickle(galsim.GSObject(gauss), irreprable=True)
 
     # Should raise an exception if >=2 radii are provided.
     try:

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -103,8 +103,7 @@ def test_roundtrip():
         do_kvalue(interp,test_im,"InterpolatedImage")
 
         # Check picklability
-        do_pickle(interp._sbii, lambda x: (galsim.Image(x.getImage()), x.stepK(), x.maxK()),
-                  irreprable=True)
+        do_pickle(interp._sbii, lambda x: (galsim.Image(x.getImage()), x.stepK(), x.maxK()))
         do_pickle(interp.SBProfile, lambda x: repr(x), irreprable=True)
         do_pickle(interp, lambda x: x.drawImage(method='no_pixel'))
         do_pickle(interp)
@@ -294,9 +293,13 @@ def test_operations_simple():
     np.testing.assert_array_almost_equal(rel.array, zeros_arr,
         test_decimal,
         err_msg='Sheared InterpolatedImage disagrees with reference')
-    if __name__ == "__main__":
-        do_pickle(test_int_im, lambda x: x.drawImage(nx=5, ny=5, scale=0.1, method='no_pixel'))
-        do_pickle(test_int_im)
+
+    # The do_pickle tests should all pass below, but the a == eval(repr(a)) check can take a
+    # really long time, so we only do that if __name__ == "__main__".
+    irreprable = not __name__ == "__main__"
+    do_pickle(test_int_im, lambda x: x.drawImage(nx=5, ny=5, scale=0.1, method='no_pixel'),
+              irreprable=irreprable)
+    do_pickle(test_int_im, irreprable=irreprable)
 
     # Magnify it, and compare with expectations from GSObjects directly
     test_mag = 1.08
@@ -319,9 +322,9 @@ def test_operations_simple():
     np.testing.assert_array_almost_equal(rel.array, zeros_arr,
         test_decimal,
         err_msg='Magnified InterpolatedImage disagrees with reference')
-    if __name__ == "__main__":
-        do_pickle(test_int_im, lambda x: x.drawImage(nx=5, ny=5, scale=0.1, method='no_pixel'))
-        do_pickle(test_int_im)
+    do_pickle(test_int_im, lambda x: x.drawImage(nx=5, ny=5, scale=0.1, method='no_pixel'),
+              irreprable=irreprable)
+    do_pickle(test_int_im, irreprable=irreprable)
 
     # Lens it (shear and magnify), and compare with expectations from GSObjects directly
     test_g1 = -0.03
@@ -346,9 +349,9 @@ def test_operations_simple():
     np.testing.assert_array_almost_equal(rel.array, zeros_arr,
         test_decimal,
         err_msg='Lensed InterpolatedImage disagrees with reference')
-    if __name__ == "__main__":
-        do_pickle(test_int_im, lambda x: x.drawImage(nx=5, ny=5, scale=0.1, method='no_pixel'))
-        do_pickle(test_int_im)
+    do_pickle(test_int_im, lambda x: x.drawImage(nx=5, ny=5, scale=0.1, method='no_pixel'),
+              irreprable=irreprable)
+    do_pickle(test_int_im, irreprable=irreprable)
 
     # Rotate it, and compare with expectations from GSObjects directly
     test_rot_angle = 32.*galsim.degrees
@@ -371,9 +374,9 @@ def test_operations_simple():
     np.testing.assert_array_almost_equal(rel.array, zeros_arr,
         test_decimal,
         err_msg='Rotated InterpolatedImage disagrees with reference')
-    if __name__ == "__main__":
-        do_pickle(test_int_im, lambda x: x.drawImage(nx=5, ny=5, scale=0.1, method='no_pixel'))
-        do_pickle(test_int_im)
+    do_pickle(test_int_im, lambda x: x.drawImage(nx=5, ny=5, scale=0.1, method='no_pixel'),
+              irreprable=irreprable)
+    do_pickle(test_int_im, irreprable=irreprable)
 
     # Shift it, and compare with expectations from GSObjects directly
     x_shift = -0.31
@@ -397,9 +400,9 @@ def test_operations_simple():
     np.testing.assert_array_almost_equal(rel.array, zeros_arr,
         test_decimal,
         err_msg='Shifted InterpolatedImage disagrees with reference')
-    if __name__ == "__main__":
-        do_pickle(test_int_im, lambda x: x.drawImage(nx=5, ny=5, scale=0.1, method='no_pixel'))
-        do_pickle(test_int_im)
+    do_pickle(test_int_im, lambda x: x.drawImage(nx=5, ny=5, scale=0.1, method='no_pixel'),
+              irreprable=irreprable)
+    do_pickle(test_int_im, irreprable=irreprable)
 
 
 @timer

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -813,6 +813,28 @@ def test_OpticalPSF_aper():
 
 
 @timer
+def test_stepk_maxk():
+    """Test options to specify (or not) stepk and maxk.
+    """
+    lam = 500
+    diam = 4.0
+
+    psf = galsim.OpticalPSF(lam=lam, diam=diam)
+    stepk = psf.stepK()
+    maxk = psf.maxK()
+
+    psf2 = galsim.OpticalPSF(lam=lam, diam=diam, _force_stepk=stepk/1.5, _force_maxk=maxk*2.0)
+    np.testing.assert_almost_equal(
+            psf2.stepK(), stepk/1.5, decimal=7,
+            err_msg="OpticalPSF did not adopt forced value for stepK")
+    np.testing.assert_almost_equal(
+            psf2.maxK(), maxk*2.0, decimal=7,
+            err_msg="OpticalPSF did not adopt forced value for maxK")
+
+    do_pickle(psf2)
+
+
+@timer
 def test_ne():
     # Use some very forgiving settings to speed up this test.  We're not actually going to draw
     # any images (other than internally the PSF), so should be okay.
@@ -844,6 +866,11 @@ def test_ne():
             galsim.OpticalPSF(lam_over_diam=1.0, flux=2.0, gsparams=gsp1),
             galsim.OpticalPSF(lam_over_diam=1.0, circular_pupil=False, gsparams=gsp1),
             galsim.OpticalPSF(lam_over_diam=1.0, interpolant='Linear', gsparams=gsp1)]
+    stepk = objs[0].stepK()
+    maxk = objs[0].maxK()
+    objs += [galsim.OpticalPSF(lam_over_diam=1.0, gsparams=gsp1, _force_stepk=stepk/1.5),
+             galsim.OpticalPSF(lam_over_diam=1.0, gsparams=gsp1, _force_maxk=maxk*2)]
+
     if __name__ == do_slow_tests:
         objs += [galsim.OpticalPSF(lam_over_diam=1.0, pupil_plane_im=pupil_plane_im, gsparams=gsp1,
                                    suppress_warning=True),
@@ -865,4 +892,5 @@ if __name__ == "__main__":
     test_Zernike_orthonormality()
     test_annular_Zernike_limit()
     test_OpticalPSF_aper()
+    test_stepk_maxk()
     test_ne()

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -90,6 +90,8 @@ def test_OpticalPSF_flux():
                 err_msg="Unaberrated Optical flux not quite unity.")
     do_pickle(optics_test, lambda x: x.drawImage(nx=20, ny=20, scale=1.7, method='no_pixel'))
     do_pickle(optics_test)
+    do_pickle(optics_test._psf)
+    do_pickle(optics_test._psf, lambda x: x.drawImage(nx=20, ny=20, scale=1.7, method='no_pixel'))
 
 
 @timer

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -441,6 +441,12 @@ def test_ne():
     objs += [galsim.PhaseScreenPSF(psl, 700.0, exptime=0.03, diam=1.0, flux=1.1)]
     psl.reset()
     objs += [galsim.PhaseScreenPSF(psl, 700.0, exptime=0.03, diam=1.0, interpolant='linear')]
+    stepk = objs[0].stepK()
+    maxk = objs[0].maxK()
+    psl.reset()
+    objs += [galsim.PhaseScreenPSF(psl, 700.0, exptime=0.03, diam=1.0, _force_stepk=stepk/1.5)]
+    psl.reset()
+    objs += [galsim.PhaseScreenPSF(psl, 700.0, exptime=0.03, diam=1.0, _force_maxk=maxk*2.0)]
     all_obj_diff(objs)
 
 

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -342,6 +342,30 @@ def test_scale_unit():
 
 
 @timer
+def test_stepk_maxk():
+    """Test options to specify (or not) stepk and maxk.
+    """
+    aper = galsim.Aperture(diam=1.0)
+    rng = galsim.BaseDeviate(1234)
+    # Test frozen AtmosphericScreen first
+    atm = galsim.Atmosphere(screen_size=30.0, altitude=10.0, speed=0.1, alpha=1.0, rng=rng)
+    psf = galsim.PhaseScreenPSF(atm, 500.0, aper=aper, scale_unit=galsim.arcsec)
+    stepk = psf.stepK()
+    maxk = psf.maxK()
+
+    psf2 = galsim.PhaseScreenPSF(atm, 500.0, aper=aper, scale_unit=galsim.arcsec,
+                                 _force_stepk=stepk/1.5, _force_maxk=maxk*2.0)
+    np.testing.assert_almost_equal(
+            psf2.stepK(), stepk/1.5, decimal=7,
+            err_msg="PhaseScreenPSF did not adopt forced value for stepK")
+    np.testing.assert_almost_equal(
+            psf2.maxK(), maxk*2.0, decimal=7,
+            err_msg="PhaseScreenPSF did not adopt forced value for maxK")
+    do_pickle(psf)
+    do_pickle(psf2)
+
+
+@timer
 def test_ne():
     """Test Apertures, PhaseScreens, PhaseScreenLists, and PhaseScreenPSFs for not-equals."""
     import copy
@@ -430,4 +454,5 @@ if __name__ == "__main__":
     test_phase_psf_batch()
     test_opt_indiv_aberrations()
     test_scale_unit()
+    test_stepk_maxk()
     test_ne()


### PR DESCRIPTION
This PR adds `_force_stepk` and `_force_maxk` kwargs to `OpticalPSF` by simply forwarding them to `PhaseScreenPSF`, where they were already available.  Additionally, both `PhaseScreenPSF` and `OpticalPSF` get a new kwarg, `ii_pad_factor`, which gets forwarded to the wrapped `InterpolatedImage` as `pad_factor`.  

(Note, we already have a (poorly named) `pad_factor` keyword for `OpticalScreen` and `PhaseScreenPSF`, which adjusts the size of the image to be passed to the `InterpolatedImage` (though it doesn't actually do any padding, it just uses a larger image to reduce FFT aliasing).  We could think about renaming the `PhaseScreenPSF` and `OpticalPSF` `pad_factor` kwarg to something like `bounds_factor`, and then the new `ii_pad_factor` could just be `pad_factor`, but I think it may be hard to safely alert users to this change in kwarg meaning).

There are also a few new tests to cover the new features.