### PR TITLE
#851 str -> basestring

### DIFF
--- a/galsim/bandpass.py
+++ b/galsim/bandpass.py
@@ -212,12 +212,13 @@ class Bandpass(object):
                     test_wave = 700
                 try:
                     self._tp = galsim.utilities.math_eval('lambda wave : ' + self._orig_tp)
-                    self._tp(test_wave)
+                    from numbers import Real
+                    assert isinstance(self._tp(test_wave), Real)
                 except Exception as e:
                     raise ValueError(
                         "String throughput must either be a valid filename or something that "+
                         "can eval to a function of wave.\n" +
-                        "Input provided: {0}\n".format(self._orig_tp) +
+                        "Input provided: {0!r}\n".format(self._orig_tp) +
                         "Caught error: {0}".format(e))
         else:
             self._tp = self._orig_tp

--- a/galsim/bandpass.py
+++ b/galsim/bandpass.py
@@ -213,7 +213,10 @@ class Bandpass(object):
                 try:
                     self._tp = galsim.utilities.math_eval('lambda wave : ' + self._orig_tp)
                     from numbers import Real
-                    assert isinstance(self._tp(test_wave), Real)
+                    if not isinstance(self._tp(test_wave), Real):
+                        raise ValueError("The given throughput function, %r, did not return a valid"
+                                         " number at test wavelength %s"%(
+                                         self._orig_tp, test_wave))
                 except Exception as e:
                     raise ValueError(
                         "String throughput must either be a valid filename or something that "+

--- a/galsim/bandpass.py
+++ b/galsim/bandpass.py
@@ -19,6 +19,7 @@
 Very simple implementation of a filter bandpass.  Used by galsim.chromatic.
 """
 
+from past.builtins import basestring
 import numpy as np
 
 import galsim
@@ -195,7 +196,7 @@ class Bandpass(object):
 
         if self._tp is not None:
             pass
-        elif isinstance(self._orig_tp, str):
+        elif isinstance(self._orig_tp, basestring):
             import os
             if os.path.isfile(self._orig_tp):
                 self._tp = galsim.LookupTable(file=self._orig_tp, interpolant='linear')

--- a/galsim/base.py
+++ b/galsim/base.py
@@ -40,8 +40,6 @@ between the scale radii used to specify the size of the GSObject and between the
 Image is acceptable.
 """
 
-import numpy as np
-
 import galsim
 from . import _galsim
 from .gsobject import GSObject
@@ -1413,4 +1411,3 @@ _galsim.SBSpergel.__getinitargs__ = lambda self: (
 _galsim.SBSpergel.__getstate__ = lambda self: None
 _galsim.SBSpergel.__repr__ = lambda self: \
         'galsim._galsim.SBSpergel(%r, %r, %r, %r, %r)'%self.__getinitargs__()
-

--- a/galsim/des/des_psfex.py
+++ b/galsim/des/des_psfex.py
@@ -218,7 +218,7 @@ class DES_PSFEx(object):
         if pol_group2 != 1:
             raise IOError("PSFEx: Expected POLGRP2 == 1, got %s"%pol_group2)
         if psf_naxis != 3:
-            raise IOError("PSFEx: Expected PSFNAXIS == 3, got %d"%psfnaxis)
+            raise IOError("PSFEx: Expected PSFNAXIS == 3, got %d"%psf_naxis)
         if psf_axis3 != ((pol_deg+1)*(pol_deg+2))//2:
             raise IOError("PSFEx: POLDEG and PSFAXIS3 disagree")
         if basis.shape[0] != psf_axis3:
@@ -272,6 +272,7 @@ class DES_PSFEx(object):
         if self.wcs:
             psf = self.wcs.toWorld(psf, image_pos=image_pos)
         elif pixel_scale:  # pragma: no cover
+            from ..deprecated import depr
             depr('pixel_scale',1.1,'wcs=PixelScale(pixel_scale) in the constructor for DES_PSFEx')
             psf = galsim.PixelScale(pixel_scale).toWorld(psf)
 
@@ -379,4 +380,3 @@ def BuildDES_PSFEx(config, base, ignore, gsparams, logger):
 
 # Register this builder with the config framework:
 galsim.config.RegisterObjectType('DES_PSFEx', BuildDES_PSFEx, input_type='des_psfex')
-

--- a/galsim/des/des_psfex.py
+++ b/galsim/des/des_psfex.py
@@ -27,6 +27,8 @@ See documentation here:
     https://www.astromatic.net/pubsvn/software/psfex/trunk/doc/psfex.pdf
 """
 
+from past.builtins import basestring
+
 import galsim
 import galsim.config
 import numpy as np
@@ -104,7 +106,7 @@ class DES_PSFEx(object):
     def __init__(self, file_name, image_file_name=None, wcs=None, dir=None):
 
         if dir:
-            if not isinstance(file_name, str):
+            if not isinstance(file_name, basestring):
                 raise ValueError("Cannot provide dir and an HDU instance")
             import os
             file_name = os.path.join(dir,file_name)
@@ -123,7 +125,7 @@ class DES_PSFEx(object):
 
     def read(self):
         from galsim._pyfits import pyfits
-        if isinstance(self.file_name, str):
+        if isinstance(self.file_name, basestring):
             hdu_list = pyfits.open(self.file_name)
             hdu = hdu_list[1]
         else:

--- a/galsim/des/des_psfex.py
+++ b/galsim/des/des_psfex.py
@@ -315,17 +315,7 @@ class PSFExLoader(galsim.config.InputLoader):
 
         if 'image_file_name' not in kwargs:
             if 'wcs' in base:
-                wcs = base['wcs']
-                if wcs.isLocal():
-                    # Then the wcs is already fine.
-                    pass
-                elif 'image_pos' in base:
-                    image_pos = base['image_pos']
-                    wcs = wcs.local(image_pos)
-                    safe = False
-                else:
-                    raise RuntimeError("No image_pos found in config, but wcs is not local.")
-                kwargs['wcs'] = wcs
+                kwargs['wcs'] = base['wcs']
             else:
                 # Then we aren't doing normal config processing, so just use pixel scale = 1.
                 kwargs['wcs'] = galsim.PixelScale(1.)

--- a/galsim/des/des_shapelet.py
+++ b/galsim/des/des_shapelet.py
@@ -79,10 +79,10 @@ class DES_Shapelet(object):
             file_name = os.path.join(dir,file_name)
         self.file_name = file_name
 
-        if not file_type:
+        if not file_type:  # pragma: no branch
             if self.file_name.lower().endswith('.fits'):
                 file_type = 'FITS'
-            else:
+            else:  # pragma: no cover
                 file_type = 'ASCII'
         file_type = file_type.upper()
         if file_type not in ['FITS', 'ASCII']:

--- a/galsim/fits.py
+++ b/galsim/fits.py
@@ -23,6 +23,7 @@ routines for handling multiple Images.
 """
 
 from future.utils import iteritems, iterkeys, itervalues
+from past.builtins import basestring
 import os
 import galsim
 import numpy as np
@@ -479,7 +480,7 @@ def closeHDUList(hdu_list, fin):
     """If necessary, close the file handle that was opened to read in the `hdu_list`"""
     hdu_list.close()
     if fin:
-        if isinstance(fin, str): # pragma: no cover
+        if isinstance(fin, basestring): # pragma: no cover
             # In this case, it is a file name that we need to delete.
             # Note: This is relevant for the _tmp versions that are not run on Travis, so
             # don't include this bit in the coverage report.
@@ -1154,7 +1155,7 @@ class FitsHeader(object):
             raise TypeError("Cannot provide both file_name and hdu_list to FitsHeader")
 
         # Interpret a string header as though it were passed as file_name.
-        if isinstance(header, str):
+        if isinstance(header, basestring):
             file_name = header
             header = None
 

--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -38,7 +38,6 @@ rescaling of flux or size, rotating, and shifting; and (c) actually make images 
 brightness profiles.
 """
 
-import os
 import numpy as np
 
 import galsim

--- a/galsim/interpolatedimage.py
+++ b/galsim/interpolatedimage.py
@@ -20,6 +20,7 @@
 InterpolatedImage is a class that allows one to treat an image as a profile.
 """
 
+from past.builtins import basestring
 import galsim
 from galsim import GSObject
 from . import _galsim
@@ -320,7 +321,7 @@ class InterpolatedImage(GSObject):
 
         # Check that given pad_image is valid:
         if pad_image:
-            if isinstance(pad_image, str):
+            if isinstance(pad_image, basestring):
                 pad_image = galsim.fits.read(pad_image)
             if not isinstance(pad_image, galsim.Image):
                 raise ValueError("Supplied pad_image is not an Image!")
@@ -525,7 +526,7 @@ class InterpolatedImage(GSObject):
                 # Make sure that we are using a specified RNG by resetting that in this cached
                 # CorrelatedNoise instance, otherwise preserve the cached RNG
                 noise = noise.copy(rng=rng)
-        elif isinstance(noise_pad, str):
+        elif isinstance(noise_pad, basestring):
             noise = galsim.CorrelatedNoise(galsim.fits.read(noise_pad), rng)
             if self.use_cache:
                 InterpolatedImage._cache_noise_pad[noise_pad] = noise

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -52,6 +52,7 @@ Atmosphere
   Convenience function to quickly assemble multiple AtmosphericScreens into a PhaseScreenList.
 """
 
+from past.builtins import basestring
 from itertools import chain
 from builtins import range
 
@@ -1396,7 +1397,8 @@ class OpticalPSF(GSObject):
             # we just disallow this combination.  Please feel free to raise an issue at
             # https://github.com/GalSim-developers/GalSim/issues if you need this functionality.
             if pupil_plane_im is not None:
-                if isinstance(pupil_plane_im, str):  # Filename, therefore specific scale exists.
+                if isinstance(pupil_plane_im, basestring):
+                    # Filename, therefore specific scale exists.
                     raise TypeError("If specifying lam_over_diam, then do not "
                                     "specify pupil_plane_im as a filename.")
                 elif (isinstance(pupil_plane_im, galsim.Image)

--- a/galsim/sed.py
+++ b/galsim/sed.py
@@ -192,14 +192,15 @@ class SED(object):
                 # Are there any other types of errors we should trap here?
                 try:
                     self._spec = galsim.utilities.math_eval('lambda wave : ' + self._orig_spec)
-                    self._spec(700)
+                    from numbers import Real
+                    assert isinstance(self._spec(700), Real)
                 except ArithmeticError:
                     pass
                 except Exception as e:
                     raise ValueError(
                         "String spec must either be a valid filename or something that "+
                         "can eval to a function of wave.\n" +
-                        "Input provided: {0}\n".format(self._orig_spec) +
+                        "Input provided: {0!r}\n".format(self._orig_spec) +
                         "Caught error: {0}".format(e))
 
         else:

--- a/galsim/sed.py
+++ b/galsim/sed.py
@@ -193,7 +193,10 @@ class SED(object):
                 try:
                     self._spec = galsim.utilities.math_eval('lambda wave : ' + self._orig_spec)
                     from numbers import Real
-                    assert isinstance(self._spec(700), Real)
+                    if not isinstance(self._spec(700.0), Real):
+                        raise ValueError("The given SED function, %r, did not return a valid"
+                                         " number at test wavelength %s"%(
+                                         self._spec, 700.0))
                 except ArithmeticError:
                     pass
                 except Exception as e:

--- a/galsim/sed.py
+++ b/galsim/sed.py
@@ -19,6 +19,7 @@
 Spectral energy distribution class.  Used by galsim/chromatic.py
 """
 
+from past.builtins import basestring
 import numpy as np
 
 import galsim
@@ -178,7 +179,7 @@ class SED(object):
                 raise ValueError("Attempt to set spectral SED using float or integer.")
             self._const = True
             self._spec = lambda w: float(self._orig_spec)
-        elif isinstance(self._orig_spec, str):
+        elif isinstance(self._orig_spec, basestring):
             import os
             if os.path.isfile(self._orig_spec):
                 self._spec = galsim.LookupTable(file=self._orig_spec, interpolant='linear')

--- a/galsim/wfirst/wfirst_psfs.py
+++ b/galsim/wfirst/wfirst_psfs.py
@@ -330,7 +330,6 @@ def storePSFImages(PSF_dict, filename, bandpass_list=None, clobber=False):
             SCA_index_list.append(SCA)
 
     # Save images to file.
-    n_ims = len(im_list)
     galsim.fits.writeMulti(im_list, filename, clobber=clobber)
 
     # Add data to file, after constructing a FITS table.  Watch out for clobbering.

--- a/galsim/wfirst/wfirst_psfs.py
+++ b/galsim/wfirst/wfirst_psfs.py
@@ -16,6 +16,7 @@
 #    and/or other materials provided with the distribution.
 #
 
+from past.builtins import basestring
 import galsim
 import galsim.wfirst
 import numpy as np
@@ -294,7 +295,7 @@ def storePSFImages(PSF_dict, filename, bandpass_list=None, clobber=False):
     if bandpass_list is None:
         bandpass_list = default_bandpass_list
     else:
-        if not isinstance(bandpass_list[0], str):
+        if not isinstance(bandpass_list[0], basestring):
             raise ValueError("Expected input list of bandpass names!")
         if not set(bandpass_list).issubset(default_bandpass_list):
             err_msg = ''

--- a/tests/test_bandpass.py
+++ b/tests/test_bandpass.py
@@ -40,6 +40,8 @@ def test_Bandpass_basic():
     try:
         # Cannot initialize bandpass without wave_type:
         np.testing.assert_raises(TypeError, galsim.Bandpass, throughput=lambda x:x)
+        # eval-str must return a Real
+        np.testing.assert_raises(ValueError, galsim.Bandpass, throughput="'spam'", wave_type='A')
     except ImportError:
         print('The assert_raises tests require nose')
 

--- a/tests/test_des.py
+++ b/tests/test_des.py
@@ -31,6 +31,7 @@ except ImportError:
     sys.path.append(os.path.abspath(os.path.join(path, "..")))
     import galsim
 
+from galsim._pyfits import pyfits
 
 @timer
 def test_meds():
@@ -538,6 +539,9 @@ def test_psf():
     psfex = galsim.des.DES_PSFEx(psfex_file, wcs_file, dir=data_dir)
     psf = psfex.getPSF(image_pos)
 
+    # The getLocalWCS function should return a local WCS
+    assert psfex.getLocalWCS(image_pos).isLocal()
+
     # Draw the postage stamp image
     # Note: the PSF already includes the pixel response, so draw with method 'no_pixel'.
     stamp = psf.drawImage(wcs=wcs.local(image_pos), bounds=b, method='no_pixel')
@@ -557,8 +561,13 @@ def test_psf():
                                       err_msg="PSFEx shape.g2 doesn't match")
 
     # Repeat without the wcs_file argument, so the model is in chip coordinates.
-    psfex = galsim.des.DES_PSFEx(psfex_file, dir=data_dir)
+    # Also check the functionality where the file is already open.
+    hdu_list = pyfits.open(os.path.join(data_dir,psfex_file))
+    psfex = galsim.des.DES_PSFEx(hdu_list[1])
     psf = psfex.getPSF(image_pos)
+
+    # In this case, the getLocalWCS function won't return anything useful.
+    assert psfex.getLocalWCS(image_pos) is None
 
     # Draw the postage stamp image.  This time in image coords, so pixel_scale = 1.0.
     stamp = psf.drawImage(bounds=b, scale=1.0, method='no_pixel')
@@ -609,8 +618,10 @@ def test_psf_config():
         'psf1' : { 'type' : 'DES_Shapelet' },
         'psf2' : { 'type' : 'DES_PSFEx', 'num' : 0 },
         'psf3' : { 'type' : 'DES_PSFEx', 'num' : 1 },
-        'psf4' : { 'type' : 'DES_Shapelet', 'image_pos' : galsim.PositionD(567,789), 'flux' : 179 },
-        'psf5' : { 'type' : 'DES_PSFEx', 'image_pos' : galsim.PositionD(789,567), 'flux' : 388 },
+        'psf4' : { 'type' : 'DES_Shapelet', 'image_pos' : galsim.PositionD(567,789), 'flux' : 179,
+                   'gsparams' : { 'folding_threshold' : 1.e-4 } },
+        'psf5' : { 'type' : 'DES_PSFEx', 'image_pos' : galsim.PositionD(789,567), 'flux' : 388,
+                   'gsparams' : { 'folding_threshold' : 1.e-4 } },
 
         # This would normally be set by the config processing.  Set it manually here.
         'image_pos' : image_pos,
@@ -633,12 +644,18 @@ def test_psf_config():
     psf3b = psfex1.getPSF(image_pos)
     gsobject_compare(psf3a, psf3b)
 
+    gsparams = galsim.GSParams(folding_threshold=1.e-4)
     psf4a = galsim.config.BuildGSObject(config, 'psf4')[0]
-    psf4b = fitpsf.getPSF(galsim.PositionD(567,789)).withFlux(179)
+    psf4b = fitpsf.getPSF(galsim.PositionD(567,789),gsparams=gsparams).withFlux(179)
     gsobject_compare(psf4a, psf4b)
 
+    # Insert a wcs for thes last one.
+    config['wcs'] = galsim.FitsWCS(os.path.join(data_dir,wcs_file))
+    del config['input_objs']
+    galsim.config.ProcessInput(config)
+    psfex2 = galsim.des.DES_PSFEx(psfex_file, dir=data_dir, wcs=config['wcs'])
     psf5a = galsim.config.BuildGSObject(config, 'psf5')[0]
-    psf5b = psfex0.getPSF(galsim.PositionD(789,567)).withFlux(388)
+    psf5b = psfex2.getPSF(galsim.PositionD(789,567),gsparams=gsparams).withFlux(388)
     gsobject_compare(psf5a, psf5b)
 
 

--- a/tests/test_sed.py
+++ b/tests/test_sed.py
@@ -44,6 +44,14 @@ def test_SED_basic():
     nm_w = np.arange(10,1002,10)
     A_w = np.arange(100,10002,100)
 
+    try:
+        # Eval-str must return a Real
+        np.testing.assert_raises(ValueError, galsim.SED,
+                                 spec="'eggs'", wave_type='A', flux_type='flambda')
+    except ImportError:
+        print('The assert_raises tests require nose')
+
+
     # All of these should be equivalent.  Flat spectrum with F_lambda = 200 erg/nm
     s_list = [
         galsim.SED(spec=lambda x: 200., flux_type='flambda', wave_type='nm'),
@@ -561,7 +569,7 @@ def test_SED_sampleWavelength():
 
     sed  = galsim.SED(galsim.LookupTable([1,2,3,4,5], [0.,1.,0.5,1.,0.]),
                       wave_type='nm', flux_type='fphotons')
-    bandpass = galsim.Bandpass(galsim.LookupTable([1,2,3,4,5], [0,0,1,1,0], interpolant='linear'), 
+    bandpass = galsim.Bandpass(galsim.LookupTable([1,2,3,4,5], [0,0,1,1,0], interpolant='linear'),
                                'nm')
     sedbp = sed*bandpass
 
@@ -611,9 +619,9 @@ def test_SED_sampleWavelength():
 
     def create_counts(sed,out,nbins=100):
         bins,step = np.linspace(sed.blue_limit,sed.red_limit,nbins+1,retstep=True)
-        centers = bins[:-1] + step/2.        
+        centers = bins[:-1] + step/2.
         cts1,_ = np.histogram(out,nbins)
-        
+
         #cts2 = np.array([galsim.integ.int1d(sed,low,low+step,1e-3,1e-6) for low in bins[:-1]])
         cts2 = np.array([galsim.integ.trapz(sed,low,low+step) for low in bins[:-1]])
         cts2 *= (float(len(out))/cts2.sum())
@@ -621,7 +629,7 @@ def test_SED_sampleWavelength():
 
     # Test the output distribution
     out = sed.sampleWavelength(1e5,None,rng=seed)
-        
+
     _,(cts1,cts2) = create_counts(sed,out)
     chisq = np.sum( (cts1 - cts2)**2 / cts1 )/len(cts1)
     np.testing.assert_almost_equal(chisq,1.0,1,"Sampled counts do not match input SED.")
@@ -644,7 +652,7 @@ def test_SED_sampleWavelength():
     _,(cdf1,cdf2) = create_cdfs(sedz,outz)
     np.testing.assert_almost_equal(cdf1, cdf2, 2,
                                    "Sampled CDF does not match input redshifted SED.")
-    
+
 
 @timer
 def test_fnu_vs_flambda():


### PR DESCRIPTION
I went through and replaced a subset of the `isinstance(variable, str)` predicates with `isinstance(variable, basestring)`.  (It didn't seem necessary to replace all of them, like the ones where we check if `scale_unit` is a string, for example.)  

I also improved the eval string sanity check in `SED` and `Bandpass` to check that the inferred lambdas yield a float.

Finally, I made a number of small cleanups suggested by pylint on the files I looked through for cases of `isinstance(var, str)`.