### PR TITLE
#833 Fix uses of Image when underlying array is not C-contiguous

### DIFF
--- a/include/galsim/Image.h
+++ b/include/galsim/Image.h
@@ -257,21 +257,6 @@ namespace galsim {
         const T& at(const Position<int>& pos) const { return at(pos.x,pos.y); }
         //@}
 
-        /**
-         *  @brief const_iterator type for pixels within a row (unchecked).
-         */
-        typedef const T* const_iterator;
-
-        /**
-         *  @brief Return an iterator to the beginning of a row.
-         */
-        const_iterator rowBegin(int y) const { return _data + addressPixel(y); }
-
-        /**
-         *  @brief Return an iterator to one-past-the-end of a row.
-         */
-        const_iterator rowEnd(int y) const { return _data + addressPixel(this->getXMax() + 1, y); }
-
         //@{
         /**
          *  @brief Return a pointer to the data at an arbitrary pixel.
@@ -558,28 +543,6 @@ namespace galsim {
         { at(x,y) = value; }
 
         /**
-         *  @brief iterator type for pixels within a row (unchecked).
-         */
-        typedef T* iterator;
-
-        /**
-         *  @brief Return an iterator to the beginning of a row.
-         */
-        iterator rowBegin(int r) { return this->_data + this->addressPixel(r); }
-
-        /**
-         *  @brief Return an iterator to one-past-the-end of a row.
-         */
-        iterator rowEnd(int r)
-        { return this->_data + this->addressPixel(this->getXMax() + 1, r); }
-
-        /**
-         *  @brief Return an iterator to an arbitrary pixel.
-         */
-        iterator getIter(int x, int y)
-        { return this->_data + this->addressPixel(x, y); }
-
-        /**
          *  @brief Deep-copy pixel values from rhs to this.
          *
          *  The bounds must be commensurate (i.e. the same shape).
@@ -792,44 +755,6 @@ namespace galsim {
          */
         void setValue(int x, int y, T value)
         { at(x,y) = value; }
-
-        //@{
-        /**
-         *  @brief Iterator type for pixels within a row (unchecked).
-         */
-        typedef T* iterator;
-        typedef const T* const_iterator;
-        //@}
-
-        //@{
-        /**
-         *  @brief Return an iterator to the beginning of a row.
-         */
-        iterator rowBegin(int r)
-        { return this->_data + this->addressPixel(r); }
-        const_iterator rowBegin(int r) const
-        { return this->_data + this->addressPixel(r); }
-        //@}
-
-        //@{
-        /**
-         *  @brief Return an iterator to one-past-the-end of a row.
-         */
-        iterator rowEnd(int r)
-        { return this->_data + this->addressPixel(this->getXMax() + 1, r); }
-        const_iterator rowEnd(int r) const
-        { return this->_data + this->addressPixel(this->getXMax() + 1, r); }
-        //@}
-
-        //@{
-        /**
-         *  @brief Return an iterator to an arbitrary pixel.
-         */
-        iterator getIter(int x, int y)
-        { return this->_data + this->addressPixel(x, y); }
-        const_iterator getIter(int x, int y) const
-        { return this->_data + this->addressPixel(x, y); }
-        //@}
 
         /**
          *  @brief Deep-copy pixel values from rhs to this.

--- a/include/galsim/Image.h
+++ b/include/galsim/Image.h
@@ -597,12 +597,7 @@ namespace galsim {
         {
             if (!this->_bounds.isSameShapeAs(rhs.getBounds()))
                 throw ImageError("Attempt im1 = im2, but bounds not the same shape");
-            for (int y=this->getYMin(), y2=rhs.getYMin(); y <= this->getYMax(); ++y, ++y2) {
-                iterator it1 = rowBegin(y);
-                const iterator ee = rowEnd(y);
-                typename BaseImage<U>::const_iterator it2 = rhs.rowBegin(y2);
-                while (it1 != ee) *(it1++) = T(*(it2++));
-            }
+            transform_pixel(*this, rhs, ReturnSecond<T,U>());
         }
     };
 

--- a/include/galsim/Image.h
+++ b/include/galsim/Image.h
@@ -274,10 +274,10 @@ namespace galsim {
 
         //@{
         /**
-         *  @brief Return an iterator to an arbitrary pixel.
+         *  @brief Return a pointer to the data at an arbitrary pixel.
          */
-        const_iterator getIter(int x, int y) const { return _data + addressPixel(x, y); }
-        const_iterator getIter(const Position<int>& pos) const { return getIter(pos.x,pos.y); }
+        const T* getPtr(int x, int y) const { return _data + addressPixel(x, y); }
+        const T* getPtr(const Position<int>& pos) const { return getPtr(pos.x,pos.y); }
         //@}
 
         /**

--- a/include/galsim/ImageArith.h
+++ b/include/galsim/ImageArith.h
@@ -164,6 +164,31 @@ namespace galsim {
         return f;
     }
 
+    // Some functionals that are useful for operating on images:
+    template <typename T>
+    class ConstReturn
+    {
+    public:
+        ConstReturn(const T v): val(v) {}
+        T operator()(const T ) const { return val; }
+    private:
+        T val;
+    };
+
+    template <typename T>
+    class ReturnInverse
+    {
+    public:
+        T operator()(const T val) const { return val==T(0) ? T(0.) : T(1./val); }
+    };
+
+    template <typename T1, typename T2>
+    class ReturnSecond
+    {
+    public:
+        T1 operator()(T1, T2 v) const { return T1(v); }
+    };
+
     // All code between the @cond and @endcond is excluded from Doxygen documentation
     //! @cond
 

--- a/include/galsim/Noise.h
+++ b/include/galsim/Noise.h
@@ -497,41 +497,6 @@ namespace galsim {
             data -= T(_sky_level);
         }
 
-        /**
-         * @brief Add noise to an Image and also report variance of each pixel.
-         *
-         * Adds noise as in applyToView(Image) signature, but second Image is filled with
-         * variance of added noise.  Note: the variance image must be the same size as the
-         * data image.
-         *
-         * @param[in,out] data The Image to be noise-ified.
-         * @param[in,out] var  The Image to fill with variance of applied noise.
-         */
-        template <class T>
-        void applyToVar(ImageView<T> data, ImageView<T> var)
-        {
-            // Typedef for image row iterable
-            typedef typename ImageView<T>::iterator ImIter;
-            assert(data.getBounds() == var.getBounds());
-            // Fill with the (constant) Gaussian contribution to variance
-            if (_read_noise > 0.) {
-                double sigma = _read_noise / (_gain > 0. ? _gain : 1.);
-                var.fill(sigma * sigma);
-            }
-            // Add the Poisson variance:
-            if (_gain > 0.) {
-                for (int y = data.getYMin(); y <= data.getYMax(); y++) {  // iterate over y
-                    ImIter ee = data.rowEnd(y);
-                    ImIter it2 = var.rowBegin(y);
-                    for (ImIter it = data.rowBegin(y); it != ee; ++it, ++it2) {
-                        if (*it > 0.) *it2 += (*it + _sky_level) / _gain;
-                    }
-                }
-            }
-            // then call noise method to instantiate noise
-            applyToView(data);
-        }
-
     protected:
         using BaseNoise::_rng;
         void doApplyTo(ImageView<double>& data) { applyToView(data); }

--- a/include/galsim/Noise.h
+++ b/include/galsim/Noise.h
@@ -98,7 +98,7 @@ namespace galsim {
         {
             // This uses the standard workaround for the fact that you can't have a
             // virtual template function.  The doApplyTo functions are virtual and
-            // are listed for each allowed value of T (
+            // are listed for each allowed value of T.
             doApplyTo(data);
         }
 
@@ -181,22 +181,25 @@ namespace galsim {
             _sigma *= sqrt(variance_ratio);
         }
 
+        template <typename T>
+        class NoiseAdder
+        {
+        public:
+            NoiseAdder(GaussianDeviate& gd) : _gd(gd) {}
+            T operator()(const T& pix) { return pix + _gd(); }
+        private:
+            GaussianDeviate& _gd;
+        };
+
         /**
          * @brief Add noise to an Image.
          */
         template <typename T>
         void applyToView(ImageView<T> data)
         {
-            // Typedef for image row iterable
-            typedef typename ImageView<T>::iterator ImIter;
-
             GaussianDeviate gd(*_rng, 0., _sigma);
-            for (int y = data.getYMin(); y <= data.getYMax(); y++) {  // iterate over y
-                ImIter ee = data.rowEnd(y);
-                for (ImIter it = data.rowBegin(y); it != ee; ++it) {
-                    *it = T(*it + gd());
-                }
-            }
+            NoiseAdder<T> adder(gd);
+            transform_pixel(data, adder);
         }
 
     protected:
@@ -281,6 +284,28 @@ namespace galsim {
             _sky_level *= variance_ratio;
         }
 
+        template <typename T>
+        class NoiseAdder
+        {
+        public:
+            NoiseAdder(PoissonDeviate& pd, GaussianDeviate& gd, double max) :
+                _pd(pd), _gd(gd), _max(max) {}
+            T operator()(const T& pix) {
+                if (pix <= 0.) return pix;
+                if (pix < _max) {
+                    _pd.setMean(pix);
+                    return T(_pd());
+                } else {
+                    _gd.setSigma(sqrt(pix));
+                    return T(pix + _gd());
+                }
+            }
+        private:
+            PoissonDeviate& _pd;
+            GaussianDeviate& _gd;
+            const double _max;
+        };
+
         /**
          * @brief Add noise to an Image.
          */
@@ -291,26 +316,13 @@ namespace galsim {
             // The Gaussian deviate is about 20% faster than Poisson, and for high N
             // they are virtually identical.
             const double MAX_POISSON=1.e5;
-            // Typedef for image row iterable
-            typedef typename ImageView<T>::iterator ImIter;
 
             data += T(_sky_level);
 
             PoissonDeviate pd(*_rng, 1.); // will reset the mean for each pixel below.
             GaussianDeviate gd(*_rng, 0., 1.);
-            for (int y = data.getYMin(); y <= data.getYMax(); y++) {  // iterate over y
-                ImIter ee = data.rowEnd(y);
-                for (ImIter it = data.rowBegin(y); it != ee; ++it) {
-                    if (*it <= 0.) continue;
-                    if (*it < MAX_POISSON) {
-                        pd.setMean(*it);
-                        *it = T(pd());
-                    } else {
-                        gd.setSigma(sqrt(*it));
-                        *it = T(*it + gd());
-                    }
-                }
-            }
+            NoiseAdder<T> adder(pd, gd, MAX_POISSON);
+            transform_pixel(data, adder);
 
             data -= T(_sky_level);
         }
@@ -444,6 +456,41 @@ namespace galsim {
             _read_noise *= sqrt(variance_ratio);
         }
 
+        template <typename T>
+        class SkyNoiseAdder
+        {
+        public:
+            SkyNoiseAdder(PoissonDeviate& pd, GaussianDeviate& gd, double gain, double max) :
+                _pd(pd), _gd(gd), _gain(gain), _max(max) {}
+            T operator()(const T& pix)
+            {
+                if (pix <= 0.) return pix;
+                double elec = pix * _gain;
+                if (elec < _max) {
+                    _pd.setMean(elec);
+                    return T(_pd() / _gain);
+                } else {
+                    _gd.setSigma(sqrt(elec)/_gain);
+                    return T(elec + _gd());
+                }
+            }
+        private:
+            PoissonDeviate& _pd;
+            GaussianDeviate& _gd;
+            const double _gain;
+            const double _max;
+        };
+
+        template <typename T>
+        class ReadNoiseAdder
+        {
+        public:
+            ReadNoiseAdder(GaussianDeviate& gd) : _gd(gd) {}
+            T operator()(const T& pix) { return pix + _gd(); }
+        private:
+            GaussianDeviate& _gd;
+        };
+
         /**
          * @brief Add noise to an Image.
          *
@@ -458,8 +505,6 @@ namespace galsim {
             // The Gaussian deviate is about 20% faster than Poisson, and for high N
             // they are virtually identical.
             const double MAX_POISSON=1.e5;
-            // Typedef for image row iterable
-            typedef typename ImageView<T>::iterator ImIter;
 
             data += T(_sky_level);
 
@@ -467,31 +512,15 @@ namespace galsim {
             if (_gain > 0.) {
                 PoissonDeviate pd(*_rng, 1.); // will reset the mean for each pixel below.
                 GaussianDeviate gd(*_rng, 0., 1.);
-                for (int y = data.getYMin(); y <= data.getYMax(); y++) {  // iterate over y
-                    ImIter ee = data.rowEnd(y);
-                    for (ImIter it = data.rowBegin(y); it != ee; ++it) {
-                        if (*it <= 0.) continue;
-                        double electrons = *it * _gain;
-                        if (electrons < MAX_POISSON) {
-                            pd.setMean(electrons);
-                            *it = T(pd() / _gain);
-                        } else {
-                            gd.setSigma(sqrt(electrons)/_gain);
-                            *it = T(*it + gd());
-                        }
-                    }
-                }
+                SkyNoiseAdder<T> adder(pd, gd, _gain, MAX_POISSON);
+                transform_pixel(data, adder);
             }
 
             // Next add the Gaussian noise:
             if (_read_noise > 0.) {
                 GaussianDeviate gd(*_rng, 0., _read_noise / (_gain > 0. ? _gain : 1.));
-                for (int y = data.getYMin(); y <= data.getYMax(); y++) {  // iterate over y
-                    ImIter ee = data.rowEnd(y);
-                    for (ImIter it = data.rowBegin(y); it != ee; ++it) {
-                        *it = T(*it + gd());
-                    }
-                }
+                ReadNoiseAdder<T> adder(gd);
+                transform_pixel(data, adder);
             }
 
             data -= T(_sky_level);
@@ -564,6 +593,16 @@ namespace galsim {
             throw std::runtime_error("scaleVariance not implemented for DeviateNoise");
         }
 
+        template <typename T>
+        class NoiseAdder
+        {
+        public:
+            NoiseAdder(BaseDeviate& dev) : _dev(dev) {}
+            T operator()(const T& pix) { return pix + _dev(); }
+        private:
+            BaseDeviate& _dev;
+        };
+
         /**
          * @brief Add noise to an Image.
          *
@@ -573,12 +612,8 @@ namespace galsim {
         void applyToView(ImageView<T> data)
         {
             // Typedef for image row iterable
-            typedef typename ImageView<T>::iterator ImIter;
-
-            for (int y = data.getYMin(); y <= data.getYMax(); y++) {  // iterate over y
-                ImIter ee = data.rowEnd(y);
-                for (ImIter it = data.rowBegin(y); it != ee; ++it) { *it = T(*it + (*_rng)()); }
-            }
+            NoiseAdder<T> adder(*_rng);
+            transform_pixel(data, adder);
         }
 
     protected:
@@ -653,6 +688,22 @@ namespace galsim {
                 "Changing the variance is not allowed for VariableGaussianNoise");
         }
 
+        template <typename T>
+        class NoiseAdder
+        {
+        public:
+            NoiseAdder(GaussianDeviate& gd) : _gd(gd) {}
+            T operator()(const T& pix, const T& var)
+            {
+                if (!(var >= 0))
+                    throw std::runtime_error("variance image has elements < 0.");
+                _gd.setSigma(sqrt(var));
+                return T(pix + _gd());
+            }
+        private:
+            GaussianDeviate& _gd;
+        };
+
         /**
          * @brief Add noise to an Image.
          */
@@ -665,22 +716,9 @@ namespace galsim {
                                          "variance image in VariableGaussianNoise object.");
             }
 
-            // Typedef for image row iterable
-            typedef typename ImageView<T>::iterator ImIter;
-            typedef typename ConstImageView<float>::const_iterator CImFIter;
-
             GaussianDeviate gd(*_rng, 0., 1.);
-            int y2 = _var_image.getYMin();
-            for (int y = data.getYMin(); y <= data.getYMax(); ++y, ++y2) {  // iterate over y
-                ImIter ee = data.rowEnd(y);
-                CImFIter var_it = _var_image.rowBegin(y2);
-                for (ImIter it = data.rowBegin(y); it != ee; ++it, ++var_it) {
-                    if (!(*var_it >= 0))
-                        throw std::runtime_error("variance image has elements < 0.");
-                    gd.setSigma(sqrt(*var_it));
-                    *it = T(*it + gd());
-                }
-            }
+            NoiseAdder<T> adder(gd);
+            transform_pixel(data, _var_image, adder);
         }
 
     protected:

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -772,33 +772,7 @@ ImageView<double> BaseImage<T>::inverse_fft(double dk) const
     return xim.subImage(Bounds<int>(-No2, No2-1, -No2, No2-1));
 }
 
