### PR TITLE
Optimizations for OpticalPSF code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,7 @@ New Features
 - Added galsim.fft module that includes functions that act as drop-in
   replacements for np.fft functions, but using the C-layer FFTW package.
   Our functions have more restrictions on the input arrays, but when valid
-  are genarally somewhat faster than the numpy functions. (#840)
+  are generally somewhat faster than the numpy functions. (#840)
 
 
 New config features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,10 @@ New Features
   (#827)
 - Added `ii_pad_factor` kwarg to PhaseScreenPSF and OpticalPSF to control the
   zero-padding of the underlying InterpolatedImage. (#835)
+- Added galsim.fft module that includes functions that act as drop-in
+  replacements for np.fft functions, but using the C-layer FFTW package.
+  Our functions have more restrictions on the input arrays, but when valid
+  are genarally somewhat faster than the numpy functions. (#840)
 
 
 New config features

--- a/galsim/__init__.py
+++ b/galsim/__init__.py
@@ -169,3 +169,4 @@ from . import dcr
 from . import meta_data
 from . import cdmodel
 from . import optics
+from . import fft

--- a/galsim/__init__.py
+++ b/galsim/__init__.py
@@ -92,7 +92,7 @@ version = __version__
 
 # First some basic building blocks that don't usually depend on anything else
 from .position import PositionI, PositionD
-from .bounds import BoundsI, BoundsD
+from .bounds import BoundsI, BoundsD, _BoundsI
 from .shear import Shear
 from .angle import Angle, AngleUnit, radians, hours, degrees, arcmin, arcsec, HMS_Angle, DMS_Angle
 from .catalog import Catalog, Dict, OutputCatalog

--- a/galsim/__init__.py
+++ b/galsim/__init__.py
@@ -100,7 +100,7 @@ from .scene import COSMOSCatalog
 from .table import LookupTable, LookupTable2D
 
 # Image
-from .image import Image, ImageS, ImageI, ImageF, ImageD, ImageC, ImageUS, ImageUI
+from .image import Image, ImageS, ImageI, ImageF, ImageD, ImageC, ImageUS, ImageUI, _Image
 
 # PhotonArray
 from .photon_array import PhotonArray, WavelengthSampler, FRatioAngles

--- a/galsim/__init__.py
+++ b/galsim/__init__.py
@@ -129,7 +129,7 @@ from .compound import Add, Sum, Convolve, Convolution, Deconvolve, Deconvolution
 from .compound import AutoConvolve, AutoConvolution, AutoCorrelate, AutoCorrelation
 from .compound import FourierSqrt, FourierSqrtProfile
 from .compound import RandomWalk
-from .transform import Transform, Transformation
+from .transform import Transform, Transformation, _Transform
 
 # Chromatic
 from .chromatic import ChromaticObject, ChromaticAtmosphere, ChromaticSum

--- a/galsim/bounds.py
+++ b/galsim/bounds.py
@@ -191,6 +191,14 @@ def _new_BoundsI_init(self, *args, **kwargs):
         _orig_BoundsI_init(self, *args, **kwargs)
 BoundsI.__init__ = _new_BoundsI_init
 
+def _BoundsI(xmin, xmax, ymin, ymax):
+    """Equivalent to BoundsI constructor, but skips some sanity checks and argument parsing.
+    This requires the four values already be int types.
+    """
+    ret = BoundsI.__new__(BoundsI)
+    _orig_BoundsI_init(ret, xmin, xmax, ymin, ymax)
+    return ret
+
 def BoundsI_numpyShape(self):
     """A simple utility function to get the numpy shape that corresponds to this Bounds object.
     """

--- a/galsim/bounds.py
+++ b/galsim/bounds.py
@@ -193,7 +193,7 @@ BoundsI.__init__ = _new_BoundsI_init
 
 def _BoundsI(xmin, xmax, ymin, ymax):
     """Equivalent to BoundsI constructor, but skips some sanity checks and argument parsing.
-    This requires the four values already be int types.
+    This requires that the four values already be int types.
     """
     ret = BoundsI.__new__(BoundsI)
     _orig_BoundsI_init(ret, xmin, xmax, ymin, ymax)

--- a/galsim/fft.py
+++ b/galsim/fft.py
@@ -97,14 +97,14 @@ def fft2(a, shift_in=False, shift_out=False):
             # This only returns kx >= 0.  Fill out the full image.
             kar = np.empty( (M,N), dtype=np.complex128)
             if shift_out:
-                kar[:,N/2:N] = rkar[:,0:N/2]
-                kar[0,0:N/2] = rkar[0,N/2:0:-1].conjugate()
-                kar[1:M/2,0:N/2] = rkar[M-1:M/2:-1,N/2:0:-1].conjugate()
-                kar[M/2:M,0:N/2] = rkar[M/2:0:-1,N/2:0:-1].conjugate()
+                kar[:,No2:N] = rkar[:,0:No2]
+                kar[0,0:No2] = rkar[0,No2:0:-1].conjugate()
+                kar[1:Mo2,0:No2] = rkar[M-1:Mo2:-1,No2:0:-1].conjugate()
+                kar[Mo2:M,0:No2] = rkar[Mo2:0:-1,No2:0:-1].conjugate()
             else:
-                kar[:,0:N/2] = rkar[:,0:N/2]
-                kar[0,N/2:N] = rkar[0,N/2:0:-1].conjugate()
-                kar[1:M,N/2:N] = rkar[M-1:0:-1,N/2:0:-1].conjugate()
+                kar[:,0:No2] = rkar[:,0:No2]
+                kar[0,No2:N] = rkar[0,No2:0:-1].conjugate()
+                kar[1:M,No2:N] = rkar[M-1:0:-1,No2:0:-1].conjugate()
     return kar
 
 

--- a/galsim/fft.py
+++ b/galsim/fft.py
@@ -90,23 +90,23 @@ def fft2(a, shift_in=False, shift_out=False):
     else:
         a = a.astype(np.float64, copy=False)
         xim = galsim._galsim.ConstImageViewD(a, -No2, -Mo2)
-        if False:
-            # This works, but it's a bit slower.
-            kar = xim.cfft(shift_in=shift_in, shift_out=shift_out).array
+
+        # This works, but it's a bit slower.
+        #kar = xim.cfft(shift_in=shift_in, shift_out=shift_out).array
+
+        # Faster to start with rfft2 version
+        rkar = xim.rfft(shift_in=shift_in, shift_out=shift_out).array
+        # This only returns kx >= 0.  Fill out the full image.
+        kar = np.empty( (M,N), dtype=np.complex128)
+        if shift_out:
+            kar[:,No2:N] = rkar[:,0:No2]
+            kar[0,0:No2] = rkar[0,No2:0:-1].conjugate()
+            kar[1:Mo2,0:No2] = rkar[M-1:Mo2:-1,No2:0:-1].conjugate()
+            kar[Mo2:M,0:No2] = rkar[Mo2:0:-1,No2:0:-1].conjugate()
         else:
-            # Start with rfft2 version
-            rkar = xim.rfft(shift_in=shift_in, shift_out=shift_out).array
-            # This only returns kx >= 0.  Fill out the full image.
-            kar = np.empty( (M,N), dtype=np.complex128)
-            if shift_out:
-                kar[:,No2:N] = rkar[:,0:No2]
-                kar[0,0:No2] = rkar[0,No2:0:-1].conjugate()
-                kar[1:Mo2,0:No2] = rkar[M-1:Mo2:-1,No2:0:-1].conjugate()
-                kar[Mo2:M,0:No2] = rkar[Mo2:0:-1,No2:0:-1].conjugate()
-            else:
-                kar[:,0:No2] = rkar[:,0:No2]
-                kar[0,No2:N] = rkar[0,No2:0:-1].conjugate()
-                kar[1:M,No2:N] = rkar[M-1:0:-1,No2:0:-1].conjugate()
+            kar[:,0:No2] = rkar[:,0:No2]
+            kar[0,No2:N] = rkar[0,No2:0:-1].conjugate()
+            kar[1:M,No2:N] = rkar[M-1:0:-1,No2:0:-1].conjugate()
     return kar
 
 

--- a/galsim/fft.py
+++ b/galsim/fft.py
@@ -82,10 +82,10 @@ def fft2(a, shift_in=False, shift_out=False):
         raise ValueError("Input array must have even sizes")
 
     if a.dtype.kind == 'c':
-        a = a.astype(np.complex128)
+        a = a.astype(np.complex128, copy=False)
         xim = galsim._galsim.ConstImageViewC(a, -No2, -Mo2)
     else:
-        a = a.astype(np.float64)
+        a = a.astype(np.float64, copy=False)
         xim = galsim._galsim.ConstImageViewD(a, -No2, -Mo2)
     return xim.cfft(shift_in=shift_in, shift_out=shift_out).array
 
@@ -142,10 +142,10 @@ def ifft2(a, shift_in=False, shift_out=False):
         raise ValueError("Input array must have even sizes")
 
     if a.dtype.kind == 'c':
-        a = a.astype(np.complex128)
+        a = a.astype(np.complex128, copy=False)
         xim = galsim._galsim.ConstImageViewC(a, -No2, -Mo2)
     else:
-        a = a.astype(np.float64)
+        a = a.astype(np.float64, copy=False)
         xim = galsim._galsim.ConstImageViewD(a, -No2, -Mo2)
     return xim.cfft(inverse=True, shift_in=shift_in, shift_out=shift_out).array
 
@@ -194,7 +194,7 @@ def rfft2(a, shift_in=False, shift_out=False):
     if M != Mo2*2 or N != No2*2:
         raise ValueError("Input array must have even sizes")
 
-    a = a.astype(np.float64)
+    a = a.astype(np.float64, copy=False)
     xim = galsim._galsim.ConstImageViewD(a, -No2, -Mo2)
     return xim.rfft(shift_in=shift_in, shift_out=shift_out).array
 
@@ -242,7 +242,7 @@ def irfft2(a, shift_in=False, shift_out=False):
     if M != Mo2*2:
         raise ValueError("Input array must have even sizes")
 
-    a = a.astype(np.complex128)
+    a = a.astype(np.complex128, copy=False)
     kim = galsim._galsim.ConstImageViewC(a, 0, -Mo2)
     return kim.irfft(shift_in=shift_in, shift_out=shift_out).array
 

--- a/galsim/fft.py
+++ b/galsim/fft.py
@@ -51,7 +51,7 @@ def fft2(a, shift_in=False, shift_out=False):
         - The size in each direction must be even. (Ideally 2^k or 3*2^k for speed, but this is
           not required.)
         - If it has a real dtype, it will be coerced to numpy.float64.
-        - If it hsa a complex dtype, it will be coerced to numpy.complex128.
+        - If it has a complex dtype, it will be coerced to numpy.complex128.
 
     The returned array will be complex with dtype numpy.complex128.
 
@@ -129,7 +129,7 @@ def ifft2(a, shift_in=False, shift_out=False):
                for kx >= N/2, ky = 0: a[0, kx] == a[0, N-kx].conjugate()
           Only the elements a[:,0:N/2+1] are accessed by this function.
         - If it has a real dtype, it will be coerced to numpy.float64.
-        - If it hsa a complex dtype, it will be coerced to numpy.complex128.
+        - If it has a complex dtype, it will be coerced to numpy.complex128.
 
     The returned array will be real with dtype numpy.float64.
 
@@ -179,7 +179,7 @@ def rfft2(a, shift_in=False, shift_out=False):
     Restrictions on this version vs the numpy version:
 
         - The input array must be 2-dimensional.
-        - If it does not have dtype numpy.float64, it will be cerced to numpy.float64.
+        - If it does not have dtype numpy.float64, it will be coerced to numpy.float64.
         - It must be square.
         - The size in each direction must be even. (Ideally 2^k or 3*2^k for speed, but this is
           not required.)
@@ -228,7 +228,7 @@ def irfft2(a, shift_in=False, shift_out=False):
     Restrictions on this version vs the numpy version:
 
         - The array must be 2-dimensional.
-        - If it does not have dtype numpy.complex128, it will be cerced to numpy.complex128.
+        - If it does not have dtype numpy.complex128, it will be coerced to numpy.complex128.
         - It must have shape (M, N/2+1).
         - The size M must be even. (Ideally 2^k or 3*2^k for speed, but this is not required.)
 

--- a/galsim/fft.py
+++ b/galsim/fft.py
@@ -189,7 +189,7 @@ def rfft2(a, shift_in=False, shift_out=False):
     No2 = N // 2
     a = a.astype(np.float64)
     xim = galsim._galsim.ConstImageViewD(a, -No2, -No2)
-    kim = xim.fft(1.0, shift_in=shift_in, shift_out=shift_out)
+    kim = xim.fft(shift_in=shift_in, shift_out=shift_out)
     kar = kim.array
     return kar
 
@@ -237,7 +237,7 @@ def irfft2(a, shift_in=False, shift_out=False):
 
     a = a.astype(np.complex128)
     kim = galsim._galsim.ConstImageViewC(a, 0, -No2)
-    xim = kim.inverse_fft(np.pi / No2, shift_in=shift_in, shift_out=shift_out)
+    xim = kim.inverse_fft(shift_in=shift_in, shift_out=shift_out)
     xar = xim.array
     return xar
 

--- a/galsim/fft.py
+++ b/galsim/fft.py
@@ -1,0 +1,244 @@
+# Copyright (c) 2012-2016 by the GalSim developers team on GitHub
+# https://github.com/GalSim-developers
+#
+# This file is part of GalSim: The modular galaxy image simulation toolkit.
+# https://github.com/GalSim-developers/GalSim
+#
+# GalSim is free software: redistribution and use in source and binary forms,
+# with or without modification, are permitted provided that the following
+# conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions, and the disclaimer given in the accompanying LICENSE
+#    file.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions, and the disclaimer given in the documentation
+#    and/or other materials provided with the distribution.
+#
+"""@file fft.py
+Functional equivalents of (some of) the np.fft functions, but using FFTW.
+
+These should be drop in replacements for np.fft.* functions.  e.g.
+
+    >>> karray = galsim.fft.fft2(xarray)
+
+is functionally equivalent to
+
+    >>> karray = np.fft.fft2(xarray)
+
+but should be a bit faster.
+
+Note that the GalSim versions often only implement the normal use case without many of the
+advanced options available with the numpy functions.  This is mostly laziness on our part --
+we only implemented the functions that we needed.  If your usage requires some option available
+in the numpy version, feel free to post a feature request on our GitHub page.
+"""
+
+import galsim
+import numpy as np
+
+def fft2(a, shift_in=False, shift_out=False):
+    """Compute the 2-dimensional discrete Fourier Transform.
+
+    For valid inputs, the result is equivalent to numpy.fft.fft2(a), but usually faster.
+
+        >>> ka1 = numpy.fft.fft2(a)
+        >>> ka2 = galsim.fft.fft2(a)
+
+    Restrictions on this version vs the numpy version:
+
+        - The input array must be 2-dimensional.
+        - It must have dtype numpy.float64 or be convertible to numpy.float64.
+        - It must be square.
+        - The size in each direction must be even.
+
+    The returned array will be complex with dtype numpy.complex128.
+
+    If shift_in is True, then this is equivalent to applying numpy.fft.fftshift to the input.
+
+        >>> ka1 = numpy.fft.fft2(numpy.fft.fftshift(a))
+        >>> ka2 = galsim.fft.fft2(a, shift_in=True)
+
+    If shift_out is True, then this is equivalent to applying numpy.fft.fftshift to the output.
+
+        >>> ka1 = numpy.fft.fftshift(numpy.fft.fft2(a))
+        >>> ka2 = galsim.fft.fft2(a, shift_out=True)
+
+    @param a            The input array to be transformed
+    @param shift_in     Whether to shift the input array so that the center is moved to (0,0).
+    @param shift_out    Whether to shift the output array so that the center is moved to (0,0).
+
+    @returns a complex numpy array
+    """
+    # Start with rfft2, which is what we really have implemented.
+    kar = rfft2(a,shift_in,shift_out)
+
+    # This only returns kx >= 0.  Fill out the full image.
+    N = a.shape[0]
+    full_kar = np.empty( (N,N), dtype=np.complex128)
+    if shift_out:
+        full_kar[:,N/2:N] = kar[:,0:N/2]
+        full_kar[0,0:N/2] = kar[0,N/2:0:-1].conjugate()
+        full_kar[1:N/2,0:N/2] = kar[N-1:N/2:-1,N/2:0:-1].conjugate()
+        full_kar[N/2:N,0:N/2] = kar[N/2:0:-1,N/2:0:-1].conjugate()
+    else:
+        full_kar[:,0:N/2] = kar[:,0:N/2]
+        full_kar[0,N/2:N] = kar[0,N/2:0:-1].conjugate()
+        full_kar[1:N,N/2:N] = kar[N-1:0:-1,N/2:0:-1].conjugate()
+    return full_kar
+
+
+def ifft2(a, shift_in=False, shift_out=False):
+    """Compute the 2-dimensional inverse discrete Fourier Transform.
+
+    For valid inputs, the result is equivalent to numpy.fft.ifft2(a), but usually faster.
+
+        >>> a1 = numpy.fft.ifft2(ka)
+        >>> a2 = galsim.fft.ifft2(ka)
+
+    Restrictions on this version vs the numpy version:
+
+        - The array must be 2-dimensional.
+        - It must have dtype numpy.complex128 or be convertible to numpy.complex128
+        - It must be square.
+        - The size in each direction must be even.
+        - The array is assumed to be Hermitian, which means the k values with kx<0 are assumed
+          to be equal to the conjuate of their inverse.  This will always be the case if
+          a is an output of fft2 (with a real input array).
+          i.e. for kx >= N/2, ky > 0: a[ky, kx] == a[N-ky, N-kx].conjugate()
+               for kx >= N/2, ky = 0: a[0, kx] == a[0, N-kx].conjugate()
+          Only the elements a[:,0:N/2+1] are accessed by this function.
+
+    The returned array will be real with dtype numpy.float64.
+
+    If shift_in is True, then this is equivalent to applying numpy.fft.fftshift to the input.
+
+        >>> a1 = numpy.fft.ifft2(numpy.fft.fftshift(ka))
+        >>> a2 = galsim.fft.ifft2(ka, shift_in=True)
+
+    If shift_out is True, then this is equivalent to applying numpy.fft.fftshift to the output.
+
+        >>> a1 = numpy.fft.fftshift(numpy.fft.ifft2(ka))
+        >>> a2 = galsim.fft.ifft2(ka, shift_out=True)
+
+    @param a            The input array to be transformed
+    @param shift_in     Whether to shift the input array so that the center is moved to (0,0).
+    @param shift_out    Whether to shift the output array so that the center is moved to (0,0).
+
+    @returns a real numpy array
+    """
+    s = a.shape
+    if len(s) != 2:
+        raise ValueError("Input array must be 2D.")
+    N = s[0]
+    if N != s[1]:
+        raise ValueError("Input array must be square.")
+
+    No2 = N // 2
+    if shift_in:
+        # In this case, the values we need aren't actually together in the input array.
+        # Need to make a temporary.
+        a1 = np.empty((N,No2+1), dtype=np.complex128)
+        a1[:,0:No2] = a[:,No2:N]
+        a1[:,No2] = a[:,0]
+        return irfft2(a1,shift_in,shift_out)
+    else:
+        return irfft2(a[:,0:No2+1],shift_in,shift_out)
+
+
+def rfft2(a, shift_in=False, shift_out=False):
+    """Compute the one-dimensional discrete Fourier Transform for real input.
+
+    For valid inputs, the result is equivalent to numpy.fft.rfft2(a), but usually faster.
+
+        >>> ka1 = numpy.fft.rfft2(a)
+        >>> ka2 = galsim.fft.rfft2(a)
+
+    Restrictions on this version vs the numpy version:
+
+        - The input array must be 2-dimensional.
+        - It must have dtype numpy.float64 or be convertible to numpy.float64.
+        - It must be square.
+        - The size in each direction must be even.
+
+    The returned array will be complex with dtype numpy.complex128.
+
+    If shift_in is True, then this is equivalent to applying numpy.fft.fftshift to the input.
+
+        >>> ka1 = numpy.fft.rfft2(numpy.fft.fftshift(a))
+        >>> ka2 = galsim.fft.rfft2(a, shift_in=True)
+
+    If shift_out is True, then this is equivalent to applying numpy.fft.fftshift to the output.
+
+        >>> ka1 = numpy.fft.fftshift(numpy.fft.rfft2(a),axes=(0,))
+        >>> ka2 = galsim.fft.rfft2(a, shift_out=True)
+
+    @param a            The input array to be transformed
+    @param shift_in     Whether to shift the input array so that the center is moved to (0,0).
+    @param shift_out    Whether to shift the output array so that the center is moved to (0,0).
+
+    @returns a complex numpy array
+    """
+    s = a.shape
+    if len(s) != 2:
+        raise ValueError("Input array must be 2D.")
+    N = s[0]
+    if N != s[1]:
+        raise ValueError("Input array must be square.")
+
+    No2 = N // 2
+    a = a.astype(np.float64)
+    xim = galsim._galsim.ConstImageViewD(a, -No2, -No2)
+    kim = xim.fft(1.0, shift_in=shift_in, shift_out=shift_out)
+    kar = kim.array
+    return kar
+
+
+def irfft2(a, shift_in=False, shift_out=False):
+    """Compute the 2-dimensional inverse FFT of a real array.
+
+    For valid inputs, the result is equivalent to numpy.fft.irfft2(a), but usually faster.
+
+        >>> a1 = numpy.fft.irfft2(ka)
+        >>> a2 = galsim.fft.irfft2(ka)
+
+    Restrictions on this version vs the numpy version:
+
+        - The array must be 2-dimensional.
+        - It must have dtype numpy.complex128 or be convertible to numpy.complex128
+        - It must have shape (N, N/2+1)
+        - The size in the y direction (axis=0) must be even.
+
+    The returned array will be real with dtype numpy.float64.
+
+    If shift_in is True, then this is equivalent to applying numpy.fft.fftshift to the input.
+
+        >>> a1 = numpy.fft.irfft2(numpy.fft.fftshift(a, axes=(0,)))
+        >>> a2 = galsim.fft.irfft2(a, shift_in=True)
+
+    If shift_out is True, then this is equivalent to applying numpy.fft.fftshift to the output.
+
+        >>> a1 = numpy.fft.fftshift(numpy.fft.irfft2(a))
+        >>> a2 = galsim.fft.irfft2(a, shift_out=True)
+
+    @param a            The input array to be transformed
+    @param shift_in     Whether to shift the input array so that the center is moved to (0,0).
+    @param shift_out    Whether to shift the output array so that the center is moved to (0,0).
+
+    @returns a real numpy array
+    """
+    s = a.shape
+    if len(s) != 2:
+        raise ValueError("Input array must be 2D.")
+    N = s[0]
+    No2 = N // 2
+    if No2+1 != s[1]:
+        raise ValueError("Input array must have shape (N, N/2+1).")
+
+    a = a.astype(np.complex128)
+    kim = galsim._galsim.ConstImageViewC(a, 0, -No2)
+    xim = kim.inverse_fft(np.pi / No2, shift_in=shift_in, shift_out=shift_out)
+    xar = xim.array
+    return xar
+
+

--- a/galsim/fft.py
+++ b/galsim/fft.py
@@ -75,13 +75,13 @@ def fft2(a, shift_in=False, shift_out=False):
     """
     s = a.shape
     if len(s) != 2:
-        raise ValueError("Input array must be 2D.  Got shape=%s"%s)
+        raise ValueError("Input array must be 2D.  Got shape=%s"%str(s))
     M, N = s
     Mo2 = M // 2
     No2 = N // 2
 
     if M != Mo2*2 or N != No2*2:
-        raise ValueError("Input array must have even sizes. Got shape=%s"%s)
+        raise ValueError("Input array must have even sizes. Got shape=%s"%str(s))
 
     if a.dtype.kind == 'c':
         a = a.astype(np.complex128, copy=False)
@@ -154,13 +154,13 @@ def ifft2(a, shift_in=False, shift_out=False):
     """
     s = a.shape
     if len(s) != 2:
-        raise ValueError("Input array must be 2D.  Got shape=%s"%s)
+        raise ValueError("Input array must be 2D.  Got shape=%s"%str(s))
     M,N = s
     Mo2 = M // 2
     No2 = N // 2
 
     if M != Mo2*2 or N != No2*2:
-        raise ValueError("Input array must have even sizes. Got shape=%s"%s)
+        raise ValueError("Input array must have even sizes. Got shape=%s"%str(s))
 
     if a.dtype.kind == 'c':
         a = a.astype(np.complex128, copy=False)
@@ -208,13 +208,13 @@ def rfft2(a, shift_in=False, shift_out=False):
     """
     s = a.shape
     if len(s) != 2:
-        raise ValueError("Input array must be 2D.  Got shape=%s"%s)
+        raise ValueError("Input array must be 2D.  Got shape=%s"%str(s))
     M,N = s
     Mo2 = M // 2
     No2 = N // 2
 
     if M != Mo2*2 or N != No2*2:
-        raise ValueError("Input array must have even sizes. Got shape=%s"%s)
+        raise ValueError("Input array must have even sizes. Got shape=%s"%str(s))
 
     a = a.astype(np.float64, copy=False)
     xim = galsim._galsim.ConstImageViewD(a, -No2, -Mo2)
@@ -258,13 +258,13 @@ def irfft2(a, shift_in=False, shift_out=False):
     """
     s = a.shape
     if len(s) != 2:
-        raise ValueError("Input array must be 2D.  Got shape=%s"%s)
+        raise ValueError("Input array must be 2D.  Got shape=%s"%str(s))
     M,No2 = s
     No2 -= 1  # s is (M,No2+1)
     Mo2 = M // 2
 
     if M != Mo2*2:
-        raise ValueError("Input array must have even sizes. Got shape=%s"%s)
+        raise ValueError("Input array must have even sizes. Got shape=%s"%str(s))
 
     a = a.astype(np.complex128, copy=False)
     kim = galsim._galsim.ConstImageViewC(a, 0, -Mo2)

--- a/galsim/fft.py
+++ b/galsim/fft.py
@@ -67,19 +67,21 @@ def fft2(a, shift_in=False, shift_out=False):
 
     @param a            The input array to be transformed
     @param shift_in     Whether to shift the input array so that the center is moved to (0,0).
+                        [default: False]
     @param shift_out    Whether to shift the output array so that the center is moved to (0,0).
+                        [default: False]
 
     @returns a complex numpy array
     """
     s = a.shape
     if len(s) != 2:
-        raise ValueError("Input array must be 2D.")
+        raise ValueError("Input array must be 2D.  Got shape=%s"%s)
     M, N = s
     Mo2 = M // 2
     No2 = N // 2
 
     if M != Mo2*2 or N != No2*2:
-        raise ValueError("Input array must have even sizes")
+        raise ValueError("Input array must have even sizes. Got shape=%s"%s)
 
     if a.dtype.kind == 'c':
         a = a.astype(np.complex128, copy=False)
@@ -119,7 +121,6 @@ def ifft2(a, shift_in=False, shift_out=False):
     Restrictions on this version vs the numpy version:
 
         - The array must be 2-dimensional.
-        - It must be square.
         - The size in each direction must be even. (Ideally 2^k or 3*2^k for speed, but this is
           not required.)
         - The array is assumed to be Hermitian, which means the k values with kx<0 are assumed
@@ -145,19 +146,21 @@ def ifft2(a, shift_in=False, shift_out=False):
 
     @param a            The input array to be transformed
     @param shift_in     Whether to shift the input array so that the center is moved to (0,0).
+                        [default: False]
     @param shift_out    Whether to shift the output array so that the center is moved to (0,0).
+                        [default: False]
 
     @returns a real numpy array
     """
     s = a.shape
     if len(s) != 2:
-        raise ValueError("Input array must be 2D.")
+        raise ValueError("Input array must be 2D.  Got shape=%s"%s)
     M,N = s
     Mo2 = M // 2
     No2 = N // 2
 
     if M != Mo2*2 or N != No2*2:
-        raise ValueError("Input array must have even sizes")
+        raise ValueError("Input array must have even sizes. Got shape=%s"%s)
 
     if a.dtype.kind == 'c':
         a = a.astype(np.complex128, copy=False)
@@ -180,7 +183,6 @@ def rfft2(a, shift_in=False, shift_out=False):
 
         - The input array must be 2-dimensional.
         - If it does not have dtype numpy.float64, it will be coerced to numpy.float64.
-        - It must be square.
         - The size in each direction must be even. (Ideally 2^k or 3*2^k for speed, but this is
           not required.)
 
@@ -198,19 +200,21 @@ def rfft2(a, shift_in=False, shift_out=False):
 
     @param a            The input array to be transformed
     @param shift_in     Whether to shift the input array so that the center is moved to (0,0).
+                        [default: False]
     @param shift_out    Whether to shift the output array so that the center is moved to (0,0).
+                        [default: False]
 
     @returns a complex numpy array
     """
     s = a.shape
     if len(s) != 2:
-        raise ValueError("Input array must be 2D.")
+        raise ValueError("Input array must be 2D.  Got shape=%s"%s)
     M,N = s
     Mo2 = M // 2
     No2 = N // 2
 
     if M != Mo2*2 or N != No2*2:
-        raise ValueError("Input array must have even sizes")
+        raise ValueError("Input array must have even sizes. Got shape=%s"%s)
 
     a = a.astype(np.float64, copy=False)
     xim = galsim._galsim.ConstImageViewD(a, -No2, -Mo2)
@@ -246,19 +250,21 @@ def irfft2(a, shift_in=False, shift_out=False):
 
     @param a            The input array to be transformed
     @param shift_in     Whether to shift the input array so that the center is moved to (0,0).
+                        [default: False]
     @param shift_out    Whether to shift the output array so that the center is moved to (0,0).
+                        [default: False]
 
     @returns a real numpy array
     """
     s = a.shape
     if len(s) != 2:
-        raise ValueError("Input array must be 2D.")
+        raise ValueError("Input array must be 2D.  Got shape=%s"%s)
     M,No2 = s
     No2 -= 1  # s is (M,No2+1)
     Mo2 = M // 2
 
     if M != Mo2*2:
-        raise ValueError("Input array must have even sizes")
+        raise ValueError("Input array must have even sizes. Got shape=%s"%s)
 
     a = a.astype(np.complex128, copy=False)
     kim = galsim._galsim.ConstImageViewC(a, 0, -Mo2)

--- a/galsim/fft.py
+++ b/galsim/fft.py
@@ -48,8 +48,8 @@ def fft2(a, shift_in=False, shift_out=False):
     Restrictions on this version vs the numpy version:
 
         - The input array must be 2-dimensional.
-        - It must be square.
-        - The size in each direction must be even.
+        - The size in each direction must be even. (Ideally 2^k or 3*2^k for speed, but this is
+          not required.)
         - If it has a real dtype, it will be coerced to numpy.float64.
         - If it hsa a complex dtype, it will be coerced to numpy.complex128.
 
@@ -74,17 +74,19 @@ def fft2(a, shift_in=False, shift_out=False):
     s = a.shape
     if len(s) != 2:
         raise ValueError("Input array must be 2D.")
-    N = s[0]
-    if N != s[1]:
-        raise ValueError("Input array must be square.")
-
+    M, N = s
+    Mo2 = M // 2
     No2 = N // 2
+
+    if M != Mo2*2 or N != No2*2:
+        raise ValueError("Input array must have even sizes")
+
     if a.dtype.kind == 'c':
         a = a.astype(np.complex128)
-        xim = galsim._galsim.ConstImageViewC(a, -No2, -No2)
+        xim = galsim._galsim.ConstImageViewC(a, -No2, -Mo2)
     else:
         a = a.astype(np.float64)
-        xim = galsim._galsim.ConstImageViewD(a, -No2, -No2)
+        xim = galsim._galsim.ConstImageViewD(a, -No2, -Mo2)
     return xim.cfft(shift_in=shift_in, shift_out=shift_out).array
 
 
@@ -100,7 +102,8 @@ def ifft2(a, shift_in=False, shift_out=False):
 
         - The array must be 2-dimensional.
         - It must be square.
-        - The size in each direction must be even.
+        - The size in each direction must be even. (Ideally 2^k or 3*2^k for speed, but this is
+          not required.)
         - The array is assumed to be Hermitian, which means the k values with kx<0 are assumed
           to be equal to the conjuate of their inverse.  This will always be the case if
           a is an output of fft2 (with a real input array).
@@ -131,20 +134,20 @@ def ifft2(a, shift_in=False, shift_out=False):
     s = a.shape
     if len(s) != 2:
         raise ValueError("Input array must be 2D.")
-    N = s[0]
-    if N != s[1]:
-        raise ValueError("Input array must be square.")
-
+    M,N = s
+    Mo2 = M // 2
     No2 = N // 2
+
+    if M != Mo2*2 or N != No2*2:
+        raise ValueError("Input array must have even sizes")
+
     if a.dtype.kind == 'c':
         a = a.astype(np.complex128)
-        xim = galsim._galsim.ConstImageViewC(a, -No2, -No2)
+        xim = galsim._galsim.ConstImageViewC(a, -No2, -Mo2)
     else:
         a = a.astype(np.float64)
-        xim = galsim._galsim.ConstImageViewD(a, -No2, -No2)
-    kim = xim.cfft(inverse=True, shift_in=shift_in, shift_out=shift_out)
-    kar = kim.array
-    return kar
+        xim = galsim._galsim.ConstImageViewD(a, -No2, -Mo2)
+    return xim.cfft(inverse=True, shift_in=shift_in, shift_out=shift_out).array
 
 
 def rfft2(a, shift_in=False, shift_out=False):
@@ -160,7 +163,8 @@ def rfft2(a, shift_in=False, shift_out=False):
         - The input array must be 2-dimensional.
         - If it does not have dtype numpy.float64, it will be cerced to numpy.float64.
         - It must be square.
-        - The size in each direction must be even.
+        - The size in each direction must be even. (Ideally 2^k or 3*2^k for speed, but this is
+          not required.)
 
     The returned array will be complex with dtype numpy.complex128.
 
@@ -183,16 +187,16 @@ def rfft2(a, shift_in=False, shift_out=False):
     s = a.shape
     if len(s) != 2:
         raise ValueError("Input array must be 2D.")
-    N = s[0]
-    if N != s[1]:
-        raise ValueError("Input array must be square.")
-
+    M,N = s
+    Mo2 = M // 2
     No2 = N // 2
+
+    if M != Mo2*2 or N != No2*2:
+        raise ValueError("Input array must have even sizes")
+
     a = a.astype(np.float64)
-    xim = galsim._galsim.ConstImageViewD(a, -No2, -No2)
-    kim = xim.rfft(shift_in=shift_in, shift_out=shift_out)
-    kar = kim.array
-    return kar
+    xim = galsim._galsim.ConstImageViewD(a, -No2, -Mo2)
+    return xim.rfft(shift_in=shift_in, shift_out=shift_out).array
 
 
 def irfft2(a, shift_in=False, shift_out=False):
@@ -207,8 +211,8 @@ def irfft2(a, shift_in=False, shift_out=False):
 
         - The array must be 2-dimensional.
         - If it does not have dtype numpy.complex128, it will be cerced to numpy.complex128.
-        - It must have shape (N, N/2+1).
-        - The size in the y direction (axis=0) must be even.
+        - It must have shape (M, N/2+1).
+        - The size M must be even. (Ideally 2^k or 3*2^k for speed, but this is not required.)
 
     The returned array will be real with dtype numpy.float64.
 
@@ -231,15 +235,15 @@ def irfft2(a, shift_in=False, shift_out=False):
     s = a.shape
     if len(s) != 2:
         raise ValueError("Input array must be 2D.")
-    N = s[0]
-    No2 = N // 2
-    if No2+1 != s[1]:
-        raise ValueError("Input array must have shape (N, N/2+1).")
+    M,No2 = s
+    No2 -= 1  # s is (M,No2+1)
+    Mo2 = M // 2
+
+    if M != Mo2*2:
+        raise ValueError("Input array must have even sizes")
 
     a = a.astype(np.complex128)
-    kim = galsim._galsim.ConstImageViewC(a, 0, -No2)
-    xim = kim.irfft(shift_in=shift_in, shift_out=shift_out)
-    xar = xim.array
-    return xar
+    kim = galsim._galsim.ConstImageViewC(a, 0, -Mo2)
+    return kim.irfft(shift_in=shift_in, shift_out=shift_out).array
 
 

--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -873,7 +873,7 @@ class GSObject(object):
                 raise ValueError("Cannot add_to_image if image bounds are not defined")
             N = self.getGoodImageSize(1.0/wmult)
             if odd: N += 1
-            bounds = galsim.BoundsI(1,N,1,N)
+            bounds = galsim._BoundsI(1,N,1,N)
             image.resize(bounds)
             image.setZero()
 
@@ -1466,14 +1466,14 @@ class GSObject(object):
                 "If you can handle the large FFT, you may update gsparams.maximum_fft_size.")
 
         # Draw the image in k space.
-        bounds = galsim.BoundsI(0,Nk/2,-Nk/2,Nk/2)
+        bounds = galsim._BoundsI(0,Nk//2,-Nk//2,Nk//2)
         kimage = galsim.ImageC(bounds=bounds, scale=dk)
         self.SBProfile.drawK(kimage.image.view(), dk)
 
         # Wrap the full image to the size we want for the FT.
         # Even if N == Nk, this is useful to make this portion properly Hermitian in the
         # N/2 column and N/2 row.
-        bwrap = galsim.BoundsI(0, N/2, -N/2, N/2-1)
+        bwrap = galsim._BoundsI(0, N//2, -N//2, N//2-1)
         kimage_wrap = kimage.image.wrap(bwrap, True, False)
 
         # Perform the fourier transform.j

--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -674,7 +674,12 @@ class GSObject(object):
 
         @returns the dilated object.
         """
-        return self.expand(scale) * (1./scale**2)  # conserve flux
+        # equivalent to self.expand(scale) * (1./scale**2)
+        new_obj = galsim.Transform(self, jac=[scale, 0., 0., scale], flux_ratio=scale**-2)
+
+        if hasattr(self, 'noise'):
+            new_obj.noise = self.noise.expand(scale) * scale**-4
+        return new_obj
 
     def magnify(self, mu):
         """Create a version of the current object with a lensing magnification applied to it,

--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -1467,7 +1467,7 @@ class GSObject(object):
 
         # Draw the image in k space.
         bounds = galsim.BoundsI(0,Nk/2,-Nk/2,Nk/2)
-        kimage = galsim.ImageC(bounds, scale=dk)
+        kimage = galsim.ImageC(bounds=bounds, scale=dk)
         self.SBProfile.drawK(kimage.image.view(), dk)
 
         # Wrap the full image to the size we want for the FT.

--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -1482,7 +1482,7 @@ class GSObject(object):
         kimage_wrap = kimage.image.wrap(bwrap, True, False)
 
         # Perform the fourier transform.j
-        real_image = kimage_wrap.inverse_fft(dk)
+        real_image = kimage_wrap.inverse_fft()
 
         # Add (a portion of) this to the original image.
         image.image += real_image.subImage(image.bounds)

--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -1481,7 +1481,7 @@ class GSObject(object):
         bwrap = galsim._BoundsI(0, N//2, -N//2, N//2-1)
         kimage_wrap = kimage.image.wrap(bwrap, True, False)
 
-        # Perform the fourier transform.j
+        # Perform the fourier transform.
         real_image = kimage_wrap.irfft()
 
         # Add (a portion of) this to the original image.

--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -1342,7 +1342,7 @@ class GSObject(object):
             return image
 
         # Making a view of the image lets us change the center without messing up the original.
-        imview = image.view()
+        imview = image._view()
         imview.setCenter(0,0)
         imview.wcs = galsim.PixelScale(1.0)
 

--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -1482,7 +1482,7 @@ class GSObject(object):
         kimage_wrap = kimage.image.wrap(bwrap, True, False)
 
         # Perform the fourier transform.j
-        real_image = kimage_wrap.inverse_fft()
+        real_image = kimage_wrap.irfft()
 
         # Add (a portion of) this to the original image.
         image.image += real_image.subImage(image.bounds)

--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -1443,8 +1443,8 @@ class GSObject(object):
         N = self.getGoodImageSize(image.scale/wmult)
 
         # We must make something big enough to cover the target image size:
-        image_N = np.max(image.bounds.numpyShape())
-        N = np.max((N, image_N))
+        image_N = max(image.bounds.numpyShape())
+        N = max(N, image_N)
 
         # Round up to a good size for making FFTs:
         N = image.good_fft_size(N)
@@ -1823,7 +1823,7 @@ class GSObject(object):
         else:
             dk = float(scale)
         if image is not None and image.bounds.isDefined():
-            dx = np.pi/( np.max(image.array.shape) // 2 * dk )
+            dx = np.pi/( max(image.array.shape) // 2 * dk )
         elif scale is None or scale <= 0:
             dx = self.nyquistScale()
         else:

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -416,7 +416,7 @@ class Image(with_metaclass(MetaImage, object)):
                 array = None
                 xmin = None
                 ymin = None
-        elif array.shape == (0,0):
+        elif array.shape[1] == 0:
             # Another way to indicate that we don't have a defined image.
             if 'dtype' not in kwargs:
                 kwargs['dtype'] = array.dtype.type

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -725,7 +725,8 @@ class Image(with_metaclass(MetaImage, object)):
         # dk = 2pi / (N dk)
         dk = np.pi / (No2 * dx)
 
-        imview = ximage.image.fft(dx)
+        imview = ximage.image.fft()
+        imview *= dx*dx
         image = Image(imview, scale=dk)
         image.setOrigin(0,-No2)
         return image
@@ -776,7 +777,8 @@ class Image(with_metaclass(MetaImage, object)):
         # dx = 2pi / (N dk)
         dx = np.pi / (No2 * dk)
 
-        imview = kimage.image.inverse_fft(dk)
+        imview = kimage.image.inverse_fft()
+        imview *= (dk * No2 / np.pi)**2
         image = Image(imview, scale=dx)
         image.setCenter(0,0)
         return image

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -848,6 +848,16 @@ class Image(with_metaclass(MetaImage, object)):
 
         return ret
 
+    def _view(self):
+        """Equivalent to im.view(), but without some of the sanity checks and extra options.
+        """
+        ret = Image.__new__(Image)
+        ret.image = self.image.view()
+        ret._array = self._array
+        ret.dtype = self.dtype
+        ret.wcs = self.wcs
+        return ret
+
     def shift(self, *args, **kwargs):
         """Shift the pixel coordinates by some (integral) dx,dy.
 

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -725,7 +725,7 @@ class Image(with_metaclass(MetaImage, object)):
         # dk = 2pi / (N dk)
         dk = np.pi / (No2 * dx)
 
-        imview = ximage.image.fft()
+        imview = ximage.image.rfft()
         imview *= dx*dx
         image = Image(imview, scale=dk)
         image.setOrigin(0,-No2)
@@ -777,7 +777,7 @@ class Image(with_metaclass(MetaImage, object)):
         # dx = 2pi / (N dk)
         dx = np.pi / (No2 * dk)
 
-        imview = kimage.image.inverse_fft()
+        imview = kimage.image.irfft()
         imview *= (dk * No2 / np.pi)**2
         image = Image(imview, scale=dx)
         image.setCenter(0,0)

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -416,7 +416,7 @@ class Image(with_metaclass(MetaImage, object)):
                 array = None
                 xmin = None
                 ymin = None
-        elif np.prod(array.shape) == 0:
+        elif array.shape == (0,0):
             # Another way to indicate that we don't have a defined image.
             if 'dtype' not in kwargs:
                 kwargs['dtype'] = array.dtype.type
@@ -706,7 +706,7 @@ class Image(with_metaclass(MetaImage, object)):
         if not self.bounds.isDefined():
             raise ValueError("calculate_fft requires that the image have defined bounds.")
 
-        No2 = np.max((-self.bounds.xmin, self.bounds.xmax+1, -self.bounds.ymin, self.bounds.ymax+1))
+        No2 = max(-self.bounds.xmin, self.bounds.xmax+1, -self.bounds.ymin, self.bounds.ymax+1)
 
         full_bounds = galsim.BoundsI(-No2, No2-1, -No2, No2-1)
         if self.bounds == full_bounds:
@@ -754,7 +754,7 @@ class Image(with_metaclass(MetaImage, object)):
         if not self.bounds.includes(galsim.PositionI(0,0)):
             raise ValueError("calculate_inverse_fft requires that the image includes point (0,0)")
 
-        No2 = np.max((self.bounds.xmax, -self.bounds.ymin, self.bounds.ymax))
+        No2 = max(self.bounds.xmax, -self.bounds.ymin, self.bounds.ymax)
 
         target_bounds = galsim.BoundsI(0, No2, -No2, No2-1)
         if self.bounds == target_bounds:

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -1385,7 +1385,7 @@ def Image_iadd(self, other):
     if dt == self.array.dtype:
         self.array[:,:] += a
     else:
-        self.array[:,:] = (self.array + a).astype(self.array.dtype)
+        self.array[:,:] = (self.array + a).astype(self.array.dtype, copy=False)
     return self
 
 def Image_sub(self, other):
@@ -1410,7 +1410,7 @@ def Image_isub(self, other):
     if dt == self.array.dtype:
         self.array[:,:] -= a
     else:
-        self.array[:,:] = (self.array - a).astype(self.array.dtype)
+        self.array[:,:] = (self.array - a).astype(self.array.dtype, copy=False)
     return self
 
 def Image_mul(self, other):
@@ -1432,7 +1432,7 @@ def Image_imul(self, other):
     if dt == self.array.dtype:
         self.array[:,:] *= a
     else:
-        self.array[:,:] = (self.array * a).astype(self.array.dtype)
+        self.array[:,:] = (self.array * a).astype(self.array.dtype, copy=False)
     return self
 
 def Image_div(self, other):
@@ -1459,7 +1459,7 @@ def Image_idiv(self, other):
         # back to an integer array.  So for integers (or mixed types), don't use /=.
         self.array[:,:] /= a
     else:
-        self.array[:,:] = (self.array / a).astype(self.array.dtype)
+        self.array[:,:] = (self.array / a).astype(self.array.dtype, copy=False)
     return self
 
 def Image_floordiv(self, other):
@@ -1485,7 +1485,7 @@ def Image_ifloordiv(self, other):
     if dt == self.array.dtype:
         self.array[:,:] //= a
     else:
-        self.array[:,:] = (self.array // a).astype(self.array.dtype)
+        self.array[:,:] = (self.array // a).astype(self.array.dtype, copy=False)
     return self
 
 def Image_mod(self, other):
@@ -1511,7 +1511,7 @@ def Image_imod(self, other):
     if dt == self.array.dtype:
         self.array[:,:] %= a
     else:
-        self.array[:,:] = (self.array % a).astype(self.array.dtype)
+        self.array[:,:] = (self.array % a).astype(self.array.dtype, copy=False)
     return self
 
 def Image_pow(self, other):

--- a/galsim/interpolatedimage.py
+++ b/galsim/interpolatedimage.py
@@ -349,8 +349,8 @@ class InterpolatedImage(GSObject):
             im_cen = self.image.bounds.center()
 
         local_wcs = self.image.wcs.local(image_pos = im_cen)
-        self.min_scale = local_wcs.minLinearScale()
-        self.max_scale = local_wcs.maxLinearScale()
+        self.min_scale = local_wcs._minScale()
+        self.max_scale = local_wcs._maxScale()
 
         # Make sure the image fits in the noise pad image:
         if noise_pad_size:

--- a/galsim/interpolatedimage.py
+++ b/galsim/interpolatedimage.py
@@ -493,7 +493,7 @@ class InterpolatedImage(GSObject):
             self._offset = None
 
         # Bring the profile from image coordinates into world coordinates
-        prof = local_wcs.toWorld(prof)
+        prof = local_wcs._profileToWorld(prof)
 
         # If the user specified a flux, then set to that flux value.
         if flux is not None:

--- a/galsim/interpolatedimage.py
+++ b/galsim/interpolatedimage.py
@@ -296,7 +296,7 @@ class InterpolatedImage(GSObject):
 
         # Store the image as an attribute and make sure we don't change the original image
         # in anything we do here.  (e.g. set scale, etc.)
-        self.image = image.view()
+        self.image = image._view()
         self.use_cache = use_cache
 
         # Set the wcs if necessary
@@ -377,7 +377,7 @@ class InterpolatedImage(GSObject):
 
                 # We will change the bounds here, so make a new view to avoid modifying the
                 # input pad_image.
-                pad_image = pad_image.view()
+                pad_image = pad_image._view()
                 pad_image.setCenter(0,0)
                 new_pad_image.setCenter(0,0)
                 if new_pad_image.bounds.includes(pad_image.bounds):

--- a/galsim/lensing_ps.py
+++ b/galsim/lensing_ps.py
@@ -1617,7 +1617,7 @@ class PowerSpectrumRealizer(object):
         if self.amplitude_E is not None:
             r1 = galsim.utilities.rand_arr(self.amplitude_E.shape, gd)
             r2 = galsim.utilities.rand_arr(self.amplitude_E.shape, gd)
-            E_k = np.empty((self.ny,self.nx), dtype=type(1.+1.j))
+            E_k = np.empty((self.ny,self.nx), dtype=complex)
             E_k[:,self.ikx] = self.amplitude_E * (r1 + 1j*r2) * ISQRT2
             # E_k corresponds to real kappa, so E_k[-k] = conj(E_k[k])
             self._make_hermitian(E_k)
@@ -1627,7 +1627,7 @@ class PowerSpectrumRealizer(object):
         if self.amplitude_B is not None:
             r1 = galsim.utilities.rand_arr(self.amplitude_B.shape, gd)
             r2 = galsim.utilities.rand_arr(self.amplitude_B.shape, gd)
-            B_k = np.empty((self.ny,self.nx), dtype=type(1.+1.j))
+            B_k = np.empty((self.ny,self.nx), dtype=complex)
             B_k[:,self.ikx] = self.amplitude_B * (r1 + 1j*r2) * ISQRT2
             # B_k corresponds to imag kappa, so B_k[-k] = -conj(B_k[k])
             # However, we later multiply this by i, so that means here B_k[-k] = conj(B_k[k])

--- a/galsim/lensing_ps.py
+++ b/galsim/lensing_ps.py
@@ -1617,7 +1617,7 @@ class PowerSpectrumRealizer(object):
         if self.amplitude_E is not None:
             r1 = galsim.utilities.rand_arr(self.amplitude_E.shape, gd)
             r2 = galsim.utilities.rand_arr(self.amplitude_E.shape, gd)
-            E_k = np.empty((self.ny,self.nx)).astype(type(1.+1.j))
+            E_k = np.empty((self.ny,self.nx), dtype=type(1.+1.j))
             E_k[:,self.ikx] = self.amplitude_E * (r1 + 1j*r2) * ISQRT2
             # E_k corresponds to real kappa, so E_k[-k] = conj(E_k[k])
             self._make_hermitian(E_k)
@@ -1627,7 +1627,7 @@ class PowerSpectrumRealizer(object):
         if self.amplitude_B is not None:
             r1 = galsim.utilities.rand_arr(self.amplitude_B.shape, gd)
             r2 = galsim.utilities.rand_arr(self.amplitude_B.shape, gd)
-            B_k = np.empty((self.ny,self.nx)).astype(type(1.+1.j))
+            B_k = np.empty((self.ny,self.nx), dtype=type(1.+1.j))
             B_k[:,self.ikx] = self.amplitude_B * (r1 + 1j*r2) * ISQRT2
             # B_k corresponds to imag kappa, so B_k[-k] = -conj(B_k[k])
             # However, we later multiply this by i, so that means here B_k[-k] = conj(B_k[k])

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -1107,12 +1107,11 @@ class PhaseScreenPSF(GSObject):
         expwf = np.exp((2j*np.pi/self.lam) * wf)
         expwf_grid = np.zeros_like(self.aper.illuminated,dtype=np.complex128)
         expwf_grid[self.aper.illuminated] = expwf
-        ftexpwf = np.fft.fft2(np.fft.fftshift(expwf_grid))
+        ftexpwf = galsim.fft.fft2(expwf_grid, shift_in=True, shift_out=True)
         self.img += np.abs(ftexpwf)**2
 
     def _finalize(self, flux, suppress_warning):
         """Take accumulated integrated PSF image and turn it into a proper GSObject."""
-        self.img = np.fft.fftshift(self.img)
         self.img *= flux / self.img.sum()
         b = galsim._BoundsI(1,self.aper.npix,1,self.aper.npix)
         self.img = galsim._Image(self.img, b, galsim.PixelScale(self.scale))

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -779,7 +779,10 @@ class PhaseScreenList(object):
                         [default: True]
         @returns        Wavefront lag or lead in nanometers over aperture.
         """
-        return np.sum([layer.wavefront(aper, theta, compact) for layer in self],axis=0)
+        if len(self._layers) > 1:
+            return np.sum([layer.wavefront(aper, theta, compact) for layer in self],axis=0)
+        else:
+            return self._layers[0].wavefront(aper, theta, compact)
 
     def makePSF(self, lam, **kwargs):
         """Compute one PSF or multiple PSFs from the current PhaseScreenList, depending on the type

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -1109,18 +1109,14 @@ class PhaseScreenPSF(GSObject):
     def _finalize(self, flux, suppress_warning):
         """Take accumulated integrated PSF image and turn it into a proper GSObject."""
         self.img = np.fft.fftshift(self.img)
-        self.img *= (flux / (self.img.sum() * self.scale**2))
+        self.img *= flux / self.img.sum()
         self.img = galsim.ImageD(self.img.astype(np.float64), scale=self.scale)
-
-        calculate_stepk = self._serialize_stepk is None
-        calculate_maxk = self._serialize_maxk is None
 
         self.ii = galsim.InterpolatedImage(
                 self.img, x_interpolant=self.interpolant,
                 _serialize_stepk=self._serialize_stepk, _serialize_maxk=self._serialize_maxk,
-                calculate_stepk=calculate_stepk, calculate_maxk=calculate_maxk,
                 pad_factor=self._ii_pad_factor,
-                use_true_center=False, normalization='sb', gsparams=self._gsparams)
+                use_true_center=False, gsparams=self._gsparams)
 
         GSObject.__init__(self, self.ii)
 
@@ -1147,7 +1143,7 @@ class PhaseScreenPSF(GSObject):
     def __setstate__(self, d):
         self.__dict__ = d
         self.ii =  galsim.InterpolatedImage(self.img, x_interpolant=self.interpolant,
-                                       use_true_center=False, normalization='sb',
+                                       use_true_center=False,
                                        pad_factor=self._ii_pad_factor,
                                        _serialize_stepk=self._serialize_stepk,
                                        _serialize_maxk=self._serialize_maxk,

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -1100,7 +1100,7 @@ class PhaseScreenPSF(GSObject):
     def _step(self):
         """Compute the current instantaneous PSF and add it to the developing integrated PSF."""
         wf = self.screen_list.wavefront(self.aper, self.theta)
-        expwf = np.exp(2j * np.pi * wf / self.lam)
+        expwf = np.exp((2j*np.pi/self.lam) * wf)
         expwf_grid = np.zeros_like(self.aper.illuminated).astype(np.complex128)
         expwf_grid[self.aper.illuminated] = expwf
         ftexpwf = np.fft.fft2(np.fft.fftshift(expwf_grid))

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -1104,7 +1104,7 @@ class PhaseScreenPSF(GSObject):
         """Compute the current instantaneous PSF and add it to the developing integrated PSF."""
         wf = self.screen_list.wavefront(self.aper, self.theta)
         expwf = np.exp((2j*np.pi/self.lam) * wf)
-        expwf_grid = np.zeros_like(self.aper.illuminated).astype(np.complex128)
+        expwf_grid = np.zeros_like(self.aper.illuminated,dtype=np.complex128)
         expwf_grid[self.aper.illuminated] = expwf
         ftexpwf = np.fft.fft2(np.fft.fftshift(expwf_grid))
         self.img += np.abs(ftexpwf)**2
@@ -1113,7 +1113,7 @@ class PhaseScreenPSF(GSObject):
         """Take accumulated integrated PSF image and turn it into a proper GSObject."""
         self.img = np.fft.fftshift(self.img)
         self.img *= flux / self.img.sum()
-        self.img = galsim.ImageD(self.img.astype(np.float64), scale=self.scale)
+        self.img = galsim.ImageD(self.img, scale=self.scale)
 
         self.ii = galsim.InterpolatedImage(
                 self.img, x_interpolant=self.interpolant,

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -409,9 +409,10 @@ class Aperture(object):
         else:
             # Rotate the pupil plane image as required based on the `pupil_angle`, being careful to
             # ensure that the image is one of the allowed types.  We ignore the scale.
-            int_im = galsim.InterpolatedImage(galsim.Image(pp_arr, scale=1., dtype=np.float64),
-                                              x_interpolant='linear', calculate_stepk=False,
-                                              calculate_maxk=False)
+            b = galsim._BoundsI(1,self.npix,1,self.npix)
+            im = galsim._Image(pp_arr, b, galsim.PixelScale(1.))
+            int_im = galsim.InterpolatedImage(im, x_interpolant='linear',
+                                              calculate_stepk=False, calculate_maxk=False)
             int_im = int_im.rotate(pupil_angle)
             new_im = galsim.Image(pp_arr.shape[1], pp_arr.shape[0])
             new_im = int_im.drawImage(image=new_im, scale=1., method='no_pixel')
@@ -1113,7 +1114,8 @@ class PhaseScreenPSF(GSObject):
         """Take accumulated integrated PSF image and turn it into a proper GSObject."""
         self.img = np.fft.fftshift(self.img)
         self.img *= flux / self.img.sum()
-        self.img = galsim.ImageD(self.img, scale=self.scale)
+        b = galsim._BoundsI(1,self.aper.npix,1,self.aper.npix)
+        self.img = galsim._Image(self.img, b, galsim.PixelScale(self.scale))
 
         self.ii = galsim.InterpolatedImage(
                 self.img, x_interpolant=self.interpolant,

--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -455,24 +455,25 @@ def _zern_rho_coefs(n, m):
     A[n-2*kmax] = val
     return A
 
-def _zern_coef_array(n, m, eps, shape, annular):
+def _zern_coef_array(n, m, obscuration, shape, annular):
     """Assemble coefficient array for evaluating Zernike (n, m) as the real part of a
     bivariate polynomial in abs(rho)^2 and rho, where rho is a complex array indicating position on
     a unit disc.
 
-    @param n        Zernike radial coefficient
-    @param m        Zernike azimuthal coefficient
-    @param eps      Linear obscuration fraction.
-    @param shape    Output array shape
-    @param annular  Boolean indicating polynomials are orthogonal on a disk or an annulus.
-    @returns        2D array of coefficients in |r|^2 and r, where r = u + 1j * v, and u, v are unit
-                    disk coordinates.
+    @param n            Zernike radial coefficient
+    @param m            Zernike azimuthal coefficient
+    @param obscuration  Linear obscuration fraction.
+    @param shape        Output array shape
+    @param annular      Boolean indicating polynomials are orthogonal on a disk or an annulus.
+
+    @returns    2D array of coefficients in |r|^2 and r, where r = u + 1j * v, and u, v are unit
+                disk coordinates.
     """
     if shape is None:
         shape = ((n//2)+1, abs(m)+1)
     out = np.zeros(shape, dtype=np.complex128)
     if annular:
-        coefs = np.array(_annular_zern_rho_coefs(n, m, eps), dtype=np.complex128)
+        coefs = np.array(_annular_zern_rho_coefs(n, m, obscuration), dtype=np.complex128)
     else:
         coefs = np.array(_zern_rho_coefs(n, m), dtype=np.complex128)
     coefs /= _zern_norm(n, m)
@@ -482,17 +483,17 @@ def _zern_coef_array(n, m, eps, shape, annular):
         out[i, abs(m)] = c
     return out
 
-def __noll_coef_array(jmax, eps, annular):
+def __noll_coef_array(jmax, obscuration, annular):
     """Assemble coefficient array for evaluating Zernike (n, m) as the real part of a
     bivariate polynomial in abs(rho)^2 and rho, where rho is a complex array indicating position on
     a unit disc.
 
-    @param jmax     Maximum Noll coefficient
-    @param eps      Linear obscuration fraction.
-    @param shape    Output array shape
-    @param annular  Boolean indicating polynomials are orthogonal on a disk or an annulus.
-    @returns        2D array of coefficients in |r|^2 and r, where r = u + 1j * v, and u, v are unit
-                    disk coordinates.
+    @param jmax         Maximum Noll coefficient
+    @param obscuration  Linear obscuration fraction.
+    @param annular      Boolean indicating polynomials are orthogonal on a disk or an annulus.
+
+    @returns    2D array of coefficients in |r|^2 and r, where r = u + 1j * v, and u, v are unit
+                disk coordinates.
     """
     maxn = _noll_to_zern(jmax)[0]
     shape = (maxn//2+1, maxn+1, jmax)  # (max power of |rho|^2,  max power of rho, noll index-1)
@@ -501,7 +502,7 @@ def __noll_coef_array(jmax, eps, annular):
     out = np.zeros(shape, dtype=np.complex128)
     for j in range(1,jmax+1):
         n,m = _noll_to_zern(j)
-        coef = _zern_coef_array(n,m,eps,shape1,annular)
+        coef = _zern_coef_array(n,m,obscuration,shape1,annular)
         out[:,:,j-1] = coef
     return out
 _noll_coef_array = utilities.LRU_Cache(__noll_coef_array)

--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -640,10 +640,8 @@ class OpticalScreen(object):
         self.annular_zernike = annular_zernike
         self.obscuration = obscuration
         self.lam_0 = lam_0
-        try:
-            maxn = max(_noll_to_zern(j)[0] for j in range(1, len(self.aberrations)))
-        except:
-            maxn = 0
+
+        maxn = _noll_to_zern(len(self.aberrations)-1)[0]
         shape = (maxn//2+1, maxn+1)  # (max power of |rho|^2,  max power of rho)
         self.coef_array = np.zeros(shape, dtype=np.complex128)
 

--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -573,11 +573,14 @@ def horner(x, coef):
     @param coef  Polynomial coefficients of increasing powers of x.
     @returns     Polynomial evaluation.  Will take on the shape of x if x is an ndarray.
     """
-    result = np.zeros_like(x, dtype=np.complex128)
     coef = np.trim_zeros(coef, trim='b')
-    for c in coef[::-1]:
+    result = np.zeros_like(x, dtype=np.complex128)
+    if len(coef) == 0: return result
+    result += coef[-1]
+    for c in coef[-2::-1]:
         result *= x
         if c != 0: result += c
+    #np.testing.assert_almost_equal(result, np.polynomial.polynomial.polyval(x,coef))
     return result
 
 def horner2d(x, y, coefs):
@@ -590,10 +593,12 @@ def horner2d(x, y, coefs):
                   increasing the power of x.
     @returns      Polynomial evaluation.  Will take on the shape of x and y if these are ndarrays.
     """
-    result = np.zeros_like(x, dtype=np.complex128)
-    for coef in coefs[::-1]:
+    result = horner(y, coefs[-1])
+    for coef in coefs[-2::-1]:
         result *= x
         result += horner(y, coef)
+    # Useful when working on this... (Numpy method is much slower, btw.)
+    #np.testing.assert_almost_equal(result, np.polynomial.polynomial.polyval2d(x,y,coefs))
     return result
 
 

--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -575,11 +575,12 @@ def horner(x, coef):
     @param coef  Polynomial coefficients of increasing powers of x.
     @returns     Polynomial evaluation.  Will take on the shape of x if x is an ndarray.
     """
-    result = 0
+    result = np.zeros_like(x, dtype=np.complex128)
+    coef = np.trim_zeros(coef, trim='b')
     for c in coef[::-1]:
-        result = result*x + c
+        result *= x
+        if c != 0: result += c
     return result
-
 
 def horner2d(x, y, coefs):
     """Evaluate bivariate polynomial using nested Horner's method.
@@ -591,9 +592,10 @@ def horner2d(x, y, coefs):
                   increasing the power of x.
     @returns      Polynomial evaluation.  Will take on the shape of x and y if these are ndarrays.
     """
-    result = 0
+    result = np.zeros_like(x, dtype=np.complex128)
     for coef in coefs[::-1]:
-        result = result*x + horner(y, coef)
+        result *= x
+        result += horner(y, coef)
     return result
 
 

--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -175,7 +175,7 @@ class AtmosphericScreen(object):
         """Generate a random phase screen with power spectrum given by self.psi**2"""
         gd = galsim.GaussianDeviate(self.rng)
         noise = utilities.rand_arr(self.psi.shape, gd)
-        return np.fft.ifft2(np.fft.fft2(noise)*self.psi).real
+        return galsim.fft.ifft2(galsim.fft.fft2(noise)*self.psi).real
 
     def advance(self):
         """Advance phase screen realization by self.time_step."""

--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -455,8 +455,7 @@ def _zern_rho_coefs(n, m):
     A[n-2*kmax] = val
     return A
 
-
-def __zern_coef_array(n, m, eps, shape, annular):
+def _zern_coef_array(n, m, eps, shape, annular):
     """Assemble coefficient array for evaluating Zernike (n, m) as the real part of a
     bivariate polynomial in abs(rho)^2 and rho, where rho is a complex array indicating position on
     a unit disc.
@@ -482,7 +481,6 @@ def __zern_coef_array(n, m, eps, shape, annular):
     for i, c in enumerate(coefs[abs(m)::2]):
         out[i, abs(m)] = c
     return out
-_zern_coef_array = utilities.LRU_Cache(__zern_coef_array)
 
 def __noll_coef_array(jmax, eps, annular):
     """Assemble coefficient array for evaluating Zernike (n, m) as the real part of a

--- a/galsim/table.py
+++ b/galsim/table.py
@@ -471,7 +471,7 @@ class LookupTable2D(object):
             shape = x.shape
             x = x.ravel()
             y = y.ravel()
-            f = np.empty_like(x, dtype=float)
+            f = np.empty_like(x)
             f.fill(self.constant)
             good = ((x >= self.x[0]) & (x <= self.x[-1]) &
                     (y >= self.y[0]) & (y <= self.y[-1]))

--- a/galsim/table.py
+++ b/galsim/table.py
@@ -115,8 +115,8 @@ class LookupTable(object):
 
         # turn x and f into numpy arrays so that all subsequent math is possible (unlike for
         # lists, tuples).  Also make sure the dtype is float
-        x = np.asarray(x).astype(float)
-        f = np.asarray(f).astype(float)
+        x = np.array(x, dtype=float)
+        f = np.array(f, dtype=float)
         self.x = x
         self.f = f
 
@@ -130,11 +130,11 @@ class LookupTable(object):
 
         # make and store table
         if x_log:
-            if np.any(np.array(x) <= 0.):
+            if np.any(x <= 0.):
                 raise ValueError("Cannot interpolate in log(x) when table contains x<=0!")
             x = np.log(x)
         if f_log:
-            if np.any(np.array(f) <= 0.):
+            if np.any(f <= 0.):
                 raise ValueError("Cannot interpolate in log(f) when table contains f<=0!")
             f = np.log(f)
 
@@ -195,20 +195,20 @@ class LookupTable(object):
             if dimen > 2:
                 raise ValueError("Arrays with dimension larger than 2 not allowed!")
             elif dimen == 2:
-                f = np.empty_like(x.ravel()).astype(float)
-                self.table.interpMany(x.astype(float).ravel(),f)
+                f = np.empty_like(x.ravel(), dtype=float)
+                self.table.interpMany(x.astype(float,copy=False).ravel(),f)
                 f = f.reshape(x.shape)
             else:
-                f = np.empty_like(x).astype(float)
-                self.table.interpMany(x.astype(float),f)
+                f = np.empty_like(x, dtype=float)
+                self.table.interpMany(x.astype(float,copy=False),f)
         # option 2: a tuple
         elif isinstance(x, tuple):
-            f = np.empty_like(x).astype(float)
+            f = np.empty_like(x, dtype=float)
             self.table.interpMany(np.array(x, dtype=float),f)
             f = tuple(f)
         # option 3: a list
         elif isinstance(x, list):
-            f = np.empty_like(x).astype(float)
+            f = np.empty_like(x, dtype=float)
             self.table.interpMany(np.array(x, dtype=float),f)
             f = list(f)
         # option 4: a single value
@@ -449,7 +449,7 @@ class LookupTable2D(object):
             shape = x.shape
             x = x.ravel()
             y = y.ravel()
-            f = np.empty_like(x).astype(float)
+            f = np.empty_like(x, dtype=float)
             self.table.interpMany(x, y, f)
             f = f.reshape(shape)
             return f
@@ -471,7 +471,7 @@ class LookupTable2D(object):
             shape = x.shape
             x = x.ravel()
             y = y.ravel()
-            f = np.empty_like(x).astype(float)
+            f = np.empty_like(x, dtype=float)
             f.fill(self.constant)
             good = ((x >= self.x[0]) & (x <= self.x[-1]) &
                     (y >= self.y[0]) & (y <= self.y[-1]))

--- a/galsim/transform.py
+++ b/galsim/transform.py
@@ -213,6 +213,24 @@ class Transformation(galsim.GSObject):
         self.__dict__ = d
         self.__init__(self._original, self._jac, self._offset, self._flux_ratio, self._gsparams)
 
+def _Transform(obj, dudx=1, dudy=0, dvdx=0, dvdy=1, offset=galsim.PositionD(0.,0.),
+               flux_ratio=1., gsparams=None):
+    """Approximately equivalent to Transform (but with jac expanded out), but without all the
+    sanity checks and options.
+
+    This is only valid for GSObjects.  For ChromaticObjects, you must use the regular Transform.
+    """
+    ret = Transformation.__new__(Transformation)
+    if hasattr(obj, 'original'):
+        ret._original = obj.original
+    else:
+        ret._original = obj
+    sbt = _galsim.SBTransform(obj.SBProfile, dudx, dudy, dvdx, dvdy, offset, flux_ratio,
+                                gsparams)
+    galsim.GSObject.__init__(ret, sbt)
+    ret._gsparams = gsparams
+    return ret
+
 
 def SBTransform_init(self):
     obj = self.getObj()

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -1093,9 +1093,9 @@ def combine_wave_list(*args):
     wave_list = np.array([], dtype=float)
     for obj in args:
         if hasattr(obj, 'blue_limit') and obj.blue_limit is not None:
-            blue_limit = np.max([blue_limit, obj.blue_limit])
+            blue_limit = max(blue_limit, obj.blue_limit)
         if hasattr(obj, 'red_limit') and obj.red_limit is not None:
-            red_limit = np.min([red_limit, obj.red_limit])
+            red_limit = min(red_limit, obj.red_limit)
         wave_list = np.union1d(wave_list, obj.wave_list)
     wave_list = wave_list[(wave_list >= blue_limit) & (wave_list <= red_limit)]
     return wave_list, blue_limit, red_limit

--- a/galsim/wcs.py
+++ b/galsim/wcs.py
@@ -1082,10 +1082,12 @@ class PixelScale(LocalWCS):
         return v / self._scale
 
     def _profileToWorld(self, image_profile):
-        return image_profile.dilate(self._scale)
+        return galsim._Transform(image_profile, self._scale, 0., 0., self._scale,
+                                 flux_ratio=self._scale**-2)
 
     def _profileToImage(self, world_profile):
-        return world_profile.dilate(1./self._scale)
+        return galsim._Transform(world_profile, 1./self._scale, 0., 0., 1./self._scale,
+                                 flux_ratio=self._scale**2)
 
     def _pixelArea(self):
         return self._scale**2
@@ -1333,15 +1335,13 @@ class JacobianWCS(LocalWCS):
         return (-self._dvdx * u + self._dudx * v)/self._det
 
     def _profileToWorld(self, image_profile):
-        ret = image_profile.transform(self._dudx, self._dudy, self._dvdx, self._dvdy)
-        ret /= self._pixelArea()
-        return ret
+        return galsim._Transform(image_profile, self._dudx, self._dudy, self._dvdx, self._dvdy,
+                                 flux_ratio=1./self._pixelArea())
 
     def _profileToImage(self, world_profile):
-        ret = world_profile.transform(self._dvdy/self._det, -self._dudy/self._det,
-                                      -self._dvdx/self._det, self._dudx/self._det)
-        ret *= self._pixelArea()
-        return ret
+        return galsim._Transform(world_profile, self._dvdy/self._det, -self._dudy/self._det,
+                                 -self._dvdx/self._det, self._dudx/self._det,
+                                 flux_ratio=self._pixelArea())
 
     def _pixelArea(self):
         return abs(self._det)

--- a/include/galsim/Image.h
+++ b/include/galsim/Image.h
@@ -293,13 +293,12 @@ namespace galsim {
         /**
          *  @brief Perform a 2D FFT from real space to k-space.
          */
-        ImageView<std::complex<double> > fft(double dx, bool shift_in=true,
-                                             bool shift_out=true) const;
+        ImageView<std::complex<double> > fft(bool shift_in=true, bool shift_out=true) const;
 
         /**
-         *  @brief Perform a 2D FFT from k-space to real space.
+         *  @brief Perform a 2D inverse FFT from k-space to real space.
          */
-        ImageView<double> inverse_fft(double dk, bool shift_in=true, bool shift_out=true) const;
+        ImageView<double> inverse_fft(bool shift_in=true, bool shift_out=true) const;
 
     protected:
 

--- a/include/galsim/Image.h
+++ b/include/galsim/Image.h
@@ -300,6 +300,13 @@ namespace galsim {
          */
         ImageView<double> inverse_fft(bool shift_in=true, bool shift_out=true) const;
 
+        /**
+         *  @brief Perform a 2D FFT from complex space to k-space or the inverse.
+         */
+        ImageView<std::complex<double> > cfft(bool inverse, bool shift_in=true,
+                                              bool shift_out=true) const;
+
+
     protected:
 
         boost::shared_ptr<T> _owner;  // manages ownership; _owner.get() != _data if subimage

--- a/include/galsim/Image.h
+++ b/include/galsim/Image.h
@@ -293,12 +293,13 @@ namespace galsim {
         /**
          *  @brief Perform a 2D FFT from real space to k-space.
          */
-        ImageView<std::complex<double> > fft(double dk) const;
+        ImageView<std::complex<double> > fft(double dx, bool shift_in=true,
+                                             bool shift_out=true) const;
 
         /**
          *  @brief Perform a 2D FFT from k-space to real space.
          */
-        ImageView<double> inverse_fft(double dk) const;
+        ImageView<double> inverse_fft(double dk, bool shift_in=true, bool shift_out=true) const;
 
     protected:
 

--- a/pysrc/Image.cpp
+++ b/pysrc/Image.cpp
@@ -217,8 +217,10 @@ struct PyImage {
             .add_property("array", &GetConstArray)
             .def("getBounds", getBounds)
             .add_property("bounds", getBounds)
-            .def("inverse_fft", &BaseImage<T>::inverse_fft, bp::args("dk"))
-            .def("fft", &BaseImage<T>::fft, bp::args("dx"))
+            .def("inverse_fft", &BaseImage<T>::inverse_fft,
+                 (bp::arg("dk"), bp::arg("shift_in")=true, bp::arg("shift_out")=true))
+            .def("fft", &BaseImage<T>::fft,
+                 (bp::arg("dx"), bp::arg("shift_in")=true, bp::arg("shift_out")=true))
             ;
         ADD_CORNER(pyBaseImage, getXMin, xmin);
         ADD_CORNER(pyBaseImage, getYMin, ymin);

--- a/pysrc/Image.cpp
+++ b/pysrc/Image.cpp
@@ -217,10 +217,10 @@ struct PyImage {
             .add_property("array", &GetConstArray)
             .def("getBounds", getBounds)
             .add_property("bounds", getBounds)
-            .def("inverse_fft", &BaseImage<T>::inverse_fft,
-                 (bp::arg("dk"), bp::arg("shift_in")=true, bp::arg("shift_out")=true))
             .def("fft", &BaseImage<T>::fft,
-                 (bp::arg("dx"), bp::arg("shift_in")=true, bp::arg("shift_out")=true))
+                 (bp::arg("shift_in")=true, bp::arg("shift_out")=true))
+            .def("inverse_fft", &BaseImage<T>::inverse_fft,
+                 (bp::arg("shift_in")=true, bp::arg("shift_out")=true))
             ;
         ADD_CORNER(pyBaseImage, getXMin, xmin);
         ADD_CORNER(pyBaseImage, getYMin, ymin);

--- a/pysrc/Image.cpp
+++ b/pysrc/Image.cpp
@@ -217,10 +217,12 @@ struct PyImage {
             .add_property("array", &GetConstArray)
             .def("getBounds", getBounds)
             .add_property("bounds", getBounds)
-            .def("fft", &BaseImage<T>::fft,
+            .def("rfft", &BaseImage<T>::fft,
                  (bp::arg("shift_in")=true, bp::arg("shift_out")=true))
-            .def("inverse_fft", &BaseImage<T>::inverse_fft,
+            .def("irfft", &BaseImage<T>::inverse_fft,
                  (bp::arg("shift_in")=true, bp::arg("shift_out")=true))
+            .def("cfft", &BaseImage<T>::cfft,
+                 (bp::arg("inverse")=false, bp::arg("shift_in")=true, bp::arg("shift_out")=true))
             ;
         ADD_CORNER(pyBaseImage, getXMin, xmin);
         ADD_CORNER(pyBaseImage, getYMin, ymin);

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -309,9 +309,9 @@ void wrap_row(T*& ptr, T*& ptrwrap, int m, int step)
 {
     // Add contents of row j to row jj
     if (step == 1)
-        for(int i=0; i<m; ++i) *ptrwrap++ += *ptr++;
+        for(; m; --m) *ptrwrap++ += *ptr++;
     else
-        for(int i=0; i<m; ++i,ptr+=step,ptrwrap+=step) *ptrwrap += *ptr;
+        for(; m; --m,ptr+=step,ptrwrap+=step) *ptrwrap += *ptr;
 }
 
 template <typename T>
@@ -358,9 +358,9 @@ template <typename T>
 void wrap_row_conj(T*& ptr, T*& ptrwrap, int m, int step)
 {
     if (step == 1)
-        for(int i=0; i<m; ++i) *ptrwrap-- += CONJ(*ptr++);
+        for(; m; --m) *ptrwrap-- += CONJ(*ptr++);
     else
-        for(int i=0; i<m; ++i,ptr+=step,ptrwrap-=step) *ptrwrap += CONJ(*ptr);
+        for(; m; --m,ptr+=step,ptrwrap-=step) *ptrwrap += CONJ(*ptr);
 }
 
 // If j == jj, this needs to be slightly different.
@@ -368,12 +368,12 @@ template <typename T>
 void wrap_row_selfconj(T*& ptr, T*& ptrwrap, int m, int step)
 {
     if (step == 1)
-        for(int i=0; i<(m+1)/2; ++i,++ptr,--ptrwrap) {
+        for(int i=(m+1)/2; i; --i,++ptr,--ptrwrap) {
             *ptrwrap += CONJ(*ptr);
             *ptr = CONJ(*ptrwrap);
         }
     else
-        for(int i=0; i<(m+1)/2; ++i,ptr+=step,ptrwrap-=step) {
+        for(int i=(m+1)/2; i; --i,ptr+=step,ptrwrap-=step) {
             *ptrwrap += CONJ(*ptr);
             *ptr = CONJ(*ptrwrap);
         }
@@ -674,22 +674,22 @@ ImageView<std::complex<double> > BaseImage<T>::fft(bool shift_in, bool shift_out
     if (shift_out) {
         double fac = (shift_in && Nyo2 % 2 == 1) ? -1 : 1.;
         if (_step == 1) {
-            for (int j=-Nyo2; j<Nyo2; ++j, ptr+=skip, xptr+=2, fac=-fac)
-                for (int i=-Nxo2; i<Nxo2; ++i)
+            for (int j=Ny; j; --j, ptr+=skip, xptr+=2, fac=-fac)
+                for (int i=Nx; i; --i)
                     *xptr++ = fac * REAL(*ptr++);
         } else {
-            for (int j=-Nyo2; j<Nyo2; ++j, ptr+=skip, xptr+=2, fac=-fac)
-                for (int i=-Nxo2; i<Nxo2; ++i, ptr+=_step)
+            for (int j=Ny; j; --j, ptr+=skip, xptr+=2, fac=-fac)
+                for (int i=Nx; i; --i, ptr+=_step)
                     *xptr++ = fac * REAL(*ptr);
         }
     } else {
         if (_step == 1) {
-            for (int j=-Nyo2; j<Nyo2; ++j, ptr+=skip, xptr+=2)
-                for (int i=-Nxo2; i<Nxo2; ++i)
+            for (int j=Ny; j; --j, ptr+=skip, xptr+=2)
+                for (int i=Nx; i; --i)
                     *xptr++ = REAL(*ptr++);
         } else {
-            for (int j=-Nyo2; j<Nyo2; ++j, ptr+=skip, xptr+=2)
-                for (int i=-Nxo2; i<Nxo2; ++i, ptr+=_step)
+            for (int j=Ny; j; --j, ptr+=skip, xptr+=2)
+                for (int i=Nx; i; --i, ptr+=_step)
                     *xptr++ = REAL(*ptr);
         }
     }
@@ -708,8 +708,8 @@ ImageView<std::complex<double> > BaseImage<T>::fft(bool shift_in, bool shift_out
         std::complex<double>* kptr = kim.getData();
         double fac = 1.;
         const bool extra_flip = (Nxo2 % 2 == 1);
-        for (int j=-Nyo2; j<Nyo2; ++j, fac=(extra_flip?-fac:fac))
-            for (int i=0; i<=Nxo2; ++i, fac=-fac)
+        for (int j=Ny; j; --j, fac=(extra_flip?-fac:fac))
+            for (int i=Nxo2+1; i; --i, fac=-fac)
                 *kptr++ *= fac;
     }
 
@@ -764,39 +764,39 @@ ImageView<double> BaseImage<T>::inverse_fft(bool shift_in, bool shift_out) const
         const T* ptr = _data + start_offset;
         const bool extra_flip = (Nxo2 % 2 == 1);
         if (_step == 1) {
-            for (int j=0; j<Nyo2; ++j, ptr+=skip, fac=(extra_flip?-fac:fac))
-                for (int i=0; i<=Nxo2; ++i, fac=-fac)
+            for (int j=Nyo2; j; --j, ptr+=skip, fac=(extra_flip?-fac:fac))
+                for (int i=Nxo2+1; i; --i, fac=-fac)
                     *kptr++ = fac * *ptr++;
             ptr = _data + mid_offset;
-            for (int j=Nyo2; j<Ny; ++j, ptr+=skip, fac=(extra_flip?-fac:fac))
-                for (int i=0; i<=Nxo2; ++i, fac=-fac)
+            for (int j=Nyo2; j; --j, ptr+=skip, fac=(extra_flip?-fac:fac))
+                for (int i=Nxo2+1; i; --i, fac=-fac)
                     *kptr++ = fac * *ptr++;
         } else {
-            for (int j=0; j<Nyo2; ++j, ptr+=skip, fac=(extra_flip?-fac:fac))
-                for (int i=0; i<=Nxo2; ++i, ptr+=_step, fac=-fac)
+            for (int j=Nyo2; j; --j, ptr+=skip, fac=(extra_flip?-fac:fac))
+                for (int i=Nxo2+1; i; --i, ptr+=_step, fac=-fac)
                     *kptr++ = fac * *ptr;
             ptr = _data + mid_offset;
-            for (int j=Nyo2; j<Ny; ++j, ptr+=skip, fac=(extra_flip?-fac:fac))
-                for (int i=0; i<=Nxo2; ++i, ptr+=_step, fac=-fac)
+            for (int j=Nyo2; j; --j, ptr+=skip, fac=(extra_flip?-fac:fac))
+                for (int i=Nxo2+1; i; --i, ptr+=_step, fac=-fac)
                     *kptr++ = fac * *ptr;
         }
     } else {
         const T* ptr = _data + start_offset;
         if (_step == 1) {
-            for (int j=0; j<Nyo2; ++j, ptr+=skip)
-                for (int i=0; i<=Nxo2; ++i)
+            for (int j=Nyo2; j; --j, ptr+=skip)
+                for (int i=Nxo2+1; i; --i)
                     *kptr++ = fac * *ptr++;
             ptr = _data + mid_offset;
-            for (int j=Nyo2; j<Ny; ++j, ptr+=skip)
-                for (int i=0; i<=Nxo2; ++i)
+            for (int j=Nyo2; j; --j, ptr+=skip)
+                for (int i=Nxo2+1; i; --i)
                     *kptr++ = fac * *ptr++;
         } else {
-            for (int j=0; j<Nyo2; ++j, ptr+=skip)
-                for (int i=0; i<=Nxo2; ++i, ptr+=_step)
+            for (int j=Nyo2; j; --j, ptr+=skip)
+                for (int i=Nxo2+1; i; --i, ptr+=_step)
                     *kptr++ = fac * *ptr;
             ptr = _data + mid_offset;
-            for (int j=Nyo2; j<Ny; ++j, ptr+=skip)
-                for (int i=0; i<=Nxo2; ++i, ptr+=_step)
+            for (int j=Nyo2; j; --j, ptr+=skip)
+                for (int i=Nxo2+1; i; --i, ptr+=_step)
                     *kptr++ = fac * *ptr;
         }
     }
@@ -840,33 +840,33 @@ ImageView<std::complex<double> > BaseImage<T>::cfft(bool inverse, bool shift_in,
         double fac = inverse ? 1./(Nx*Ny) : 1.;
         if (shift_in && (Nxo2 + Nyo2) % 2 == 1) fac = -fac;
         if (_step == 1) {
-            for (int j=-Nyo2; j<Nyo2; ++j, ptr+=skip, fac=-fac)
-                for (int i=-Nxo2; i<Nxo2; ++i, fac=-fac)
+            for (int j=Ny; j; --j, ptr+=skip, fac=-fac)
+                for (int i=Nx; i; --i, fac=-fac)
                     *kptr++ = fac * *ptr++;
         } else {
-            for (int j=-Nyo2; j<Nyo2; ++j, ptr+=skip, fac=-fac)
-                for (int i=-Nxo2; i<Nxo2; ++i, ptr+=_step, fac=-fac)
+            for (int j=Ny; j; --j, ptr+=skip, fac=-fac)
+                for (int i=Nx; i; --i, ptr+=_step, fac=-fac)
                     *kptr++ = fac * *ptr;
         }
     } else if (inverse) {
         double fac = 1./(Nx*Ny);
         if (_step == 1) {
-            for (int j=-Nyo2; j<Nyo2; ++j, ptr+=skip)
-                for (int i=-Nxo2; i<Nxo2; ++i)
+            for (int j=Ny; j; --j, ptr+=skip)
+                for (int i=Nx; i; --i)
                     *kptr++ = fac * *ptr++;
         } else {
-            for (int j=-Nyo2; j<Nyo2; ++j, ptr+=skip)
-                for (int i=-Nxo2; i<Nxo2; ++i, ptr+=_step)
+            for (int j=Ny; j; --j, ptr+=skip)
+                for (int i=Nx; i; --i, ptr+=_step)
                     *kptr++ = fac * *ptr;
         }
     } else {
         if (_step == 1) {
-            for (int j=-Nyo2; j<Nyo2; ++j, ptr+=skip)
-                for (int i=-Nxo2; i<Nxo2; ++i)
+            for (int j=Ny; j; --j, ptr+=skip)
+                for (int i=Nx; i; --i)
                     *kptr++ = *ptr++;
         } else {
-            for (int j=-Nyo2; j<Nyo2; ++j, ptr+=skip)
-                for (int i=-Nxo2; i<Nxo2; ++i, ptr+=_step)
+            for (int j=Ny; j; --j, ptr+=skip)
+                for (int i=Nx; i; --i, ptr+=_step)
                     *kptr++ = *ptr;
         }
     }
@@ -882,8 +882,8 @@ ImageView<std::complex<double> > BaseImage<T>::cfft(bool inverse, bool shift_in,
     if (shift_in) {
         kptr = kim.getData();
         double fac = 1.;
-        for (int j=-Nyo2; j<Nyo2; ++j, fac=-fac)
-            for (int i=-Nxo2; i<Nxo2; ++i, fac=-fac)
+        for (int j=Ny; j; --j, fac=-fac)
+            for (int i=Nx; i; --i, fac=-fac)
                 *kptr++ *= fac;
     }
 

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -639,7 +639,7 @@ ImageView<T> ImageView<T>::wrap(const Bounds<int>& b, bool hermx, bool hermy)
 
 
 template <typename T>
-ImageView<std::complex<double> > BaseImage<T>::fft(double dx) const
+ImageView<std::complex<double> > BaseImage<T>::fft(double dx, bool shift_in, bool shift_out) const
 {
     dbg<<"Start BaseImage::fft\n";
     dbg<<"self bounds = "<<this->_bounds<<std::endl;
@@ -669,16 +669,28 @@ ImageView<std::complex<double> > BaseImage<T>::fft(double dx) const
 
     // The FT image that FFTW will return will have FT(0,0) placed at the origin.  We
     // want it placed in the middle instead.  We can make that happen by inverting every other
-    // column in the input image.
-    double fac = 1.;
-    if (_step == 1) {
-        for (int j=-No2; j<No2; ++j, ptr+=skip, xptr+=2, fac=-fac)
-            for (int i=-No2; i<No2; ++i)
-                *xptr++ = fac * REAL(*ptr++);
+    // column in the input image.  We also apply the factor dx^2.
+    double fac = dx*dx;
+    if (shift_out) {
+        if (_step == 1) {
+            for (int j=-No2; j<No2; ++j, ptr+=skip, xptr+=2, fac=-fac)
+                for (int i=-No2; i<No2; ++i)
+                    *xptr++ = fac * REAL(*ptr++);
+        } else {
+            for (int j=-No2; j<No2; ++j, ptr+=skip, xptr+=2, fac=-fac)
+                for (int i=-No2; i<No2; ++i, ptr+=_step)
+                    *xptr++ = fac * REAL(*ptr++);
+        }
     } else {
-        for (int j=-No2; j<No2; ++j, ptr+=skip, xptr+=2, fac=-fac)
-            for (int i=-No2; i<No2; ++i, ptr+=_step)
-                *xptr++ = fac * REAL(*ptr++);
+        if (_step == 1) {
+            for (int j=-No2; j<No2; ++j, ptr+=skip, xptr+=2)
+                for (int i=-No2; i<No2; ++i)
+                    *xptr++ = fac * REAL(*ptr++);
+        } else {
+            for (int j=-No2; j<No2; ++j, ptr+=skip, xptr+=2)
+                for (int i=-No2; i<No2; ++i, ptr+=_step)
+                    *xptr++ = fac * REAL(*ptr++);
+        }
     }
 
     fftw_complex* kdata = reinterpret_cast<fftw_complex*>(kim.getData());
@@ -690,20 +702,22 @@ ImageView<std::complex<double> > BaseImage<T>::fft(double dx) const
     fftw_destroy_plan(plan);
 
     // The resulting image will still have a checkerboard pattern of +-1 on it, which
-    // we want to remove.  We also apply the factor dx^2.
-    fac = dx*dx;
+    // we want to remove.
     std::complex<double>* kptr = kim.getData();
-    const bool extra_flip = (No2 % 2 == 1);
-    for (int j=-No2; j<No2; ++j, fac=(extra_flip?-fac:fac))
-        for (int i=0; i<=No2; ++i, fac=-fac)
-            *kptr++ *= fac;
+    if (shift_in) {
+        double fac = 1.;
+        const bool extra_flip = (No2 % 2 == 1);
+        for (int j=-No2; j<No2; ++j, fac=(extra_flip?-fac:fac))
+            for (int i=0; i<=No2; ++i, fac=-fac)
+                *kptr++ *= fac;
+    }
 
     // Now simply return a view of this image.
     return kim.view();
 }
 
 template <typename T>
-ImageView<double> BaseImage<T>::inverse_fft(double dk) const
+ImageView<double> BaseImage<T>::inverse_fft(double dk, bool shift_in, bool shift_out) const
 {
     dbg<<"Start BaseImage::inverse_fft\n";
     dbg<<"self bounds = "<<this->_bounds<<std::endl;
@@ -739,25 +753,49 @@ ImageView<double> BaseImage<T>::inverse_fft(double dk) const
     // and need to scale by (dk/2pi)^2.
     double fac = dk * dk / (4*M_PI*M_PI);
 
+    const int start_offset = shift_in ? No2 * _stride : 0;
+    const int mid_offset = shift_in ? 0 : No2 * _stride;
+
     const int skip = this->getNSkip();
-    const T* ptr = _data + No2*_stride;
-    const bool extra_flip = (No2 % 2 == 1);
-    if (_step == 1) {
-        for (int j=0; j<No2; ++j, ptr+=skip, fac=(extra_flip?-fac:fac))
-            for (int i=0; i<=No2; ++i, fac=-fac)
-                *kptr++ = fac * *ptr++;
-        ptr = _data;
-        for (int j=-No2; j<0; ++j, ptr+=skip, fac=(extra_flip?-fac:fac))
-            for (int i=0; i<=No2; ++i, fac=-fac)
-                *kptr++ = fac * *ptr++;
+    if (shift_out) {
+        const T* ptr = _data + start_offset;
+        const bool extra_flip = (No2 % 2 == 1);
+        if (_step == 1) {
+            for (int j=0; j<No2; ++j, ptr+=skip, fac=(extra_flip?-fac:fac))
+                for (int i=0; i<=No2; ++i, fac=-fac)
+                    *kptr++ = fac * *ptr++;
+            ptr = _data + mid_offset;
+            for (int j=-No2; j<0; ++j, ptr+=skip, fac=(extra_flip?-fac:fac))
+                for (int i=0; i<=No2; ++i, fac=-fac)
+                    *kptr++ = fac * *ptr++;
+        } else {
+            for (int j=0; j<No2; ++j, ptr+=skip, fac=(extra_flip?-fac:fac))
+                for (int i=0; i<=No2; ++i, ptr+=_step, fac=-fac)
+                    *kptr++ = fac * *ptr;
+            ptr = _data + mid_offset;
+            for (int j=No2; j<N; ++j, ptr+=skip, fac=(extra_flip?-fac:fac))
+                for (int i=0; i<=No2; ++i, ptr+=_step, fac=-fac)
+                    *kptr++ = fac * *ptr;
+        }
     } else {
-        for (int j=0; j<No2; ++j, ptr+=skip, fac=(extra_flip?-fac:fac))
-            for (int i=0; i<=No2; ++i, ptr+=_step, fac=-fac)
-                *kptr++ = fac * *ptr;
-        ptr = _data;
-        for (int j=No2; j<N; ++j, ptr+=skip, fac=(extra_flip?-fac:fac))
-            for (int i=0; i<=No2; ++i, ptr+=_step, fac=-fac)
-                *kptr++ = fac * *ptr;
+        const T* ptr = _data + start_offset;
+        if (_step == 1) {
+            for (int j=0; j<No2; ++j, ptr+=skip)
+                for (int i=0; i<=No2; ++i)
+                    *kptr++ = fac * *ptr++;
+            ptr = _data + mid_offset;
+            for (int j=-No2; j<0; ++j, ptr+=skip)
+                for (int i=0; i<=No2; ++i)
+                    *kptr++ = fac * *ptr++;
+        } else {
+            for (int j=0; j<No2; ++j, ptr+=skip)
+                for (int i=0; i<=No2; ++i, ptr+=_step)
+                    *kptr++ = fac * *ptr;
+            ptr = _data + mid_offset;
+            for (int j=No2; j<N; ++j, ptr+=skip)
+                for (int i=0; i<=No2; ++i, ptr+=_step)
+                    *kptr++ = fac * *ptr;
+        }
     }
 
     double* xdata = xim.getData();

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -1123,9 +1123,18 @@ def test_np_fft():
                                   [1,2,3,2],
                                   [2,3,4,3],
                                   [1,2,3,2] ], dtype=int ))
+    input_list.append( np.array([ [0,1],
+                                  [1,2],
+                                  [2,3],
+                                  [1,2] ], dtype=int ))
     noise = galsim.GaussianNoise(sigma=5, rng=galsim.BaseDeviate(1234))
     for N in [2,4,8,10]:
         xim = galsim.ImageD(N,N)
+        xim.addNoise(noise)
+        input_list.append(xim.array)
+
+    for Nx,Ny in [ (2,4), (4,2), (10,6), (6,10) ]:
+        xim = galsim.ImageD(Nx,Ny)
         xim.addNoise(noise)
         input_list.append(xim.array)
 
@@ -1135,21 +1144,30 @@ def test_np_fft():
         xim.imag.addNoise(noise)
         input_list.append(xim.array)
 
+    for Nx,Ny in [ (2,4), (4,2), (10,6), (6,10) ]:
+        xim = galsim.ImageC(Nx,Ny)
+        xim.real.addNoise(noise)
+        xim.imag.addNoise(noise)
+        input_list.append(xim.array)
+
     for xar in input_list:
-        print('xar = ',xar)
-        M,N = xar.shape
+        Ny,Nx = xar.shape
+        print('Nx,Ny = ',Nx,Ny)
+        if Nx + Ny < 10:
+            print('xar = ',xar)
         kar1 = np.fft.fft2(xar)
         #print('numpy kar = ',kar1)
         kar2 = galsim.fft.fft2(xar)
-        print('kar = ',kar2)
+        if Nx + Ny < 10:
+            print('kar = ',kar2)
         np.testing.assert_almost_equal(kar1, kar2, 9, "fft2 not equivalent to np.fft.fft2")
 
         # Check that kar is Hermitian in the way that we describe in the doc for ifft2
         if not np.iscomplexobj(xar):
-            for kx in range(N/2,N):
-                np.testing.assert_almost_equal(kar2[0,kx], kar2[0,N-kx].conjugate())
-                for ky in range(1,N):
-                    np.testing.assert_almost_equal(kar2[ky,kx], kar2[N-ky,N-kx].conjugate())
+            for kx in range(Nx/2,Nx):
+                np.testing.assert_almost_equal(kar2[0,kx], kar2[0,Nx-kx].conjugate())
+                for ky in range(1,Ny):
+                    np.testing.assert_almost_equal(kar2[ky,kx], kar2[Ny-ky,Nx-kx].conjugate())
 
         # Check shift_in
         kar3 = np.fft.fft2(np.fft.fftshift(xar))
@@ -1170,7 +1188,8 @@ def test_np_fft():
         #print('ifft2')
         xar1 = np.fft.ifft2(kar2)
         xar2 = galsim.fft.ifft2(kar2)
-        print('xar2 = ',xar2)
+        if Nx + Ny < 10:
+            print('xar2 = ',xar2)
         np.testing.assert_almost_equal(xar1, xar2, 9, "ifft2 not equivalent to np.fft.ifft2")
         np.testing.assert_almost_equal(xar2, xar, 9, "ifft2(fft2(a)) != a")
 

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -1118,158 +1118,118 @@ def test_fft():
 def test_np_fft():
     """Test the equivalence between np.fft functions and the galsim versions
     """
-    N = 6
-
-    # fft2
+    input_list = []
+    input_list.append( np.array([ [0,1,2,1],
+                                  [1,2,3,2],
+                                  [2,3,4,3],
+                                  [1,2,3,2] ], dtype=int ))
     noise = galsim.GaussianNoise(sigma=5, rng=galsim.BaseDeviate(1234))
-    if True:
+    for N in [2,4,8,10]:
         xim = galsim.ImageD(N,N)
         xim.addNoise(noise)
-        xar = xim.array
-    else:
-        N = 4
-        xar = np.array([ [0,1,2,1],
-                         [1,2,3,2],
-                         [2,3,4,3],
-                         [1,2,3,2] ])
-    print('xar = ',xar)
-    kar1 = np.fft.fft2(xar)
-    print('numpy kar = ',kar1)
-    kar2 = galsim.fft.fft2(xar)
-    print('galsim kar = ',kar2)
-    np.testing.assert_almost_equal(kar1, kar2, 9, "fft2 not equivalent to np.fft.fft2")
+        input_list.append(xim.array)
 
-    # Check that kar is Hermitian in the way that we describe in the doc for ifft2
-    for kx in range(N/2,N):
-        np.testing.assert_almost_equal(kar2[0,kx], kar2[0,N-kx].conjugate())
-        for ky in range(1,N):
-            np.testing.assert_almost_equal(kar2[ky,kx], kar2[N-ky,N-kx].conjugate())
-
-    # Check shift_in
-    kar3 = np.fft.fft2(np.fft.fftshift(xar))
-    kar4 = galsim.fft.fft2(xar, shift_in=True)
-    np.testing.assert_almost_equal(kar3, kar4, 9, "fft2(shift_in) failed")
-
-    # Check shift_out
-    kar5 = np.fft.fftshift(np.fft.fft2(xar))
-    kar6 = galsim.fft.fft2(xar, shift_out=True)
-    np.testing.assert_almost_equal(kar5, kar6, 9, "fft2(shift_out) failed")
-
-    # Check both
-    kar7 = np.fft.fftshift(np.fft.fft2(np.fft.fftshift(xar)))
-    kar8 = galsim.fft.fft2(xar, shift_in=True, shift_out=True)
-    np.testing.assert_almost_equal(kar7, kar8, 9, "fft2(shift_in,shift_out) failed")
-
-    # ifft2
-    print('ifft2')
-    xar1 = np.fft.ifft2(kar2)
-    xar2 = galsim.fft.ifft2(kar2)
-    np.testing.assert_almost_equal(xar1, xar2, 9, "ifft2 not equivalent to np.fft.ifft2")
-    np.testing.assert_almost_equal(xar2, xar, 9, "ifft2(fft2(a)) != a")
-
-    xar3 = np.fft.ifft2(np.fft.fftshift(kar6))
-    xar4 = galsim.fft.ifft2(kar6, shift_in=True)
-    np.testing.assert_almost_equal(xar3, xar4, 9, "ifft2(shift_in) failed")
-    np.testing.assert_almost_equal(xar4, xar, 9, "ifft2(fft2(a)) != a with shift_in/out")
-
-    xar5 = np.fft.fftshift(np.fft.ifft2(kar4))
-    xar6 = galsim.fft.ifft2(kar4, shift_out=True)
-    np.testing.assert_almost_equal(xar5, xar6, 9, "ifft2(shift_out) failed")
-    np.testing.assert_almost_equal(xar6, xar, 9, "ifft2(fft2(a)) != a with shift_out/in")
-
-    xar7 = np.fft.fftshift(np.fft.ifft2(np.fft.fftshift(kar8)))
-    xar8 = galsim.fft.ifft2(kar8, shift_in=True, shift_out=True)
-    np.testing.assert_almost_equal(xar7, xar8, 9, "ifft2(shift_in,shift_out) failed")
-    np.testing.assert_almost_equal(xar8, xar, 9, "ifft2(fft2(a)) != a with all shifts")
-
-    # rfft2
-    print('rfft2')
-    rkar1 = np.fft.rfft2(xar)
-    rkar2 = galsim.fft.rfft2(xar)
-    np.testing.assert_almost_equal(rkar1, rkar2, 9, "rfft2 not equivalent to np.fft.rfft2")
-
-    rkar3 = np.fft.rfft2(np.fft.fftshift(xar))
-    rkar4 = galsim.fft.rfft2(xar, shift_in=True)
-    np.testing.assert_almost_equal(rkar3, rkar4, 9, "rfft2(shift_in) failed")
-
-    rkar5 = np.fft.fftshift(np.fft.rfft2(xar),axes=(0,))
-    rkar6 = galsim.fft.rfft2(xar, shift_out=True)
-    np.testing.assert_almost_equal(rkar5, rkar6, 9, "rfft2(shift_out) failed")
-
-    rkar7 = np.fft.fftshift(np.fft.rfft2(np.fft.fftshift(xar)),axes=(0,))
-    rkar8 = galsim.fft.rfft2(xar, shift_in=True, shift_out=True)
-    np.testing.assert_almost_equal(rkar7, rkar8, 9, "rfft2(shift_in,shift_out) failed")
-
-    # irfft2
-    print('irfft2')
-    xar1 = np.fft.irfft2(rkar1)
-    xar2 = galsim.fft.irfft2(rkar1)
-    np.testing.assert_almost_equal(xar1, xar2, 9, "irfft2 not equivalent to np.fft.irfft2")
-    np.testing.assert_almost_equal(xar2, xar, 9, "irfft2(rfft2(a)) != a")
-
-    xar3 = np.fft.irfft2(np.fft.fftshift(rkar6,axes=(0,)))
-    xar4 = galsim.fft.irfft2(rkar6, shift_in=True)
-    np.testing.assert_almost_equal(xar3, xar4, 9, "irfft2(shift_in) failed")
-    np.testing.assert_almost_equal(xar4, xar, 9, "irfft2(rfft2(a)) != a with shift_in/out")
-
-    xar5 = np.fft.fftshift(np.fft.irfft2(rkar4))
-    xar6 = galsim.fft.irfft2(rkar4, shift_out=True)
-    np.testing.assert_almost_equal(xar5, xar6, 9, "irfft2(shift_out) failed")
-    np.testing.assert_almost_equal(xar6, xar, 9, "irfft2(rfft2(a)) != a with shift_out/in")
-
-    xar7 = np.fft.fftshift(np.fft.irfft2(np.fft.fftshift(rkar8,axes=(0,))))
-    xar8 = galsim.fft.irfft2(rkar8, shift_in=True, shift_out=True)
-    np.testing.assert_almost_equal(xar7, xar8, 9, "irfft2(shift_in,shift_out) failed")
-    np.testing.assert_almost_equal(xar8, xar, 9, "irfft2(rfft2(a)) != a with all shifts")
-
-    # cfft2
-    if True:
+    for N in [2,4,8,10]:
         xim = galsim.ImageC(N,N)
         xim.real.addNoise(noise)
         xim.imag.addNoise(noise)
-        xar = xim.array
-    else:
-        xar = xar * (1 + 2j)
+        input_list.append(xim.array)
 
-    print('cfft2')
-    kar1 = np.fft.fft2(xar)
-    kar2 = galsim.fft.fft2(xar)
-    np.testing.assert_almost_equal(kar1, kar2, 9, "c fft2 not equivalent to np.fft.fft2")
+    for xar in input_list:
+        print('xar = ',xar)
+        M,N = xar.shape
+        kar1 = np.fft.fft2(xar)
+        #print('numpy kar = ',kar1)
+        kar2 = galsim.fft.fft2(xar)
+        print('kar = ',kar2)
+        np.testing.assert_almost_equal(kar1, kar2, 9, "fft2 not equivalent to np.fft.fft2")
 
-    kar3 = np.fft.fft2(np.fft.fftshift(xar))
-    kar4 = galsim.fft.fft2(xar, shift_in=True)
-    np.testing.assert_almost_equal(kar3, kar4, 9, "c fft2(shift_in) failed")
+        # Check that kar is Hermitian in the way that we describe in the doc for ifft2
+        if not np.iscomplexobj(xar):
+            for kx in range(N/2,N):
+                np.testing.assert_almost_equal(kar2[0,kx], kar2[0,N-kx].conjugate())
+                for ky in range(1,N):
+                    np.testing.assert_almost_equal(kar2[ky,kx], kar2[N-ky,N-kx].conjugate())
 
-    kar5 = np.fft.fftshift(np.fft.fft2(xar))
-    kar6 = galsim.fft.fft2(xar, shift_out=True)
-    np.testing.assert_almost_equal(kar5, kar6, 9, "c fft2(shift_out) failed")
+        # Check shift_in
+        kar3 = np.fft.fft2(np.fft.fftshift(xar))
+        kar4 = galsim.fft.fft2(xar, shift_in=True)
+        np.testing.assert_almost_equal(kar3, kar4, 9, "fft2(shift_in) failed")
 
-    kar7 = np.fft.fftshift(np.fft.fft2(np.fft.fftshift(xar)))
-    kar8 = galsim.fft.fft2(xar, shift_in=True, shift_out=True)
-    np.testing.assert_almost_equal(kar7, kar8, 9, "c fft2(shift_in,shift_out) failed")
+        # Check shift_out
+        kar5 = np.fft.fftshift(np.fft.fft2(xar))
+        kar6 = galsim.fft.fft2(xar, shift_out=True)
+        np.testing.assert_almost_equal(kar5, kar6, 9, "fft2(shift_out) failed")
 
-    # icfft2
-    print('icfft2')
-    xar1 = np.fft.ifft2(kar2)
-    xar2 = galsim.fft.ifft2(kar2)
-    np.testing.assert_almost_equal(xar1, xar2, 9, "c ifft2 not equivalent to np.fft.ifft2")
-    np.testing.assert_almost_equal(xar2, xar, 9, "c ifft2(fft2(a)) != a")
+        # Check both
+        kar7 = np.fft.fftshift(np.fft.fft2(np.fft.fftshift(xar)))
+        kar8 = galsim.fft.fft2(xar, shift_in=True, shift_out=True)
+        np.testing.assert_almost_equal(kar7, kar8, 9, "fft2(shift_in,shift_out) failed")
 
-    xar3 = np.fft.ifft2(np.fft.fftshift(kar6))
-    xar4 = galsim.fft.ifft2(kar6, shift_in=True)
-    np.testing.assert_almost_equal(xar3, xar4, 9, "c ifft2(shift_in) failed")
-    np.testing.assert_almost_equal(xar4, xar, 9, "c ifft2(fft2(a)) != a with shift_in/out")
+        # ifft2
+        #print('ifft2')
+        xar1 = np.fft.ifft2(kar2)
+        xar2 = galsim.fft.ifft2(kar2)
+        print('xar2 = ',xar2)
+        np.testing.assert_almost_equal(xar1, xar2, 9, "ifft2 not equivalent to np.fft.ifft2")
+        np.testing.assert_almost_equal(xar2, xar, 9, "ifft2(fft2(a)) != a")
 
-    xar5 = np.fft.fftshift(np.fft.ifft2(kar4))
-    xar6 = galsim.fft.ifft2(kar4, shift_out=True)
-    np.testing.assert_almost_equal(xar5, xar6, 9, "c ifft2(shift_out) failed")
-    np.testing.assert_almost_equal(xar6, xar, 9, "c ifft2(fft2(a)) != a with shift_out/in")
+        xar3 = np.fft.ifft2(np.fft.fftshift(kar6))
+        xar4 = galsim.fft.ifft2(kar6, shift_in=True)
+        np.testing.assert_almost_equal(xar3, xar4, 9, "ifft2(shift_in) failed")
+        np.testing.assert_almost_equal(xar4, xar, 9, "ifft2(fft2(a)) != a with shift_in/out")
 
-    xar7 = np.fft.fftshift(np.fft.ifft2(np.fft.fftshift(kar8)))
-    xar8 = galsim.fft.ifft2(kar8, shift_in=True, shift_out=True)
-    np.testing.assert_almost_equal(xar7, xar8, 9, "c ifft2(shift_in,shift_out) failed")
-    np.testing.assert_almost_equal(xar8, xar, 9, "c ifft2(fft2(a)) != a with all shifts")
+        xar5 = np.fft.fftshift(np.fft.ifft2(kar4))
+        xar6 = galsim.fft.ifft2(kar4, shift_out=True)
+        np.testing.assert_almost_equal(xar5, xar6, 9, "ifft2(shift_out) failed")
+        np.testing.assert_almost_equal(xar6, xar, 9, "ifft2(fft2(a)) != a with shift_out/in")
 
+        xar7 = np.fft.fftshift(np.fft.ifft2(np.fft.fftshift(kar8)))
+        xar8 = galsim.fft.ifft2(kar8, shift_in=True, shift_out=True)
+        np.testing.assert_almost_equal(xar7, xar8, 9, "ifft2(shift_in,shift_out) failed")
+        np.testing.assert_almost_equal(xar8, xar, 9, "ifft2(fft2(a)) != a with all shifts")
+
+        if np.iscomplexobj(xar): continue
+
+        # rfft2
+        #print('rfft2')
+        rkar1 = np.fft.rfft2(xar)
+        rkar2 = galsim.fft.rfft2(xar)
+        np.testing.assert_almost_equal(rkar1, rkar2, 9, "rfft2 not equivalent to np.fft.rfft2")
+
+        rkar3 = np.fft.rfft2(np.fft.fftshift(xar))
+        rkar4 = galsim.fft.rfft2(xar, shift_in=True)
+        np.testing.assert_almost_equal(rkar3, rkar4, 9, "rfft2(shift_in) failed")
+
+        rkar5 = np.fft.fftshift(np.fft.rfft2(xar),axes=(0,))
+        rkar6 = galsim.fft.rfft2(xar, shift_out=True)
+        np.testing.assert_almost_equal(rkar5, rkar6, 9, "rfft2(shift_out) failed")
+
+        rkar7 = np.fft.fftshift(np.fft.rfft2(np.fft.fftshift(xar)),axes=(0,))
+        rkar8 = galsim.fft.rfft2(xar, shift_in=True, shift_out=True)
+        np.testing.assert_almost_equal(rkar7, rkar8, 9, "rfft2(shift_in,shift_out) failed")
+
+        # irfft2
+        #print('irfft2')
+        xar1 = np.fft.irfft2(rkar1)
+        xar2 = galsim.fft.irfft2(rkar1)
+        np.testing.assert_almost_equal(xar1, xar2, 9, "irfft2 not equivalent to np.fft.irfft2")
+        np.testing.assert_almost_equal(xar2, xar, 9, "irfft2(rfft2(a)) != a")
+
+        xar3 = np.fft.irfft2(np.fft.fftshift(rkar6,axes=(0,)))
+        xar4 = galsim.fft.irfft2(rkar6, shift_in=True)
+        np.testing.assert_almost_equal(xar3, xar4, 9, "irfft2(shift_in) failed")
+        np.testing.assert_almost_equal(xar4, xar, 9, "irfft2(rfft2(a)) != a with shift_in/out")
+
+        xar5 = np.fft.fftshift(np.fft.irfft2(rkar4))
+        xar6 = galsim.fft.irfft2(rkar4, shift_out=True)
+        np.testing.assert_almost_equal(xar5, xar6, 9, "irfft2(shift_out) failed")
+        np.testing.assert_almost_equal(xar6, xar, 9, "irfft2(rfft2(a)) != a with shift_out/in")
+
+        xar7 = np.fft.fftshift(np.fft.irfft2(np.fft.fftshift(rkar8,axes=(0,))))
+        xar8 = galsim.fft.irfft2(rkar8, shift_in=True, shift_out=True)
+        np.testing.assert_almost_equal(xar7, xar8, 9, "irfft2(shift_in,shift_out) failed")
+        np.testing.assert_almost_equal(xar8, xar, 9, "irfft2(rfft2(a)) != a with all shifts")
 
 if __name__ == "__main__":
     test_np_fft()

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -1222,6 +1222,53 @@ def test_np_fft():
     np.testing.assert_almost_equal(xar7, xar8, 9, "irfft2(shift_in,shift_out) failed")
     np.testing.assert_almost_equal(xar8, xar, 9, "irfft2(rfft2(a)) != a with all shifts")
 
+    # cfft2
+    if True:
+        xim = galsim.ImageC(N,N)
+        xim.real.addNoise(noise)
+        xim.imag.addNoise(noise)
+        xar = xim.array
+    else:
+        xar = xar * (1 + 2j)
+
+    print('cfft2')
+    kar1 = np.fft.fft2(xar)
+    kar2 = galsim.fft.fft2(xar)
+    np.testing.assert_almost_equal(kar1, kar2, 9, "c fft2 not equivalent to np.fft.fft2")
+
+    kar3 = np.fft.fft2(np.fft.fftshift(xar))
+    kar4 = galsim.fft.fft2(xar, shift_in=True)
+    np.testing.assert_almost_equal(kar3, kar4, 9, "c fft2(shift_in) failed")
+
+    kar5 = np.fft.fftshift(np.fft.fft2(xar))
+    kar6 = galsim.fft.fft2(xar, shift_out=True)
+    np.testing.assert_almost_equal(kar5, kar6, 9, "c fft2(shift_out) failed")
+
+    kar7 = np.fft.fftshift(np.fft.fft2(np.fft.fftshift(xar)))
+    kar8 = galsim.fft.fft2(xar, shift_in=True, shift_out=True)
+    np.testing.assert_almost_equal(kar7, kar8, 9, "c fft2(shift_in,shift_out) failed")
+
+    # icfft2
+    print('icfft2')
+    xar1 = np.fft.ifft2(kar2)
+    xar2 = galsim.fft.ifft2(kar2)
+    np.testing.assert_almost_equal(xar1, xar2, 9, "c ifft2 not equivalent to np.fft.ifft2")
+    np.testing.assert_almost_equal(xar2, xar, 9, "c ifft2(fft2(a)) != a")
+
+    xar3 = np.fft.ifft2(np.fft.fftshift(kar6))
+    xar4 = galsim.fft.ifft2(kar6, shift_in=True)
+    np.testing.assert_almost_equal(xar3, xar4, 9, "c ifft2(shift_in) failed")
+    np.testing.assert_almost_equal(xar4, xar, 9, "c ifft2(fft2(a)) != a with shift_in/out")
+
+    xar5 = np.fft.fftshift(np.fft.ifft2(kar4))
+    xar6 = galsim.fft.ifft2(kar4, shift_out=True)
+    np.testing.assert_almost_equal(xar5, xar6, 9, "c ifft2(shift_out) failed")
+    np.testing.assert_almost_equal(xar6, xar, 9, "c ifft2(fft2(a)) != a with shift_out/in")
+
+    xar7 = np.fft.fftshift(np.fft.ifft2(np.fft.fftshift(kar8)))
+    xar8 = galsim.fft.ifft2(kar8, shift_in=True, shift_out=True)
+    np.testing.assert_almost_equal(xar7, xar8, 9, "c ifft2(shift_in,shift_out) failed")
+    np.testing.assert_almost_equal(xar8, xar, 9, "c ifft2(fft2(a)) != a with all shifts")
 
 
 if __name__ == "__main__":

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -1271,3 +1271,4 @@ if __name__ == "__main__":
     test_offset()
     test_drawImage_area_exptime()
     test_fft()
+    test_np_fft()

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -1164,7 +1164,7 @@ def test_np_fft():
 
         # Check that kar is Hermitian in the way that we describe in the doc for ifft2
         if not np.iscomplexobj(xar):
-            for kx in range(Nx/2,Nx):
+            for kx in range(Nx//2,Nx):
                 np.testing.assert_almost_equal(kar2[0,kx], kar2[0,Nx-kx].conjugate())
                 for ky in range(1,Ny):
                     np.testing.assert_almost_equal(kar2[ky,kx], kar2[Ny-ky,Nx-kx].conjugate())

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -1118,30 +1118,32 @@ def test_fft():
 def test_np_fft():
     """Test the equivalence between np.fft functions and the galsim versions
     """
-    N = 8
+    N = 6
 
     # fft2
+    noise = galsim.GaussianNoise(sigma=5, rng=galsim.BaseDeviate(1234))
     if True:
         xim = galsim.ImageD(N,N)
-        xim.addNoise(galsim.GaussianNoise(sigma=5, rng=galsim.BaseDeviate(1234)))
+        xim.addNoise(noise)
         xar = xim.array
     else:
+        N = 4
         xar = np.array([ [0,1,2,1],
                          [1,2,3,2],
                          [2,3,4,3],
                          [1,2,3,2] ])
     print('xar = ',xar)
-    kar = np.fft.fft2(xar)
-    print('numpy kar = ',kar)
+    kar1 = np.fft.fft2(xar)
+    print('numpy kar = ',kar1)
     kar2 = galsim.fft.fft2(xar)
     print('galsim kar = ',kar2)
-    np.testing.assert_almost_equal(kar, kar2, 9, "fft2 not equivalent to np.fft.fft2")
+    np.testing.assert_almost_equal(kar1, kar2, 9, "fft2 not equivalent to np.fft.fft2")
 
     # Check that kar is Hermitian in the way that we describe in the doc for ifft2
     for kx in range(N/2,N):
-        np.testing.assert_almost_equal(kar[0,kx], kar[0,N-kx].conjugate())
+        np.testing.assert_almost_equal(kar2[0,kx], kar2[0,N-kx].conjugate())
         for ky in range(1,N):
-            np.testing.assert_almost_equal(kar[ky,kx], kar[N-ky,N-kx].conjugate())
+            np.testing.assert_almost_equal(kar2[ky,kx], kar2[N-ky,N-kx].conjugate())
 
     # Check shift_in
     kar3 = np.fft.fft2(np.fft.fftshift(xar))
@@ -1159,8 +1161,9 @@ def test_np_fft():
     np.testing.assert_almost_equal(kar7, kar8, 9, "fft2(shift_in,shift_out) failed")
 
     # ifft2
-    xar1 = np.fft.ifft2(kar)
-    xar2 = galsim.fft.ifft2(kar)
+    print('ifft2')
+    xar1 = np.fft.ifft2(kar2)
+    xar2 = galsim.fft.ifft2(kar2)
     np.testing.assert_almost_equal(xar1, xar2, 9, "ifft2 not equivalent to np.fft.ifft2")
     np.testing.assert_almost_equal(xar2, xar, 9, "ifft2(fft2(a)) != a")
 
@@ -1180,9 +1183,10 @@ def test_np_fft():
     np.testing.assert_almost_equal(xar8, xar, 9, "ifft2(fft2(a)) != a with all shifts")
 
     # rfft2
-    rkar = np.fft.rfft2(xar)
+    print('rfft2')
+    rkar1 = np.fft.rfft2(xar)
     rkar2 = galsim.fft.rfft2(xar)
-    np.testing.assert_almost_equal(rkar, rkar2, 9, "rfft2 not equivalent to np.fft.rfft2")
+    np.testing.assert_almost_equal(rkar1, rkar2, 9, "rfft2 not equivalent to np.fft.rfft2")
 
     rkar3 = np.fft.rfft2(np.fft.fftshift(xar))
     rkar4 = galsim.fft.rfft2(xar, shift_in=True)
@@ -1197,8 +1201,9 @@ def test_np_fft():
     np.testing.assert_almost_equal(rkar7, rkar8, 9, "rfft2(shift_in,shift_out) failed")
 
     # irfft2
-    xar1 = np.fft.irfft2(rkar)
-    xar2 = galsim.fft.irfft2(rkar)
+    print('irfft2')
+    xar1 = np.fft.irfft2(rkar1)
+    xar2 = galsim.fft.irfft2(rkar1)
     np.testing.assert_almost_equal(xar1, xar2, 9, "irfft2 not equivalent to np.fft.irfft2")
     np.testing.assert_almost_equal(xar2, xar, 9, "irfft2(rfft2(a)) != a")
 

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -1250,9 +1250,19 @@ def test_np_fft():
         np.testing.assert_almost_equal(xar7, xar8, 9, "irfft2(shift_in,shift_out) failed")
         np.testing.assert_almost_equal(xar8, xar, 9, "irfft2(rfft2(a)) != a with all shifts")
 
+        # ifft can also accept real arrays
+        xar9 = galsim.fft.fft2(galsim.fft.ifft2(xar))
+        np.testing.assert_almost_equal(xar9, xar, 9, "fft2(ifft2(a)) != a")
+        xar10 = galsim.fft.fft2(galsim.fft.ifft2(xar,shift_in=True),shift_out=True)
+        np.testing.assert_almost_equal(xar10, xar, 9, "fft2(ifft2(a)) != a with shift_in/out")
+        xar11 = galsim.fft.fft2(galsim.fft.ifft2(xar,shift_out=True),shift_in=True)
+        np.testing.assert_almost_equal(xar11, xar, 9, "fft2(ifft2(a)) != a with shift_out/in")
+        xar12 = galsim.fft.fft2(galsim.fft.ifft2(xar,shift_in=True,shift_out=True),
+                                shift_in=True,shift_out=True)
+        np.testing.assert_almost_equal(xar12, xar, 9, "fft2(ifft2(a)) != a with all shifts")
+
+
 if __name__ == "__main__":
-    test_np_fft()
-    quit()
     test_drawImage()
     test_draw_methods()
     test_drawKImage()

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -1261,6 +1261,44 @@ def test_np_fft():
                                 shift_in=True,shift_out=True)
         np.testing.assert_almost_equal(xar12, xar, 9, "fft2(ifft2(a)) != a with all shifts")
 
+    # Check for invalid inputs
+    try:
+        # Must be 2-d arrays
+        xar_1d = input_list[0].ravel()
+        xar_3d = input_list[0].reshape(2,2,4)
+        xar_4d = input_list[0].reshape(2,2,2,2)
+        np.testing.assert_raises(ValueError, galsim.fft.fft2, xar_1d)
+        np.testing.assert_raises(ValueError, galsim.fft.fft2, xar_3d)
+        np.testing.assert_raises(ValueError, galsim.fft.fft2, xar_4d)
+        np.testing.assert_raises(ValueError, galsim.fft.ifft2, xar_1d)
+        np.testing.assert_raises(ValueError, galsim.fft.ifft2, xar_3d)
+        np.testing.assert_raises(ValueError, galsim.fft.ifft2, xar_4d)
+        np.testing.assert_raises(ValueError, galsim.fft.rfft2, xar_1d)
+        np.testing.assert_raises(ValueError, galsim.fft.rfft2, xar_3d)
+        np.testing.assert_raises(ValueError, galsim.fft.rfft2, xar_4d)
+        np.testing.assert_raises(ValueError, galsim.fft.irfft2, xar_1d)
+        np.testing.assert_raises(ValueError, galsim.fft.irfft2, xar_3d)
+        np.testing.assert_raises(ValueError, galsim.fft.irfft2, xar_4d)
+
+        # Must have even sizes
+        xar_oo = input_list[0][:3,:3]
+        xar_oe = input_list[0][:3,:]
+        xar_eo = input_list[0][:,:3]
+        np.testing.assert_raises(ValueError, galsim.fft.fft2, xar_oo)
+        np.testing.assert_raises(ValueError, galsim.fft.fft2, xar_oe)
+        np.testing.assert_raises(ValueError, galsim.fft.fft2, xar_eo)
+        np.testing.assert_raises(ValueError, galsim.fft.ifft2, xar_oo)
+        np.testing.assert_raises(ValueError, galsim.fft.ifft2, xar_oe)
+        np.testing.assert_raises(ValueError, galsim.fft.ifft2, xar_eo)
+        np.testing.assert_raises(ValueError, galsim.fft.rfft2, xar_oo)
+        np.testing.assert_raises(ValueError, galsim.fft.rfft2, xar_oe)
+        np.testing.assert_raises(ValueError, galsim.fft.rfft2, xar_eo)
+        np.testing.assert_raises(ValueError, galsim.fft.irfft2, xar_oo)
+        np.testing.assert_raises(ValueError, galsim.fft.irfft2, xar_oe)
+        # eo is ok, since the second dimension is actually N/2+1
+    except ImportError:
+        pass
+
 
 if __name__ == "__main__":
     test_drawImage()

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -898,6 +898,53 @@ def test_ne():
                                    pupil_angle=10*galsim.degrees, suppress_warning=True)]
     all_obj_diff(objs)
 
+@timer
+def test_noll():
+
+    # This function stolen from https://github.com/tvwerkhoven/libtim-py/blob/master/libtim/zern.py
+    # It used to be in phase_screen.py, but now we use a faster lookup-table implementation.
+    # This reference version is still useful as a test.
+    def noll_to_zern(j):
+        if (j == 0):
+            raise ValueError("Noll indices start at 1. 0 is invalid.")
+        n = 0
+        j1 = j-1
+        while (j1 > n):
+            n += 1
+            j1 -= n
+        m = (-1)**j * ((n % 2) + 2 * int((j1+((n+1) % 2)) / 2.0))
+        return (n, m)
+
+    # Test that the version of _noll_to_zern in phase_screens.py is accurate.
+    for j in range(1,30):
+        true_n,true_m = noll_to_zern(j)
+        n,m = galsim.phase_screens._noll_to_zern(j)
+        #print('j=%d, noll = %d,%d, true_noll = %d,%d'%(j,n,m,true_n,true_m))
+        assert n == true_n
+        assert m == true_m
+        # These didn't turn out to be all that useful for fast conversions, but they're cute.
+        assert n == int(np.sqrt(8*j-7)-1)//2
+        mm = -m if (n//2)%2 == 0 else m
+        assert j == n*(n+1)/2 + (abs(2*mm+1)+1)//2
+
+    # Again, the reference version of this function used to be in phase_screens.py
+    def zern_rho_coefs(n, m):
+        """Compute coefficients of radial part of Zernike (n, m).
+        """
+        from galsim.phase_screens import _nCr
+        kmax = (n-abs(m)) // 2
+        A = np.zeros(n+1)
+        for k in range(kmax+1):
+            A[n-2*k] = (-1)**k * _nCr(n-k, k) * _nCr(n-2*k, kmax-k)
+        return A
+
+    for j in range(1,30):
+        n,m = galsim.phase_screens._noll_to_zern(j)
+        true_coefs = zern_rho_coefs(n,m)
+        coefs = galsim.phase_screens._zern_rho_coefs(n,m)
+        #print('j=%d, coefs = %s'%(j,coefs))
+        np.testing.assert_array_equal(coefs,true_coefs)
+
 
 if __name__ == "__main__":
     test_OpticalPSF_flux()
@@ -914,3 +961,4 @@ if __name__ == "__main__":
     test_OpticalPSF_aper()
     test_stepk_maxk_iipad()
     test_ne()
+    test_noll()


### PR DESCRIPTION
This is basically all speed-related optimizations.  

Josh was comparing the timing of @aaronroodman's donutlib code to the equivalent functionality in GalSim's phase_psf and found that GalSim was significantly slower.  He made some changes in #835 to try to get the code to at least do the same thing in terms of padding and such.  But even with an apples-to-apples comparison, GalSim was still more than a factor of 2 slower.

Anyway, he and I have been working on some optimizations.  I think we're probably done so here they are.  Some highlights:

- Caching some of the calculations related to Zernikes that are independent of the wavefront and just a function of jmax.
- Faster horner implementation that beats np.polyval for the typical inputs we have in the phase_screen code by more than a factor of 3.
- Use `np.dot` for doing the sum of aberration coefficients times their corresponding wavefronts as a matrix-vector product to avoid the explicit python loop.
- New galsim.fft package that has some functions which can serve as drop in replacements for the same-named np.fft functions, although with some more restrictive requirements on the input array and fewer options.  e.g. `np.fft.fft2(a)` -> `galsim.fft.fft2(a)` is equivalent, but typically ~20-30% faster.
- Added a number of leading-underscore functions that avoid the python kruft in some of our regular functions or class constructors.  The most significant of these is `_Image(array, bounds, wcs)` which only accepts those arguments, not the panoply of options the regular constructor accepts, and doesn't do any sanity checks on the inputs.  But since we do that combination pretty often, and we already know the inputs are sane, it's a nice time savings.  (This is a standard trick that Erin uses a lot in his code.)
- Lots of micro-optimizations like using `max` rather than `np.max` for scalars, avoiding copies in `astype()` when possible, etc.

The upshot is that the code is now basically as fast as donutlib.  And some of this effort has of course impacted other uses as well.  On my laptop, the test suites are now about 5% faster, so that's more than just the OpticalPSF stuff being sped up.

Note: I only inserted the galsim.fft functions into the phase psf code.  The PowerSpectrum and CorrelatedNoise classes are other purveyors of np.fft.  However, they currently allow odd-sized inputs, which I didn't implement for galsim.fft.  I may get around to updating the code to allow that (there are annoying bookkeeping issues to deal with), but a better solution would likely be to pad out the fft arrays to a "good fft size".  However, I suspect there are subtleties to that, which I didn't feel like tackling, so I put them off to a later issue.