### PR TITLE
#842 Fix a bug in Image.subImage that can cause seg faults on some machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Bug Fixes
 - Fixed bug when whitening noise in images based on COSMOS training datasets
   using the config functionality. (#792)
 - Fixed some handling of images with undefined bounds. (#799)
+- Fixed bug in image.subImage that could cause seg faults in some cases. (#848)
 
 
 Deprecated Features

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -570,11 +570,15 @@ class Image(with_metaclass(MetaImage, object)):
         """
         if not isinstance(bounds, galsim.BoundsI):
             raise TypeError("bounds must be a galsim.BoundsI instance")
-        subimage = self.image.subImage(bounds)
+        i1 = bounds.ymin - self.bounds.ymin
+        i2 = bounds.ymax - self.bounds.ymin + 1
+        j1 = bounds.xmin - self.bounds.xmin
+        j2 = bounds.xmax - self.bounds.xmin + 1
+        subarray = self.array[i1:i2, j1:j2]
         # NB. The wcs is still accurate, since the sub-image uses the same (x,y) values
         # as the original image did for those pixels.  It's only once you recenter or
         # reorigin that you need to update the wcs.  So that's taken care of in im.shift.
-        return _Image(subimage.array, bounds, self.wcs)
+        return _Image(subarray, bounds, self.wcs)
 
     def setSubImage(self, bounds, rhs):
         """Set a portion of the full image to the values in another image

--- a/pysrc/Interpolant.cpp
+++ b/pysrc/Interpolant.cpp
@@ -50,7 +50,7 @@ namespace galsim {
                     --end;
                     conserve = false;
                 }
-                int n = strtol(str.substr(7,end).c_str(),0,0);
+                int n = strtol(str.c_str()+7,0,0);
                 if (n <= 0) {
                     PyErr_SetString(PyExc_TypeError, "Invalid Lanczos order");
                     bp::throw_error_already_set();

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1766,6 +1766,31 @@ def test_Image_subImage():
 
         do_pickle(image)
 
+def make_subImage(file_name, bounds):
+    """Helper function for test_subImage_persistence
+    """
+    full_im = galsim.fits.read(file_name)
+    stamp = full_im.subImage(bounds)
+    return stamp
+
+@timer
+def test_subImage_persistence():
+    """Test that a subimage is properly accessible even if the original image has gone out
+    of scope.
+    """
+    file_name = os.path.join('fits_files','tpv.fits')
+    bounds = galsim.BoundsI(123, 133, 45, 55)  # Something random
+
+    # In this case, the original image has gone out of scope.  At least on some systems,
+    # this used to caus a seg fault when accessing stamp1.array.  (BAD!)
+    stamp1 = make_subImage(file_name, bounds)
+    print('stamp1 = ',stamp1.array)
+
+    full_im = galsim.fits.read(file_name)
+    stamp2 = full_im.subImage(bounds)
+    print('stamp2 = ',stamp2.array)
+
+    np.testing.assert_array_equal(stamp1.array, stamp2.array)
 
 @timer
 def test_Image_resize():
@@ -2980,6 +3005,7 @@ if __name__ == "__main__":
     test_Image_inplace_scalar_divide()
     test_Image_inplace_scalar_pow()
     test_Image_subImage()
+    test_subImage_persistence()
     test_Image_resize()
     test_ConstImage_array_constness()
     test_BoundsI_init_with_non_pure_ints()


### PR DESCRIPTION
@esheldon [reported](https://github.com/rmjarvis/Piff/issues/50) a bug running Piff unit tests that I eventually tracked down to a bug in GalSim that apparently only shows up for particular systems (Ubuntu Anaconda in his case).

The bug shows up if a suitably large image is loaded from a fits file, and subimages are taken from that image and stored.  Then if the main image goes out of scope and the file is closed, then accessing those stored subimages can cause seg faults.

I'm pretty sure the underlying issue is how we do our wrapping of the numpy arrays and how we set the owner of them, but I didn't fix it there, since I'm planning to rewrite all of that stuff relatively soon anyway as part of the no-boost migration.

Rather, I changed the `Image.subImage` call to make the subarray in python and then make an Image of that.  This means numpy is in charge of persisting the memory, and they do that correctly, so all works fine.

There's also one tiny little edit that I did for the #842 effort of tracking down installation problems Erin was having on that same machine.  It turns out it wasn't super helpful in the end, since Erin ended up switching to miniconda, but I figured I'd leave it in.  Erin was getting linking errors about `throw_out_of_range_fmt` not being found trying to cross-compile across gcc versions.  It turned out that we only have [one place in the code](https://github.com/rmjarvis) that uses that (implicitly in a substr call), and it was easy to get rid of.  So maybe this will help someone else down the line not run into that problem.