-namespace {
-
-template <typename T>
-class ConstReturn
-{
-public:
-    ConstReturn(const T v): val(v) {}
-    T operator()(const T ) const { return val; }
-private:
-    T val;
-};
-
-template <typename T>
-class ReturnInverse
-{
-public:
-    T operator()(const T val) const { return val==T(0) ? T(0.) : T(1./val); }
-};
-
-template <typename T>
-class ReturnSecond
-{
-public:
-    T operator()(T, T v) const { return v; }
-};
-
-} // anonymous
+// The classes ConstReturn, ReturnInverse, and ReturnSecond are defined in ImageArith.h.
 
 template <typename T>
 void ImageView<T>::fill(T x)
@@ -817,7 +791,7 @@ void ImageView<T>::copyFrom(const BaseImage<T>& rhs)
 {
     if (!this->_bounds.isSameShapeAs(rhs.getBounds()))
         throw ImageError("Attempt im1 = im2, but bounds not the same shape");
-    transform_pixel(*this, rhs, ReturnSecond<T>());
+    transform_pixel(*this, rhs, ReturnSecond<T,T>());
 }
 
 // A helper function that will return the smallest 2^n or 3x2^n value that is

--- a/src/SBInterpolatedImage.cpp
+++ b/src/SBInterpolatedImage.cpp
@@ -423,14 +423,21 @@ namespace galsim {
         oss << "galsim._galsim.ConstImageViewD(array([";
 
         ConstImageView<double> im = getImage();
-        Bounds<int> _bds = im.getBounds();
-        for (int y = _bds.getYMin(); y<=_bds.getYMax(); ++y) {
-            if (y > _bds.getYMin()) oss <<",";
-            BaseImage<double>::const_iterator it = im.rowBegin(y);
-            oss << "[" << *it++;
-            for (; it != im.rowEnd(y); ++it) oss << "," << *it;
+        const double* ptr = im.getData();
+        const int skip = im.getNSkip();
+        const int step = im.getStep();
+        const int xmin = im.getXMin();
+        const int xmax = im.getXMax();
+        const int ymin = im.getYMin();
+        const int ymax = im.getYMax();
+        for (int j=ymin; j<=ymax; j++, ptr+=skip) {
+            if (j > ymin) oss <<",";
+            oss << "[" << *ptr;
+            ptr += step;
+            for (int i=xmin+1; i<=xmax; i++, ptr+=step) oss << "," << *ptr;
             oss << "]";
         }
+
         oss<<"],dtype=float)), ";
 
         boost::shared_ptr<Interpolant> xinterp = getXInterp();
@@ -987,19 +994,24 @@ namespace galsim {
         std::ostringstream oss(" ");
         oss.precision(std::numeric_limits<double>::digits10 + 4);
         oss << "galsim._galsim.SBInterpolatedKImage(";
-
         oss << "galsim._galsim.ConstImageViewD(array([";
+
         ConstImageView<double> data = getKData();
-        Bounds<int> _bds = data.getBounds();
-        int ymin = _bds.getYMin();
-        int ymax = _bds.getYMax();
-        for (int y = ymin; y<=ymax; ++y) {
-            if (y > 0) oss <<",";
-            BaseImage<double>::const_iterator it = data.rowBegin(y);
-            oss << "[" << *it++;
-            for (; it != data.rowEnd(y); ++it) oss << "," << *it;
+        const double* ptr = data.getData();
+        const int skip = data.getNSkip();
+        const int step = data.getStep();
+        const int xmin = data.getXMin();
+        const int xmax = data.getXMax();
+        const int ymin = data.getYMin();
+        const int ymax = data.getYMax();
+        for (int j=ymin; j<=ymax; j++, ptr+=skip) {
+            if (j > ymin) oss <<",";
+            oss << "[" << *ptr;
+            ptr += step;
+            for (int i=xmin+1; i<=xmax; i++, ptr+=step) oss << "," << *ptr;
             oss << "]";
         }
+
         oss<<"],dtype=float)), ";
 
         oss << _ktab->getDk() << ", " << stepK() << ", " << maxK() << ", ";

--- a/src/hsm/PSFCorr.cpp
+++ b/src/hsm/PSFCorr.cpp
@@ -510,11 +510,11 @@ namespace hsm {
 
         /* Setup */
         int xmin = data.getXMin();
-        int xmax = data.getXMax();
         int ymin = data.getYMin();
-        int ymax = data.getYMax();
-        int nx = xmax-xmin+1;
-        int ny = ymax-ymin+1;
+        int nx = data.getNCol();
+        int ny = data.getNRow();
+        int sx = data.getStep();
+        int sy = data.getStride();
         tmv::Matrix<double> psi_x(nx, max_order+1);
         tmv::Matrix<double> psi_y(ny, max_order+1);
 
@@ -522,7 +522,7 @@ namespace hsm {
         qho1d_wf_1(nx, (double)xmin - x0, 1., max_order, sigma, psi_x);
         qho1d_wf_1(ny, (double)ymin - y0, 1., max_order, sigma, psi_y);
 
-        tmv::ConstMatrixView<double> mdata(data.getData(),nx,ny,1,data.getStride(),tmv::NonConj);
+        tmv::ConstMatrixView<double> mdata(data.getData(),nx,ny,sx,sy,tmv::NonConj);
 
         moments = psi_x.transpose() * mdata * psi_y;
     }
@@ -717,10 +717,11 @@ namespace hsm {
             if (ix2 > xmax) ix2 = xmax;
             if (ix1 > ix2) continue;  // rare, but it can happen after the ceil and floor.
 
-            const double* imageptr = data.getIter(ix1,y);
+            const double* imageptr = data.getPtr(ix1,y);
+            const int step = data.getStep();
             double x_x0 = ix1 - x0;
             const double* mxxptr = Minv_xx__x_x0__x_x0.cptr() + ix1-xmin;
-            for(int x=ix1;x<=ix2;++x,x_x0+=1.) {
+            for(int x=ix1;x<=ix2;++x,x_x0+=1.,imageptr+=step) {
                 /* Compute displacement from weight centroid, then
                  * get elliptical radius and weight.
                  */
@@ -728,7 +729,7 @@ namespace hsm {
                 xdbg<<"Using pixel: "<<x<<" "<<y<<" with value "<<*(imageptr)<<" rho2 "<<rho2<<" x_x0 "<<x_x0<<" y_y0 "<<y_y0<<std::endl;
                 xassert(rho2 < hsmparams->max_moment_nsig2 + 1.e-8); // allow some numerical error.
 
-                double intensity = std::exp(-0.5 * rho2) * (*imageptr++);
+                double intensity = std::exp(-0.5 * rho2) * (*imageptr);
 
                 /* Now do the addition */
                 double intensity__x_x0 = intensity * x_x0;
@@ -895,23 +896,26 @@ namespace hsm {
         dbg<<"image1.bounds = "<<image1.getBounds()<<std::endl;
         dbg<<"image2.bounds = "<<image2.getBounds()<<std::endl;
         dbg<<"image_out.bounds = "<<image_out.getBounds()<<std::endl;
-        int nx1 = image1.getXMax() - image1.getXMin() + 1;
-        int ny1 = image1.getYMax() - image1.getYMin() + 1;
-        int s1 = image1.getStride();
-        int nx2 = image2.getXMax() - image2.getXMin() + 1;
-        int ny2 = image2.getYMax() - image2.getYMin() + 1;
-        int s2 = image2.getStride();
-        int nx3 = image_out.getXMax() - image_out.getXMin() + 1;
-        int ny3 = image_out.getYMax() - image_out.getYMin() + 1;
-        int s3 = image_out.getStride();
-        dbg<<"image1: "<<nx1<<','<<ny1<<','<<s1<<std::endl;
-        dbg<<"image2: "<<nx2<<','<<ny2<<','<<s2<<std::endl;
-        dbg<<"image3: "<<nx3<<','<<ny3<<','<<s3<<std::endl;
+        int nx1 = image1.getNCol();
+        int ny1 = image1.getNRow();
+        int sx1 = image1.getStep();
+        int sy1 = image1.getStride();
+        int nx2 = image2.getNCol();
+        int ny2 = image2.getNRow();
+        int sx2 = image2.getStep();
+        int sy2 = image2.getStride();
+        int nx3 = image_out.getNCol();
+        int ny3 = image_out.getNRow();
+        int sx3 = image_out.getStep();
+        int sy3 = image_out.getStride();
+        dbg<<"image1: "<<nx1<<','<<ny1<<','<<sx1<<','<<sy1<<std::endl;
+        dbg<<"image2: "<<nx2<<','<<ny2<<','<<sx2<<','<<sy2<<std::endl;
+        dbg<<"image3: "<<nx3<<','<<ny3<<','<<sx3<<','<<sy3<<std::endl;
 
         // Convenient matrix views into the images:
-        tmv::ConstMatrixView<double> mIm1(image1.getData(),nx1,ny1,1,s1,tmv::NonConj);
-        tmv::ConstMatrixView<double> mIm2(image2.getData(),nx2,ny2,1,s2,tmv::NonConj);
-        tmv::MatrixView<double> mIm3(image_out.getData(),nx3,ny3,1,s3,tmv::NonConj);
+        tmv::ConstMatrixView<double> mIm1(image1.getData(),nx1,ny1,sx1,sy1,tmv::NonConj);
+        tmv::ConstMatrixView<double> mIm2(image2.getData(),nx2,ny2,sx2,sy2,tmv::NonConj);
+        tmv::MatrixView<double> mIm3(image_out.getData(),nx3,ny3,sx3,sy3,tmv::NonConj);
         dbg<<"mIm1 = "<<mIm1<<std::endl;
         dbg<<"mIm2 = "<<mIm2<<std::endl;
         dbg<<"mIm3 = "<<mIm3<<std::endl;

--- a/tests/test_hsm.py
+++ b/tests/test_hsm.py
@@ -803,24 +803,30 @@ def test_noncontiguous():
     img = gal.drawImage(nx=64, ny=64, scale=0.2)
     meas_shape1 = galsim.hsm.FindAdaptiveMom(img).observed_shape
     print(meas_shape1)
-    np.testing.assert_almost_equal(meas_shape1.g1, 0.1, decimal=3)
-    np.testing.assert_almost_equal(meas_shape1.g2, 0.2, decimal=3)
+    np.testing.assert_almost_equal(meas_shape1.g1, 0.1, decimal=3,
+                                   err_msg="HSM measured wrong shear on normal image")
+    np.testing.assert_almost_equal(meas_shape1.g2, 0.2, decimal=3,
+                                   err_msg="HSM measured wrong shear on normal image")
 
     # Transpose the image, which should just flip the sign of g1.
     # Note, though, that this changes the ndarray from C-ordering to FORTRAN-ordering.
     fimg = galsim.Image(img.array.T, scale=0.2)
     meas_shape2 = galsim.hsm.FindAdaptiveMom(fimg).observed_shape
     print(meas_shape2)
-    np.testing.assert_almost_equal(meas_shape2.g1, -0.1, decimal=3)
-    np.testing.assert_almost_equal(meas_shape2.g2, 0.2, decimal=3)
+    np.testing.assert_almost_equal(meas_shape2.g1, -0.1, decimal=3,
+                                   err_msg="HSM measured wrong shear on transposed image")
+    np.testing.assert_almost_equal(meas_shape2.g2, 0.2, decimal=3,
+                                   err_msg="HSM measured wrong shear on transposed image")
 
     # Also test the real part of an ImageC, which not contiguous in either direction (step=2)
     # This should have the negative shear from drawing in k space.
     kimg = gal.drawKImage(nx=64, ny=64)
     meas_shape3 = galsim.hsm.FindAdaptiveMom(kimg.real).observed_shape
     print(meas_shape3)
-    np.testing.assert_almost_equal(meas_shape3.g1, -0.1, decimal=3)
-    np.testing.assert_almost_equal(meas_shape3.g2, -0.2, decimal=3)
+    np.testing.assert_almost_equal(meas_shape3.g1, -0.1, decimal=3,
+                                   err_msg="HSM measured wrong shear on image with step=2")
+    np.testing.assert_almost_equal(meas_shape3.g2, -0.2, decimal=3,
+                                   err_msg="HSM measured wrong shear on image with step=2")
 
 
 if __name__ == "__main__":

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -110,6 +110,17 @@ def test_roundtrip():
         do_pickle(interp)
         do_pickle(interp.SBProfile)
 
+    # Test using a non-c-contiguous image  (.T transposes the image, making it fourtran order)
+    image_T = galsim.Image(ref_array.astype(array_type).T)
+    interp = galsim.InterpolatedImage(image_T, scale=test_scale)
+    test_array = np.zeros(ref_array.T.shape, dtype=array_type)
+    image_out = galsim.Image(test_array, scale=test_scale)
+    interp.drawImage(image_out, method='no_pixel')
+    np.testing.assert_array_equal(
+            ref_array.T.astype(array_type),image_out.array,
+            err_msg="Transposed array failed InterpolatedImage roundtrip.")
+    check_basic(interp, "InterpolatedImage (Fortran ordering)", approx_maxsb=True)
+
     # Also check picklability of the Interpolants
     im = galsim.Gaussian(sigma=4).drawImage()
     test_func = lambda x : (

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -110,7 +110,7 @@ def test_roundtrip():
         do_pickle(interp)
         do_pickle(interp.SBProfile)
 
-    # Test using a non-c-contiguous image  (.T transposes the image, making it fourtran order)
+    # Test using a non-c-contiguous image  (.T transposes the image, making it Fortran order)
     image_T = galsim.Image(ref_array.astype(array_type).T)
     interp = galsim.InterpolatedImage(image_T, scale=test_scale)
     test_array = np.zeros(ref_array.T.shape, dtype=array_type)

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -237,6 +237,14 @@ def test_uniform():
             testimage.array.flatten(), np.array(uResult), precision,
             err_msg='Wrong uniform random number sequence generated when applied to image.')
 
+    # Test filling an image with Fortran ordering
+    u.seed(testseed)
+    testimage = galsim.ImageD(np.zeros((5, 5)).T)
+    testimage.addNoise(galsim.DeviateNoise(u))
+    np.testing.assert_array_almost_equal(
+            [testimage(1,1),testimage(2,1),testimage(3,1)], np.array(uResult), precision,
+            err_msg="Wrong uniform randoms generated for Fortran-ordered Image")
+
     # Check picklability
     do_pickle(u, lambda x: x.serialize())
     do_pickle(u, lambda x: (x(), x(), x(), x()))
@@ -367,6 +375,14 @@ def test_gaussian():
     np.testing.assert_array_almost_equal(
             testimage.array.flatten(), np.array(gResult)-gMean, precision,
             err_msg="GaussianNoise applied to Images does not reproduce expected sequence")
+
+    # Test filling an image with Fortran ordering
+    rng.seed(testseed)
+    testimage = galsim.ImageD(np.zeros((5, 5)).T)
+    testimage.addNoise(gn)
+    np.testing.assert_array_almost_equal(
+            [testimage(1,1),testimage(2,1),testimage(3,1)], np.array(gResult)-gMean, precision,
+            err_msg="Wrong Gaussian noise generated for Fortran-ordered Image")
 
     # Check GaussianNoise variance:
     np.testing.assert_almost_equal(
@@ -708,6 +724,14 @@ def test_poisson():
     np.testing.assert_array_equal(
             testimage.array.flatten(), np.array(pResult)-pMean,
             err_msg='Wrong poisson random number sequence generated using PoissonNoise')
+
+    # Test filling an image with Fortran ordering
+    rng.seed(testseed)
+    testimage = galsim.ImageD(np.zeros((5, 5)).T)
+    testimage.addNoise(pn)
+    np.testing.assert_array_almost_equal(
+            [testimage(1,1),testimage(2,1),testimage(3,1)], np.array(pResult)-pMean,
+            err_msg="Wrong Poisson noise generated for Fortran-ordered Image")
 
     # Check PoissonNoise variance:
     np.testing.assert_almost_equal(
@@ -1474,6 +1498,15 @@ def test_ccdnoise():
                 testImage.array, cResult, prec,
                 err_msg="Wrong CCD noise random sequence generated for Image"+typestrings[i]+
                 " using addNoise")
+
+        # Test filling an image with Fortran ordering
+        rng.seed(testseed)
+        testImageF = galsim.Image(np.zeros((2, 2)).T, dtype=types[i])
+        testImageF.fill(sky)
+        testImageF.addNoise(ccdnoise)
+        np.testing.assert_array_almost_equal(
+                testImageF.array, cResult, prec,
+                err_msg="Wrong CCD noise generated for Fortran-ordered Image"+typestrings[i])
 
         # Now include sky_level in ccdnoise
         rng.seed(testseed)


### PR DESCRIPTION
In #799, I updated the Image class to work with arbitrary steps between the values in both directions, i.e. not require the underlying array to be C-contiguous.  However, I missed some uses that depended on the C-contiguousness of the array.  Since that's usually what we have, it didn't trigger any errors in the tests.

Anyway, Josh ran across one, which he reported in #833.  I fixed that and added unit tests that would have caught the problem.  There were also problems with the addNoise implementations, so I fixed that and added tests there as well.

SBInterpolatedImage serialize also used the error-prone iterators, although it always uses a C-contiguous image, so it wasn't ever a problem.  But I switched it anyway and removed the Image iterator methods.