### PR TITLE
#787

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,9 @@ New Features
       I(R,z) = I_0 / (2h_s) * sech^2 (z/h_s) * exp(-R/R_s),
   inclined to the line of sight at a desired angle. If face-on (inclination =
   0 degrees), this will be identical to the Exponential profile.  (#782)
+- Allow selection of random galaxies from a RealGalaxyCatalog or COSMOSCatalog
+  in a way that accounts for any selection effects in catalog creation, using
+  the 'weight' entries in the catalog. (#787)
 - Added possibility of using `dtype=complex` for Images, the shorthand alias
   for which is called ImageC. (#799)
 - Added `maxSB()` method to GSObjects to return an estimate of the maximum

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Bug Fixes
 Deprecated Features
 -------------------
 
+- Deprecated `simReal` method, a little-used way of simulating images
+  based on realistic galaxies. (#787)
 - Deprecated `Chromatic` class.  This functionality has been subsumed by
   `ChromaticTransformation`.  (#789)
 - Deprecated `.copy()` methods for immutable classes, including `GSObject`,

--- a/examples/demo11.py
+++ b/examples/demo11.py
@@ -38,7 +38,7 @@ New features introduced in this demo:
 - psf = galsim.InterpolatedImage(psf_filename, scale, flux)
 - tab = galsim.LookupTable(file)
 - cosmos_cat = galsim.COSMOSCatalog(file_name, dir)
-- gal = cosmos_cat.makeGalaxy(index, gal_type, noise_pad_size, rng)
+- gal = cosmos_cat.makeGalaxy(gal_type, noise_pad_size, rng)
 - ps = galsim.PowerSpectrum(..., units)
 - gal = gal.lens(g1, g2, mu)
 - image.whitenNoise(correlated_noise)
@@ -116,7 +116,7 @@ def main(argv):
     logger.info('Starting demo script 11')
 
     # Read in galaxy catalog
-    # The COSMOSCatalog uses the same input file as we have been usign for RealGalaxyCatalogs
+    # The COSMOSCatalog uses the same input file as we have been using for RealGalaxyCatalogs
     # along with a second file called real_galaxy_catalog_23.5_examples_fits.fits, which stores
     # the information about the parameteric fits.  There is no need to specify the second file
     # name, since the name is derivable from the name of the main catalog.
@@ -248,7 +248,14 @@ def main(argv):
         # a RealGalaxy using the original HST image and PSF, or a parametric model based on
         # parametric fits to the light distribution of the HST observation.  The parametric
         # models are either a Sersic fit to the data or a bulge + disk fit according to which
-        # one gave the better chisq value.
+        # one gave the better chisq value.  We will select a galaxy at random from the catalog.
+        # One could easily do this by choosing an index = int(ud() * cosmos_cat.nobjects), but
+        # we will instead allow the catalog to choose a random galaxy for us.  It will remove any
+        # selection effects involved in postage stamp creation using weights that are stored in
+        # the catalog.  (If for some reason you prefer not to do that, you can always choose a
+        # purely random index yourself using int(ud() * cosmos_cat.nobjects).)  We employ this
+        # random selection by simply failing to specify an index or identifier for a galaxy, in
+        # which case it chooses a random one.
 
         # First determine whether we will make a real galaxy (`gal_type = 'real'`) or a parametric
         # galaxy (`gal_type = 'parametric'`).  The real galaxies take longer to render, so for this
@@ -260,9 +267,6 @@ def main(argv):
         # i.e. How many heads you get after N flips if each flip has a chance, p, of being heads.
         binom = galsim.BinomialDeviate(ud, N=1, p=0.3)
         real = binom()
-
-        # Next determine which index in the catalog we will use for this object.
-        index = int(ud() * cosmos_cat.nobjects)
 
         if real:
             # For real galaxies, we will want to whiten the noise in the image (below).
@@ -282,9 +286,9 @@ def main(argv):
             # to at least 40 x sqrt(2), we should be safe even if the galaxy image is rotated
             # with respect to the psf image.
             #     noise_pad_size = 40 * sqrt(2) * 0.2 arcsec/pixel = 11.3 arcsec
-            gal = cosmos_cat.makeGalaxy(index=index, gal_type='real', rng=ud, noise_pad_size=11.3)
+            gal = cosmos_cat.makeGalaxy(gal_type='real', rng=ud, noise_pad_size=11.3)
         else:
-            gal = cosmos_cat.makeGalaxy(index=index, gal_type='parametric')
+            gal = cosmos_cat.makeGalaxy(gal_type='parametric', rng=ud)
 
         # Apply a random rotation
         theta = ud()*2.0*numpy.pi*galsim.radians

--- a/examples/demo11.yaml
+++ b/examples/demo11.yaml
@@ -150,7 +150,12 @@ gal :
     #     noise_pad_size = 40 * sqrt(2) * 0.2 arcsec/pixel = 11.3 arcsec
     noise_pad_size : 11.3
 
-    index : { type : Random }
+    # We will select a galaxy at random from the catalog. One could easily do this by setting 
+    # index : { type : Random }
+    # but we will instead allow the catalog to choose a random galaxy for us.  It will remove any
+    # selection effects involved in postage stamp creation using weights that are stored in the
+    # catalog.  We employ this random selection by simply failing to specify an index or identifier
+    # for a galaxy, in which case it chooses a random one.
 
     shear :
         # We again use PowerSpectrumShear, which is set up below using input : power_spectrum.

--- a/galsim/config/input_cosmos.py
+++ b/galsim/config/input_cosmos.py
@@ -98,7 +98,8 @@ def _BuildCOSMOSGalaxy(config, base, ignore, gsparams, logger):
             kwargs['rng'] = galsim.config.check_for_rng(base, logger, 'COSMOSGalaxy')
 
     # NB. Even though index is officially optional, it will always be present, either because it was
-    #     set by a call to selectRandomIndices or because it was specified explicitly.
+    #     set by a call to selectRandomIndices, explicitly by the user, or due to the call to
+    #     SetDefaultIndex.
     index = kwargs['index']
     if index >= cosmos_cat.getNObjects():
         raise IndexError(

--- a/galsim/config/input_cosmos.py
+++ b/galsim/config/input_cosmos.py
@@ -78,11 +78,10 @@ def _BuildCOSMOSGalaxy(config, base, ignore, gsparams, logger):
         ignore = ignore)
     if gsparams: kwargs['gsparams'] = galsim.GSParams(**gsparams)
 
+    rng = None
     if 'index' not in kwargs:
-        make_kwargs = {'_n_rng_calls': True}
         rng = galsim.config.check_for_rng(base, logger, 'COSMOSGalaxy')
-        make_kwargs['rng'] = rng
-        kwargs['index'], n_rng_calls = cosmos_cat.selectRandomIndices(1, **make_kwargs)
+        kwargs['index'], n_rng_calls = cosmos_cat.selectRandomIndices(1, rng=rng, _n_rng_calls=True)
 
         # Make sure this process gives consistent results regardless of the number of processes
         # being used.
@@ -92,10 +91,9 @@ def _BuildCOSMOSGalaxy(config, base, ignore, gsparams, logger):
             rng.discard(int(n_rng_calls))
 
     if 'gal_type' in kwargs and kwargs['gal_type'] == 'real':
-        if 'make_kwargs' in locals():
-            kwargs['rng'] = make_kwargs.get('rng',None)
-        else:
-            kwargs['rng'] = galsim.config.check_for_rng(base, logger, 'COSMOSGalaxy')
+        if rng is None:
+            rng = galsim.config.check_for_rng(base, logger, 'COSMOSGalaxy')
+        kwargs['rng'] = rng
 
     # NB. Even though index is officially optional, it will always be present, either because it was
     #     set by a call to selectRandomIndices, explicitly by the user, or due to the call to

--- a/galsim/config/input_cosmos.py
+++ b/galsim/config/input_cosmos.py
@@ -89,7 +89,7 @@ def _BuildCOSMOSGalaxy(config, base, ignore, gsparams, logger):
         if not isinstance(cosmos_cat, galsim.COSMOSCatalog) and rng is not None:
             # Then cosmos_cat is really a proxy, which means the rng was pickled, so we need to
             # discard the same number of random calls from the one in the config dict.
-            rng.discard(n_rng_calls)
+            rng.discard(int(n_rng_calls))
 
     if 'gal_type' in kwargs and kwargs['gal_type'] == 'real':
         if 'make_kwargs' in locals():

--- a/galsim/config/input_cosmos.py
+++ b/galsim/config/input_cosmos.py
@@ -78,6 +78,14 @@ def _BuildCOSMOSGalaxy(config, base, ignore, gsparams, logger):
         ignore = ignore)
     if gsparams: kwargs['gsparams'] = galsim.GSParams(**gsparams)
 
+    # Deal with defaults for gal_type, if it wasn't specified:
+    # If COSMOSCatalog was constructed with 'use_real'=True, then default is 'real'.  Otherwise, the
+    # default is 'parametric'.  This code is in makeGalaxy, but since config has to use
+    # _makeSingleGalaxy, we have to include this here too.
+    if 'gal_type' not in kwargs:
+        if cosmos_cat.use_real: kwargs['gal_type'] = 'real'
+        else: kwargs['gal_type'] = 'parametric'
+
     rng = None
     if 'index' not in kwargs:
         rng = galsim.config.check_for_rng(base, logger, 'COSMOSGalaxy')
@@ -90,7 +98,9 @@ def _BuildCOSMOSGalaxy(config, base, ignore, gsparams, logger):
             # discard the same number of random calls from the one in the config dict.
             rng.discard(int(n_rng_calls))
 
-    if 'gal_type' in kwargs and kwargs['gal_type'] == 'real':
+    # Even though gal_type is optional, it will have been set in the code above.  So we can at this
+    # point assume that kwargs['gal_type'] exists.
+    if kwargs['gal_type'] == 'real':
         if rng is None:
             rng = galsim.config.check_for_rng(base, logger, 'COSMOSGalaxy')
         kwargs['rng'] = rng

--- a/galsim/config/input_cosmos.py
+++ b/galsim/config/input_cosmos.py
@@ -66,6 +66,11 @@ def _BuildCOSMOSGalaxy(config, base, ignore, gsparams, logger):
 
     ignore = ignore + ['num']
 
+    # Special: if galaxies are selected based on index, and index is Sequence or Random, and max
+    # isn't set, set it to nobjects-1.
+    if 'index' in config:
+        galsim.config.SetDefaultIndex(config, cosmos_cat.getNObjects())
+
     kwargs, safe = galsim.config.GetAllParams(config, base,
         req = galsim.COSMOSCatalog.makeGalaxy._req_params,
         opt = galsim.COSMOSCatalog.makeGalaxy._opt_params,

--- a/galsim/config/input_cosmos.py
+++ b/galsim/config/input_cosmos.py
@@ -81,7 +81,7 @@ def _BuildCOSMOSGalaxy(config, base, ignore, gsparams, logger):
     rng = None
     if 'index' not in kwargs:
         rng = galsim.config.check_for_rng(base, logger, 'COSMOSGalaxy')
-        kwargs['index'], n_rng_calls = cosmos_cat.selectRandomIndices(1, rng=rng, _n_rng_calls=True)
+        kwargs['index'], n_rng_calls = cosmos_cat.selectRandomIndex(1, rng=rng, _n_rng_calls=True)
 
         # Make sure this process gives consistent results regardless of the number of processes
         # being used.
@@ -96,7 +96,7 @@ def _BuildCOSMOSGalaxy(config, base, ignore, gsparams, logger):
         kwargs['rng'] = rng
 
     # NB. Even though index is officially optional, it will always be present, either because it was
-    #     set by a call to selectRandomIndices, explicitly by the user, or due to the call to
+    #     set by a call to selectRandomIndex, explicitly by the user, or due to the call to
     #     SetDefaultIndex.
     index = kwargs['index']
     if index >= cosmos_cat.getNObjects():

--- a/galsim/config/input_real.py
+++ b/galsim/config/input_real.py
@@ -39,6 +39,9 @@ def _BuildRealGalaxy(config, base, ignore, gsparams, logger, param_name='RealGal
         else:
             if not config['random']:
                 galsim.config.SetDefaultIndex(config, real_cat.getNObjects())
+                # Need to do this to avoid being caught by the GetAllParams() call, which will flag
+                # it if it has 'index' and 'random' set (but 'random' is False, so really it's OK).
+                del config['random']
 
     kwargs, safe = galsim.config.GetAllParams(config, base,
         req = galsim.__dict__['RealGalaxy']._req_params,

--- a/galsim/config/input_real.py
+++ b/galsim/config/input_real.py
@@ -32,9 +32,13 @@ def _BuildRealGalaxy(config, base, ignore, gsparams, logger, param_name='RealGal
     real_cat = galsim.config.GetInputObj('real_catalog', config, base, param_name)
 
     # Special: if index is Sequence or Random, and max isn't set, set it to nobjects-1.
-    # But not if they specify 'id' which overrides that.
+    # But not if they specify 'id' or have 'random=True', which overrides that.
     if 'id' not in config:
-        galsim.config.SetDefaultIndex(config, real_cat.getNObjects())
+        if 'random' not in config:
+            galsim.config.SetDefaultIndex(config, real_cat.getNObjects())
+        else:
+            if not config['random']:
+                galsim.config.SetDefaultIndex(config, real_cat.getNObjects())
 
     kwargs, safe = galsim.config.GetAllParams(config, base,
         req = galsim.__dict__['RealGalaxy']._req_params,

--- a/galsim/real.py
+++ b/galsim/real.py
@@ -140,9 +140,9 @@ class RealGalaxy(GSObject):
                     "flux" : float ,
                     "flux_rescale" : float ,
                     "pad_factor" : float,
-                    "noise_pad_size" : float,
+                    "noise_pad_size" : float
                   }
-    _single_params = [ { "index" : int , "id" : str } ]
+    _single_params = [ { "index" : int , "id" : str , "random" : bool } ]
     _takes_rng = True
 
     def __init__(self, real_galaxy_catalog, index=None, id=None, random=False,

--- a/galsim/real.py
+++ b/galsim/real.py
@@ -177,7 +177,7 @@ class RealGalaxy(GSObject):
                 if random is True:
                     raise AttributeError('Too many methods for selecting a galaxy!')
                 use_index = real_galaxy_catalog.getIndexForID(id)
-            elif random is True:
+            elif random:
                 ud = galsim.UniformDeviate(self.rng)
                 use_index = int(real_galaxy_catalog.nobjects * ud())
                 if hasattr(real_galaxy_catalog, 'weight'):

--- a/galsim/real.py
+++ b/galsim/real.py
@@ -473,6 +473,7 @@ class RealGalaxyCatalog(object):
         # relative selection effects within the catalog, not absolute subsampling.  If the maximum
         # is above 1, then our random number generation test used to draw a weighted sample will
         # fail since we use uniform deviates in the range 0 to 1.
+        weight = self.cat.field('weight')
         self.weight = weight/np.max(weight)
         if 'stamp_flux' in self.cat.names:
             self.stamp_flux = self.cat.field('stamp_flux')

--- a/galsim/real.py
+++ b/galsim/real.py
@@ -473,7 +473,10 @@ class RealGalaxyCatalog(object):
         weight = self.cat.field('weight')
         if np.min(weight) >= 0. and np.max(weight) <= 1. and \
                 not np.any(np.isnan(weight)) and not np.any(np.isinf(weight)):
-            self.weight = weight # weight factor to account for size-dependent probability
+            # Note the renormalization by the maximum.  If the maximum is below 1, that just means
+            # that all galaxies were subsampled at some level, and here we only want to account for
+            # relative selection effects within the catalog, not absolute subsampling.
+            self.weight = weight/np.max(weight)
         if 'stamp_flux' in self.cat.names:
             self.stamp_flux = self.cat.field('stamp_flux')
 
@@ -692,8 +695,6 @@ class RealGalaxyCatalog(object):
         self.loaded_lock = Lock()
         self.noise_lock = Lock()
         pass
-
-
 
 def simReal(real_galaxy, target_PSF, target_pixel_scale, g1=0.0, g2=0.0, rotation_angle=None,
             rand_rotate=True, rng=None, target_flux=1000.0, image=None):

--- a/galsim/real.py
+++ b/galsim/real.py
@@ -29,9 +29,6 @@ This module defines the RealGalaxyCatalog class, used to store all required info
 real galaxy simulation training sample and accompanying PSF model.  For information about
 downloading GalSim-readable RealGalaxyCatalog data in FITS format, see the RealGalaxy Data Download
 page on the GalSim Wiki: https://github.com/GalSim-developers/GalSim/wiki/RealGalaxy%20Data
-
-The function simReal() takes this information and uses it to simulate a (no-noise-added) image from
-some lower-resolution telescope.
 """
 
 
@@ -696,7 +693,7 @@ class RealGalaxyCatalog(object):
 
 def simReal(real_galaxy, target_PSF, target_pixel_scale, g1=0.0, g2=0.0, rotation_angle=None,
             rand_rotate=True, rng=None, target_flux=1000.0, image=None):
-    """Function to simulate images (no added noise) from real galaxy training data.
+    """Deprecated method to simulate images (no added noise) from real galaxy training data.
 
     This function takes a RealGalaxy from some training set, and manipulates it as needed to
     simulate a (no-noise-added) image from some lower-resolution telescope.  It thus requires a
@@ -731,6 +728,11 @@ def simReal(real_galaxy, target_PSF, target_pixel_scale, g1=0.0, g2=0.0, rotatio
 
     @return a simulated galaxy image.
     """
+    # pragma: no cover
+    from .deprecated import depr
+    depr('simReal', 1.5, '',
+         'This method has been deprecated due to lack of widespread use.  If you '+
+         'have a need for it, please open an issue requesting that it be reinstated.')
     # do some checking of arguments
     if not isinstance(real_galaxy, galsim.RealGalaxy):
         raise RuntimeError("Error: simReal requires a RealGalaxy!")

--- a/galsim/real.py
+++ b/galsim/real.py
@@ -466,17 +466,14 @@ class RealGalaxyCatalog(object):
         self.variance = self.cat.field('noise_variance') # noise variance for image
         self.mag = self.cat.field('mag')   # apparent magnitude
         self.band = self.cat.field('band') # bandpass in which apparent mag is measured, e.g., F814W
-        # Add the weight factor to the catalog only if it behaves properly.  In particular, it
-        # should be a float between 0 and 1 (so that random selections of indices can use it to
-        # remove any selection effects in the catalog creation process).  If the weight does not
-        # behave like this, then the catalog simply won't have a weight column.
-        weight = self.cat.field('weight')
-        if np.min(weight) >= 0. and np.max(weight) <= 1. and \
-                not np.any(np.isnan(weight)) and not np.any(np.isinf(weight)):
-            # Note the renormalization by the maximum.  If the maximum is below 1, that just means
-            # that all galaxies were subsampled at some level, and here we only want to account for
-            # relative selection effects within the catalog, not absolute subsampling.
-            self.weight = weight/np.max(weight)
+        # The weight factor should be a float value >=0 (so that random selections of indices can
+        # use it to remove any selection effects in the catalog creation process).
+        # Here we renormalize by the maximum weight.  If the maximum is below 1, that just means
+        # that all galaxies were subsampled at some level, and here we only want to account for
+        # relative selection effects within the catalog, not absolute subsampling.  If the maximum
+        # is above 1, then our random number generation test used to draw a weighted sample will
+        # fail since we use uniform deviates in the range 0 to 1.
+        self.weight = weight/np.max(weight)
         if 'stamp_flux' in self.cat.names:
             self.stamp_flux = self.cat.field('stamp_flux')
 

--- a/galsim/real.py
+++ b/galsim/real.py
@@ -692,7 +692,7 @@ class RealGalaxyCatalog(object):
         pass
 
 def simReal(real_galaxy, target_PSF, target_pixel_scale, g1=0.0, g2=0.0, rotation_angle=None,
-            rand_rotate=True, rng=None, target_flux=1000.0, image=None):
+            rand_rotate=True, rng=None, target_flux=1000.0, image=None): # pragma: no cover
     """Deprecated method to simulate images (no added noise) from real galaxy training data.
 
     This function takes a RealGalaxy from some training set, and manipulates it as needed to
@@ -728,7 +728,6 @@ def simReal(real_galaxy, target_PSF, target_pixel_scale, g1=0.0, g2=0.0, rotatio
 
     @return a simulated galaxy image.
     """
-    # pragma: no cover
     from .deprecated import depr
     depr('simReal', 1.5, '',
          'This method has been deprecated due to lack of widespread use.  If you '+

--- a/galsim/real.py
+++ b/galsim/real.py
@@ -189,7 +189,7 @@ class RealGalaxy(GSObject):
                     # If weight factors are available, make sure the random selection uses the
                     # weights to remove the catalog-level selection effects (flux_radius-dependent
                     # probability of making a postage stamp for a given object).
-                    while ud() > self.real_cat.weight[use_index]:
+                    while ud() > real_galaxy_catalog.weight[use_index]:
                         # Pick another one to try.
                         use_index = int(real_galaxy_catalog.nobjects * ud())
             else:

--- a/galsim/scene.py
+++ b/galsim/scene.py
@@ -610,7 +610,7 @@ class COSMOSCatalog(object):
         # By default, get the number of RNG calls.  We then decide whether or not to return them
         # based on _n_rng_calls.
         index, n_rng_calls = galsim.utilities.rand_with_replacement(
-                n_random, rng, self.nobjects, use_weights, _n_rng_calls=True)
+                n_random, self.nobjects, rng, use_weights, _n_rng_calls=True)
 
         if n_random>1:
             if _n_rng_calls:

--- a/galsim/scene.py
+++ b/galsim/scene.py
@@ -615,7 +615,10 @@ class COSMOSCatalog(object):
             # to remove the catalog-level selection effects (flux_radius-dependent probability
             # of making a postage stamp for a given object).
             test_vals = np.zeros(n_random)
+            # The test values should not necessarily go up to 1, but rather to the maximum weight in
+            # the catalog.  This is necessary to ensure convergence.
             ud.generate(test_vals)
+            test_vals *= np.max(self.real_cat.weight)
             # The ones with mask==True are the ones we should replace.
             mask = test_vals > self.real_cat.weight[self.orig_index[index]]
             while np.any(mask):
@@ -632,7 +635,10 @@ class COSMOSCatalog(object):
                           'selection effects (requires existence of real catalog with '
                           'weights in addition to parametric one).')
 
-        return index
+        if n_random>1:
+            return index
+        else:
+            return index[0]
 
     def _makeReal(self, indices, noise_pad_size, rng, gsparams):
         return [ galsim.RealGalaxy(self.real_cat, index=self.orig_index[i],
@@ -947,6 +953,7 @@ class COSMOSCatalog(object):
                                "noise_pad_size" : float,
                                "deep" : bool,
                                "sersic_prec": float,
+                               "n_random": int
                              }
     makeGalaxy._single_params = []
     makeGalaxy._takes_rng = True

--- a/galsim/scene.py
+++ b/galsim/scene.py
@@ -515,7 +515,7 @@ class COSMOSCatalog(object):
         # Select random indices if necessary (no index given).
         if index is None:
             if n_random is None: n_random = 1
-            index = self.selectRandomIndices(n_random, rng=rng)
+            index = self.selectRandomIndex(n_random, rng=rng)
         else:
             if n_random is not None:
                 import warnings
@@ -581,23 +581,24 @@ class COSMOSCatalog(object):
         else:
             return gal_list[0]
 
-    def selectRandomIndices(self, n_random, rng=None, _n_rng_calls=False):
+    def selectRandomIndex(self, n_random=1, rng=None, _n_rng_calls=False):
         """
         Routine to select random indices out of the catalog.  This routine does a weighted random
         selection with replacement (i.e., there is no guarantee of uniqueness of the selected
         indices).  Weighting uses the weight factors available in the catalog, if any; these weights
         are typically meant to remove any selection effects in the catalog creation process.
 
-        @param n_random     Number of random indices to return.
+        @param n_random     Number of random indices to return. [default: 1]
         @param rng          A random number generator to use for selecting a random galaxy
                             (may be any kind of BaseDeviate or None). [default: None]
-        @returns A NumPy array containing the randomly-selected indices.
+        @returns A single index if n_random==1 or a NumPy array containing the randomly-selected
+        indices if n_random>1.
         """
         # Set up the random number generator.
         if rng is None:
             rng = galsim.BaseDeviate()
         elif not isinstance(rng, galsim.BaseDeviate):
-            raise TypeError("The rng provided to selectRandomIndices() is not a BaseDeviate")
+            raise TypeError("The rng provided to selectRandomIndex() is not a BaseDeviate")
         ud = galsim.UniformDeviate(rng)
 
         # Sanity check the requested number of random indices.
@@ -647,8 +648,8 @@ class COSMOSCatalog(object):
         else:
             import warnings
             warnings.warn('Selecting random object without correcting for catalog-level '
-                          'selection effects (requires existence of real catalog with '
-                          'weights in addition to parametric one).')
+                          'selection effects.  This correction requires the existence of '
+                          'real catalog with valid weights in addition to parametric one.')
 
         if n_random>1:
             if _n_rng_calls:

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -1209,7 +1209,7 @@ def binomial(a, b, n):
             yield c
     return np.fromiter(generate(), float, n+1)
 
-def rand_with_replacement(n, rng, n_choices, weight=None, _n_rng_calls=False):
+def rand_with_replacement(n, n_choices, rng, weight=None, _n_rng_calls=False):
     """Select some number of random choices from a list, with replacement, using a supplied RNG.
 
     `n` random choices with replacement are made assuming that those choices should range from 0 to
@@ -1218,8 +1218,8 @@ def rand_with_replacement(n, rng, n_choices, weight=None, _n_rng_calls=False):
     weighted choices from the list.
 
     @param n           Number of random selections to make.
-    @param rng         RNG to use.  Should be a galsim.BaseDeviate.
     @param n_choices   Number of entries from which to choose.
+    @param rng         RNG to use.  Should be a galsim.BaseDeviate.
     @param weight      Optional list of weight factors to use for weighting the selection of
                        random indices.
     @returns a NumPy array of length `n` containing the integer-valued indices that were selected.

--- a/tests/test_config_gsobject.py
+++ b/tests/test_config_gsobject.py
@@ -566,7 +566,6 @@ def test_pixel():
         gal4b = gal4b.shear(g1 = 0.03, g2 = -0.05).shift(dx = 0.7, dy = -1.2)
         gsobject_compare(gal4a, gal4b, conv=galsim.Gaussian(0.1))
 
-
 @timer
 def test_realgalaxy():
     """Test various ways to build a RealGalaxy
@@ -664,6 +663,79 @@ def test_realgalaxy():
     gal7a = galsim.config.BuildGSObject(config, 'gal7')[0]
     gal7b = galsim.RealGalaxy(real_cat, random=True, rng=galsim.BaseDeviate(1234))
     gsobject_compare(gal7a, gal7b, conv=conv)
+
+@timer
+def test_cosmosgalaxy():
+    """Test various ways to build a COSMOSGalaxy
+    """
+    # I don't want to gratuitously copy the real_catalog catalog, so use the
+    # version in the examples directory.
+    real_gal_dir = os.path.join('..','examples','data')
+    real_gal_cat = 'real_galaxy_catalog_23.5_example.fits'
+    config = {
+
+        'input' : { 'cosmos_catalog' : 
+                    { 'dir' : real_gal_dir ,
+                      'file_name' : real_gal_cat,
+                      'preload' : True}
+                    },
+
+        # First one uses defaults for gal_type (real, since we used the actual catalog and not the
+        # parametric one) and selects a random galaxy using internal routines
+        # (the default if index is unspecified).
+        'gal1' : { 'type' : 'COSMOSGalaxy', 'scale_flux' : 3.14 },
+
+        # Second uses parametric gal_type and selects a random galaxy using the config sequence
+        # option.  Includes flux modifications and rotation.
+        'gal2' : { 'type' : 'COSMOSGalaxy', 'gal_type' : 'parametric',
+                   'index' : { 'type' : 'Sequence', 'nitems' : 1},
+                   'scale_flux' : 0.3,
+                   'rotate' : 30 * galsim.degrees },
+
+        # Third uses parametric gal_type and a specific galaxy index.  Includes flux modifications,
+        # shear and magnification.
+        'gal3' : {'type' : 'COSMOSGalaxy', 'gal_type' : 'parametric',
+                  'index' : 27, 'scale_flux' : 1.e6,
+                  'magnify' : 0.9, 'shear' : galsim.Shear(g1=0.01, g2=-0.07)},
+
+        # Fourth tries to select outside the catalog; make sure the exception is caught.
+        'gal4' : {'type' : 'COSMOSGalaxy', 'gal_type' : 'parametric',
+                  'index' : 1001}
+    }
+    rng = galsim.UniformDeviate(1234)
+    config['rng'] = galsim.UniformDeviate(1234) # A second copy starting with the same seed.
+
+    galsim.config.ProcessInput(config)
+
+    cosmos_cat = galsim.COSMOSCatalog(
+        dir=real_gal_dir, file_name=real_gal_cat, preload=True)
+
+    # For these profiles, we convolve by a gaussian to smooth out the profile.
+    # This makes the comparison much faster without changing the validity of the test.
+    conv = galsim.Gaussian(sigma = 1)
+
+    config['obj_num'] = 0
+    gal1a = galsim.config.BuildGSObject(config, 'gal1')[0]
+    gal1b = 3.14*cosmos_cat.makeGalaxy(rng=rng)
+    gsobject_compare(gal1a, gal1b, conv=conv)
+
+    config['obj_num'] = 1
+    gal2a = galsim.config.BuildGSObject(config, 'gal2')[0]
+    gal2b = cosmos_cat.makeGalaxy(index=0, gal_type='parametric', rng=rng)
+    gal2b = gal2b.withScaledFlux(0.3).rotate(30*galsim.degrees)
+    gsobject_compare(gal2a, gal2b, conv=conv)
+
+    config['obj_num'] = 2
+    gal3a = galsim.config.BuildGSObject(config, 'gal3')[0]
+    gal3b = cosmos_cat.makeGalaxy(index=27, gal_type='parametric', rng=rng)
+    gal3b = gal3b.withScaledFlux(1.e6).magnify(0.9).shear(g1=0.01, g2=-0.07)
+    gsobject_compare(gal3a, gal3b, conv=conv)
+
+    config['obj_num'] = 3
+    try:
+        np.testing.assert_raises(IndexError, galsim.config.BuildGSObject, config, 'gal4')
+    except ImportError:
+        print('The assert_raises tests require nose')
 
 @timer
 def test_interpolated_image():
@@ -1208,6 +1280,7 @@ if __name__ == "__main__":
     test_devaucouleurs()
     test_pixel()
     test_realgalaxy()
+    test_cosmosgalaxy()
     test_interpolated_image()
     test_add()
     test_convolve()

--- a/tests/test_config_gsobject.py
+++ b/tests/test_config_gsobject.py
@@ -594,7 +594,10 @@ def test_realgalaxy():
                  },
         'gal5' : { 'type' : 'RealGalaxy' , 'index' : 23, 'noise_pad_size' : 10 },
         'gal6' : { 'type' : 'RealGalaxyOriginal' },
-        'gal7' : { 'type' : 'RealGalaxy' , 'random' : True}
+        'gal7' : { 'type' : 'RealGalaxy' , 'random' : True},
+        # I admit the one below is odd (why would you specify "random" and have it be False?) but
+        # one could imagine setting it based on some probabilistic process...
+        'gal8' : { 'type' : 'RealGalaxy' , 'random' : False}
     }
     rng = galsim.UniformDeviate(1234)
     config['rng'] = galsim.UniformDeviate(1234) # A second copy starting with the same seed.
@@ -663,6 +666,11 @@ def test_realgalaxy():
     gal7a = galsim.config.BuildGSObject(config, 'gal7')[0]
     gal7b = galsim.RealGalaxy(real_cat, random=True, rng=galsim.BaseDeviate(1234))
     gsobject_compare(gal7a, gal7b, conv=conv)
+
+    config['obj_num'] = 7
+    gal8a = galsim.config.BuildGSObject(config, 'gal8')[0]
+    gal8b = galsim.RealGalaxy(real_cat, index=0)
+    gsobject_compare(gal8a, gal8b, conv=conv)
 
 @timer
 def test_cosmosgalaxy():

--- a/tests/test_config_gsobject.py
+++ b/tests/test_config_gsobject.py
@@ -595,6 +595,7 @@ def test_realgalaxy():
                  },
         'gal5' : { 'type' : 'RealGalaxy' , 'index' : 23, 'noise_pad_size' : 10 },
         'gal6' : { 'type' : 'RealGalaxyOriginal' },
+        'gal7' : { 'type' : 'RealGalaxy' , 'random' : True}
     }
     rng = galsim.UniformDeviate(1234)
     config['rng'] = galsim.UniformDeviate(1234) # A second copy starting with the same seed.
@@ -652,11 +653,17 @@ def test_realgalaxy():
     assert "No base['rng'] available" in cl.output
 
     config['obj_num'] = 5
-    gal1a = galsim.config.BuildGSObject(config, 'gal6')[0]
-    gal1b = galsim.RealGalaxy(real_cat, index=0).original_gal
+    gal6a = galsim.config.BuildGSObject(config, 'gal6')[0]
+    gal6b = galsim.RealGalaxy(real_cat, index=0).original_gal
     # The convolution here
     gsobject_compare(gal1a, gal1b, conv=conv)
 
+    config['obj_num'] = 6
+    # Since we are comparing the random functionality, we need to reset the RNG.
+    config['rng'] = galsim.UniformDeviate(1234)
+    gal7a = galsim.config.BuildGSObject(config, 'gal7')[0]
+    gal7b = galsim.RealGalaxy(real_cat, random=True, rng=galsim.BaseDeviate(1234))
+    gsobject_compare(gal7a, gal7b, conv=conv)
 
 @timer
 def test_interpolated_image():

--- a/tests/test_config_gsobject.py
+++ b/tests/test_config_gsobject.py
@@ -656,7 +656,7 @@ def test_realgalaxy():
     gal6a = galsim.config.BuildGSObject(config, 'gal6')[0]
     gal6b = galsim.RealGalaxy(real_cat, index=0).original_gal
     # The convolution here
-    gsobject_compare(gal1a, gal1b, conv=conv)
+    gsobject_compare(gal6a, gal6b, conv=conv)
 
     config['obj_num'] = 6
     # Since we are comparing the random functionality, we need to reset the RNG.

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -44,6 +44,21 @@ if __name__ == "__main__":
     test_sersic_n = [1.5, -4]
     test_scale = [1.8, 0.002]
 
+# some helper functions
+def ellip_to_moments(e1, e2, sigma):
+    a_val = (1.0 + e1) / (1.0 - e1)
+    b_val = np.sqrt(a_val - (0.5*(1.0+a_val)*e2)**2)
+    mxx = a_val * (sigma**2) / b_val
+    myy = (sigma**2) / b_val
+    mxy = 0.5 * e2 * (mxx + myy)
+    return mxx, myy, mxy
+
+def moments_to_ellip(mxx, myy, mxy):
+    e1 = (mxx - myy) / (mxx + myy)
+    e2 = 2*mxy / (mxx + myy)
+    sig = (mxx*myy - mxy**2)**(0.25)
+    return e1, e2, sig
+
 
 def check_dep(f, *args, **kwargs):
     """Check that some function raises a GalSimDeprecationWarning as a warning, but not an error.
@@ -1545,6 +1560,122 @@ def test_dep_kroundtrip():
     np.testing.assert_array_almost_equal(a_conv_c_img.array, b_conv_c_img.array, 5,
                                          "Convolution of InterpolatedKImage drawn incorrectly.")
 
+@timer
+def test_dep_simreal():
+    """Test accuracy of various calculations with fake Gaussian RealGalaxy vs. ideal expectations
+    and stored results"""
+    image_dir = './real_comparison_images'
+    catalog_file = 'test_catalog.fits'
+
+    ind_fake = 1 # index of mock galaxy (Gaussian) in catalog
+    fake_gal_fwhm = 0.7 # arcsec
+    fake_gal_shear1 = 0.29 # shear representing intrinsic shape component 1
+    fake_gal_shear2 = -0.21 # shear representing intrinsic shape component 2
+    fake_gal_flux = 1000.0
+    fake_gal_orig_PSF_fwhm = 0.1 # arcsec
+    fake_gal_orig_PSF_shear1 = 0.0
+    fake_gal_orig_PSF_shear2 = -0.07
+
+    targ_pixel_scale = [0.18, 0.25] # arcsec
+    targ_PSF_fwhm = [0.7, 1.0] # arcsec
+    targ_PSF_shear1 = [-0.03, 0.0]
+    targ_PSF_shear2 = [0.05, -0.08]
+    targ_applied_shear1 = 0.06
+    targ_applied_shear2 = -0.04
+
+    sigma_to_fwhm = 2.0*np.sqrt(2.0*np.log(2.0)) # multiply sigma by this to get FWHM for Gaussian
+    fwhm_to_sigma = 1.0/sigma_to_fwhm
+
+    ind_real = 0 # index of real galaxy in catalog
+    shera_file = 'real_comparison_images/shera_result.fits'
+    shera_target_PSF_file = 'real_comparison_images/shera_target_PSF.fits'
+    shera_target_pixel_scale = 0.24
+    shera_target_flux = 1000.0
+
+    # read in faked Gaussian RealGalaxy from file
+    rgc = galsim.RealGalaxyCatalog(catalog_file, dir=image_dir)
+    rg = galsim.RealGalaxy(rgc, index=ind_fake)
+
+    ## for the generation of the ideal right answer, we need to add the intrinsic shape of the
+    ## galaxy and the lensing shear using the rule for addition of distortions which is ugly, but oh
+    ## well:
+    (d1, d2) = galsim.utilities.g1g2_to_e1e2(fake_gal_shear1, fake_gal_shear2)
+    (d1app, d2app) = galsim.utilities.g1g2_to_e1e2(targ_applied_shear1, targ_applied_shear2)
+    denom = 1.0 + d1*d1app + d2*d2app
+    dapp_sq = d1app**2 + d2app**2
+    d1tot = (d1 + d1app + d2app/dapp_sq*(1.0 - np.sqrt(1.0-dapp_sq))*(d2*d1app - d1*d2app))/denom
+    d2tot = (d2 + d2app + d1app/dapp_sq*(1.0 - np.sqrt(1.0-dapp_sq))*(d1*d2app - d2*d1app))/denom
+
+    # convolve with a range of Gaussians, with and without shear (note, for this test all the
+    # original and target ePSFs are Gaussian - there's no separate pixel response so that everything
+    # can be calculated analytically)
+    for tps in targ_pixel_scale:
+        for tpf in targ_PSF_fwhm:
+            for tps1 in targ_PSF_shear1:
+                for tps2 in targ_PSF_shear2:
+                    print('tps,tpf,tps1,tps2 = ',tps,tpf,tps1,tps2)
+                    # make target PSF
+                    targ_PSF = galsim.Gaussian(fwhm = tpf).shear(g1=tps1, g2=tps2)
+                    # simulate image
+                    sim_image = check_dep(galsim.simReal,
+                                          rg, targ_PSF, tps,
+                                          g1 = targ_applied_shear1,
+                                          g2 = targ_applied_shear2,
+                                          rand_rotate = False,
+                                          target_flux = fake_gal_flux)
+                    # galaxy sigma, in units of pixels on the final image
+                    sigma_ideal = (fake_gal_fwhm/tps)*fwhm_to_sigma
+                    # compute analytically the expected galaxy moments:
+                    mxx_gal, myy_gal, mxy_gal = ellip_to_moments(d1tot, d2tot, sigma_ideal)
+                    # compute analytically the expected PSF moments:
+                    targ_PSF_e1, targ_PSF_e2 = galsim.utilities.g1g2_to_e1e2(tps1, tps2)
+                    targ_PSF_sigma = (tpf/tps)*fwhm_to_sigma
+                    mxx_PSF, myy_PSF, mxy_PSF = ellip_to_moments(
+                            targ_PSF_e1, targ_PSF_e2, targ_PSF_sigma)
+                    # get expected e1, e2, sigma for the PSF-convolved image
+                    tot_e1, tot_e2, tot_sigma = moments_to_ellip(
+                            mxx_gal+mxx_PSF, myy_gal+myy_PSF, mxy_gal+mxy_PSF)
+
+                    # compare with images that are expected
+                    expected_gaussian = galsim.Gaussian(
+                            flux = fake_gal_flux, sigma = tps*tot_sigma)
+                    expected_gaussian = expected_gaussian.shear(e1 = tot_e1, e2 = tot_e2)
+                    expected_image = galsim.ImageD(
+                            sim_image.array.shape[0], sim_image.array.shape[1])
+                    expected_gaussian.drawImage(expected_image, scale=tps, method='no_pixel')
+                    printval(expected_image,sim_image)
+                    np.testing.assert_array_almost_equal(
+                        sim_image.array, expected_image.array, decimal = 3,
+                        err_msg = "Error in comparison of ideal Gaussian RealGalaxy calculations")
+
+    full_catalog_file = os.path.join(image_dir,catalog_file)
+    rgc = galsim.RealGalaxyCatalog(full_catalog_file)
+    rg = galsim.RealGalaxy(rgc, index=ind_real)
+
+    # read in expected result for some shear
+    shera_image = galsim.fits.read(shera_file)
+    shera_target_PSF_image = galsim.fits.read(shera_target_PSF_file)
+
+    # simulate the same galaxy with galsim.simReal
+    sim_image = check_dep(galsim.simReal, rg, shera_target_PSF_image,
+                          shera_target_pixel_scale, g1=targ_applied_shear1,
+                          g2=targ_applied_shear2, rand_rotate=False,
+                          target_flux=shera_target_flux)
+
+    # there are centroid issues when comparing Shera vs. SBProfile outputs, so compare 2nd moments
+    # instead of images
+    sbp_res = sim_image.FindAdaptiveMom()
+    shera_res = shera_image.FindAdaptiveMom()
+
+    np.testing.assert_almost_equal(sbp_res.observed_shape.e1,
+                                   shera_res.observed_shape.e1, 2,
+                                   err_msg = "Error in comparison with SHERA result: e1")
+    np.testing.assert_almost_equal(sbp_res.observed_shape.e2,
+                                   shera_res.observed_shape.e2, 2,
+                                   err_msg = "Error in comparison with SHERA result: e2")
+    np.testing.assert_almost_equal(sbp_res.moments_sigma, shera_res.moments_sigma, 2,
+                                   err_msg = "Error in comparison with SHERA result: sigma")
+
 if __name__ == "__main__":
     test_dep_bandpass()
     test_dep_base()
@@ -1564,3 +1695,4 @@ if __name__ == "__main__":
     test_dep_drawKImage()
     test_dep_drawKImage_Gaussian()
     test_dep_kroundtrip()
+    test_dep_simreal()

--- a/tests/test_real.py
+++ b/tests/test_real.py
@@ -96,6 +96,10 @@ def test_real_galaxy_ideal():
         np.testing.assert_raises(AttributeError, galsim.RealGalaxy, rgc)
     except ImportError:
         print('The assert_raises tests require nose')
+    # Different RNGs give different random galaxies.
+    rg_3 = galsim.RealGalaxy(rgc, random=True, rng=galsim.BaseDeviate(12345))
+    rg_4 = galsim.RealGalaxy(rgc, random=True, rng=galsim.BaseDeviate(67890))
+    assert rg_3.index != rg_4.index, 'Different seeds did not give different random objects!'
 
     check_basic(rg, "RealGalaxy", approx_maxsb=True)
     check_basic(rg_1, "RealGalaxy", approx_maxsb=True)

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -144,10 +144,10 @@ def test_cosmos_fluxnorm():
 @timer
 def test_cosmos_random():
     """Check the random object functionality of the COSMOS catalog."""
-    # For most of this test, we'll use the selectRandomIndices() routine, which does not try to
+    # For most of this test, we'll use the selectRandomIndex() routine, which does not try to
     # construct the GSObjects.  This makes the test go fast.  However, we will at the end have a
     # test to ensure that calling makeGalaxy() while requesting a random object has the same
-    # behavior as using selectRandomIndices() in limited cases.
+    # behavior as using selectRandomIndex() in limited cases.
 
     # Initialize the catalog.  The first will have weights, while the second will not (since they
     # are in the RealGalaxyCatalog).
@@ -160,9 +160,9 @@ def test_cosmos_random():
 
     # Check for exception handling if bad inputs given for the random functionality.
     try:
-        np.testing.assert_raises(ValueError, cat.selectRandomIndices, 0)
-        np.testing.assert_raises(ValueError, cat.selectRandomIndices, 10.7)
-        np.testing.assert_raises(TypeError, cat.selectRandomIndices, 10, rng=3)
+        np.testing.assert_raises(ValueError, cat.selectRandomIndex, 0)
+        np.testing.assert_raises(ValueError, cat.selectRandomIndex, 10.7)
+        np.testing.assert_raises(TypeError, cat.selectRandomIndex, 10, rng=3)
     except ImportError:
         print('The assert_raises tests require nose')
 
@@ -177,7 +177,7 @@ def test_cosmos_random():
     except ImportError:
         print('The assert_raises tests require nose')
     # Make sure we use enough objects that the mean weights converge properly.
-    randind_wt = cat.selectRandomIndices(30000, rng=galsim.BaseDeviate(1234))
+    randind_wt = cat.selectRandomIndex(30000, rng=galsim.BaseDeviate(1234))
     wtrand = cat.real_cat.weight[cat.orig_index[randind_wt]] / \
         np.max(cat.real_cat.weight[cat.orig_index])
     # The average value of wtrand should be wavgw_weight_val in this case, since we used the weights
@@ -190,7 +190,7 @@ def test_cosmos_random():
     import warnings
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        randind = cat_param.selectRandomIndices(30000, rng=galsim.BaseDeviate(1234))
+        randind = cat_param.selectRandomIndex(30000, rng=galsim.BaseDeviate(1234))
     wtrand = cat.real_cat.weight[cat.orig_index[randind]] / \
         np.max(cat.real_cat.weight[cat.orig_index])
     # The average value of wtrand should be avg_weight_val, since we did not do a weighted
@@ -204,17 +204,17 @@ def test_cosmos_random():
     # weighting.
     rng1 = galsim.BaseDeviate(1234)
     rng2 = galsim.BaseDeviate(1234)
-    ind1 = cat.selectRandomIndices(10, rng=rng1)
-    ind2 = cat.selectRandomIndices(10, rng=rng2)
+    ind1 = cat.selectRandomIndex(10, rng=rng1)
+    ind2 = cat.selectRandomIndex(10, rng=rng2)
     np.testing.assert_array_equal(ind1,ind2,
                                   err_msg='Different random indices selected with same seed!')
-    ind1p = cat_param.selectRandomIndices(10, rng=rng1)
-    ind2p = cat_param.selectRandomIndices(10, rng=rng2)
+    ind1p = cat_param.selectRandomIndex(10, rng=rng1)
+    ind2p = cat_param.selectRandomIndex(10, rng=rng2)
     np.testing.assert_array_equal(ind1p,ind2p,
                                   err_msg='Different random indices selected with same seed!')
     rng3 = galsim.BaseDeviate(5678)
-    ind3 = cat.selectRandomIndices(10, rng=rng3)
-    ind3p = cat_param.selectRandomIndices(10) # initialize RNG based on time
+    ind3 = cat.selectRandomIndex(10, rng=rng3)
+    ind3p = cat_param.selectRandomIndex(10) # initialize RNG based on time
     try:
         np.testing.assert_raises(AssertionError, np.testing.assert_array_equal, ind1, ind1p)
         np.testing.assert_raises(AssertionError, np.testing.assert_array_equal, ind1, ind3)
@@ -222,12 +222,12 @@ def test_cosmos_random():
     except ImportError:
         print('The assert_raises tests require nose')
 
-    # Finally, make sure that directly calling selectRandomIndices() gives the same random ones as
+    # Finally, make sure that directly calling selectRandomIndex() gives the same random ones as
     # makeGalaxy().  We'll do one real object because they are slower, and multiple parametric (just
     # to make sure that the multi-object selection works consistently).
     use_seed = 567
     obj = cat.makeGalaxy(rng=galsim.BaseDeviate(use_seed))
-    ind = cat.selectRandomIndices(1, rng=galsim.BaseDeviate(use_seed))
+    ind = cat.selectRandomIndex(1, rng=galsim.BaseDeviate(use_seed))
     obj_2 = cat.makeGalaxy(ind)
     # Note: for real galaxies we cannot require that obj==obj_2, just that obj.index==obj_2.index.
     # That's because we want to make sure the same galaxy is being randomly selected, but we cannot
@@ -237,7 +237,7 @@ def test_cosmos_random():
 
     n_random = 3
     objs = cat_param.makeGalaxy(rng=galsim.BaseDeviate(use_seed), n_random=n_random)
-    inds = cat_param.selectRandomIndices(n_random, rng=galsim.BaseDeviate(use_seed))
+    inds = cat_param.selectRandomIndex(n_random, rng=galsim.BaseDeviate(use_seed))
     objs_2 = cat_param.makeGalaxy(inds)
     for i in range(n_random):
         # With parametric objects there is no noise padding, so we can require completely identical
@@ -251,7 +251,7 @@ def test_cosmos_random():
                                dir=datapath, exclusion_level='none')
     rgc = galsim.RealGalaxyCatalog(file_name='real_galaxy_catalog_23.5_example.fits',
                                    dir=datapath)
-    ind_cc = cat.selectRandomIndices(1, rng=galsim.BaseDeviate(use_seed))
+    ind_cc = cat.selectRandomIndex(1, rng=galsim.BaseDeviate(use_seed))
     foo = galsim.RealGalaxy(rgc, random=True, rng=galsim.BaseDeviate(use_seed))
     ind_rgc = foo.index
     assert ind_cc==ind_rgc,\
@@ -260,7 +260,7 @@ def test_cosmos_random():
     # test.
     del cat.real_cat
     del rgc.weight
-    ind_cc = cat.selectRandomIndices(1, rng=galsim.BaseDeviate(use_seed))
+    ind_cc = cat.selectRandomIndex(1, rng=galsim.BaseDeviate(use_seed))
     foo = galsim.RealGalaxy(rgc, random=True, rng=galsim.BaseDeviate(use_seed))
     ind_rgc = foo.index
     assert ind_cc==ind_rgc,\

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -266,6 +266,18 @@ def test_cosmos_random():
     assert ind_cc==ind_rgc,\
         'Different unweighted random index selected from COSMOSCatalog and RealGalaxyCatalog'
 
+    # Check that setting _n_rng_calls properly tracks the RNG calls for n_random=1 and >1.
+    test_seed = 123456
+    ud = galsim.UniformDeviate(test_seed)
+    obj, n_rng_calls = cat.selectRandomIndex(1, rng=ud, _n_rng_calls=True)
+    ud2 = galsim.UniformDeviate(test_seed)
+    ud2.discard(n_rng_calls)
+    assert ud()==ud2(), '_n_rng_calls kwarg did not give proper tracking of RNG calls'
+    ud = galsim.UniformDeviate(test_seed)
+    obj, n_rng_calls = cat.selectRandomIndex(17, rng=ud, _n_rng_calls=True)
+    ud2 = galsim.UniformDeviate(test_seed)
+    ud2.discard(n_rng_calls)
+    assert ud()==ud2(), '_n_rng_calls kwarg did not give proper tracking of RNG calls'
 
 if __name__ == "__main__":
     test_cosmos_basic()

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -141,7 +141,133 @@ def test_cosmos_fluxnorm():
     assert hasattr(gal1_param.shear(g1=0.05).original, 'index'), \
         'Bulge+disk galaxy does not retain index information after transformation'
 
+@timer
+def test_cosmos_random():
+    """Check the random object functionality of the COSMOS catalog."""
+    # For most of this test, we'll use the selectRandomIndices() routine, which does not try to
+    # construct the GSObjects.  This makes the test go fast.  However, we will at the end have a
+    # test to ensure that calling makeGalaxy() while requesting a random object has the same
+    # behavior as using selectRandomIndices() in limited cases.
+
+    # Initialize the catalog.  The first will have weights, while the second will not (since they
+    # are in the RealGalaxyCatalog).
+    cat = galsim.COSMOSCatalog(file_name='real_galaxy_catalog_23.5_example.fits',
+                               dir=datapath)
+    cat_param = galsim.COSMOSCatalog(file_name='real_galaxy_catalog_23.5_example.fits',
+                                     dir=datapath, use_real=False)
+    assert hasattr(cat, 'real_cat')
+    assert not hasattr(cat_param, 'real_cat')
+
+    # Check for exception handling if bad inputs given for the random functionality.
+    try:
+        np.testing.assert_raises(ValueError, cat.selectRandomIndices, 0)
+        np.testing.assert_raises(ValueError, cat.selectRandomIndices, 10.7)
+        np.testing.assert_raises(TypeError, cat.selectRandomIndices, 10, rng=3)
+    except ImportError:
+        print('The assert_raises tests require nose')
+
+    # Check that random objects give the right <weight> without/with weighting.
+    wt = cat.real_cat.weight[cat.orig_index]
+    wt /= np.max(wt)
+    avg_weight_val = np.sum(wt)/len(wt)
+    wavg_weight_val = np.sum(wt**2)/np.sum(wt)
+    try:
+        np.testing.assert_raises(AssertionError, np.testing.assert_almost_equal, avg_weight_val,
+                                 wavg_weight_val, 3)
+    except ImportError:
+        print('The assert_raises tests require nose')
+    # Make sure we use enough objects that the mean weights converge properly.
+    randind_wt = cat.selectRandomIndices(30000, rng=galsim.BaseDeviate(1234))
+    wtrand = cat.real_cat.weight[cat.orig_index[randind_wt]] / \
+        np.max(cat.real_cat.weight[cat.orig_index])
+    # The average value of wtrand should be wavgw_weight_val in this case, since we used the weights
+    # to probabilistically select galaxies.
+    np.testing.assert_almost_equal(np.mean(wtrand), wavg_weight_val,3,
+                                   err_msg='Average weight for random sample is wrong')
+    # From here on we need to suppress some warnings that come from calling cat_param.  It doesn't
+    # have weights, so it does unweighted selection, which emits a warning.  We know about this and
+    # don't want to spit out the warning each time, so suppress it.
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        randind = cat_param.selectRandomIndices(30000, rng=galsim.BaseDeviate(1234))
+    wtrand = cat.real_cat.weight[cat.orig_index[randind]] / \
+        np.max(cat.real_cat.weight[cat.orig_index])
+    # The average value of wtrand should be avg_weight_val, since we did not do a weighted
+    # selection.
+    np.testing.assert_almost_equal(np.mean(wtrand), avg_weight_val,3,
+                                   err_msg='Average weight for random sample is wrong')
+
+    # Check for consistency of randoms with same random seed.  Do this both for the weighted and the
+    # unweighted calculation.
+    # Check for inconsistency of randoms with different random seed, or same seed but without/with
+    # weighting.
+    rng1 = galsim.BaseDeviate(1234)
+    rng2 = galsim.BaseDeviate(1234)
+    ind1 = cat.selectRandomIndices(10, rng=rng1)
+    ind2 = cat.selectRandomIndices(10, rng=rng2)
+    np.testing.assert_array_equal(ind1,ind2,
+                                  err_msg='Different random indices selected with same seed!')
+    ind1p = cat_param.selectRandomIndices(10, rng=rng1)
+    ind2p = cat_param.selectRandomIndices(10, rng=rng2)
+    np.testing.assert_array_equal(ind1p,ind2p,
+                                  err_msg='Different random indices selected with same seed!')
+    rng3 = galsim.BaseDeviate(5678)
+    ind3 = cat.selectRandomIndices(10, rng=rng3)
+    ind3p = cat_param.selectRandomIndices(10) # initialize RNG based on time
+    try:
+        np.testing.assert_raises(AssertionError, np.testing.assert_array_equal, ind1, ind1p)
+        np.testing.assert_raises(AssertionError, np.testing.assert_array_equal, ind1, ind3)
+        np.testing.assert_raises(AssertionError, np.testing.assert_array_equal, ind1p, ind3p)
+    except ImportError:
+        print('The assert_raises tests require nose')
+
+    # Finally, make sure that directly calling selectRandomIndices() gives the same random ones as
+    # makeGalaxy().  We'll do one real object because they are slower, and multiple parametric (just
+    # to make sure that the multi-object selection works consistently).
+    use_seed = 567
+    obj = cat.makeGalaxy(rng=galsim.BaseDeviate(use_seed))
+    ind = cat.selectRandomIndices(1, rng=galsim.BaseDeviate(use_seed))
+    obj_2 = cat.makeGalaxy(ind)
+    # Note: for real galaxies we cannot require that obj==obj_2, just that obj.index==obj_2.index.
+    # That's because we want to make sure the same galaxy is being randomly selected, but we cannot
+    # require that noise padding be the same, given the inconsistency in how the BaseDeviates are
+    # used in the above cases.
+    assert obj.index==obj_2.index,'makeGalaxy selects random objects inconsistently'
+
+    n_random = 3
+    objs = cat_param.makeGalaxy(rng=galsim.BaseDeviate(use_seed), n_random=n_random)
+    inds = cat_param.selectRandomIndices(n_random, rng=galsim.BaseDeviate(use_seed))
+    objs_2 = cat_param.makeGalaxy(inds)
+    for i in range(n_random):
+        # With parametric objects there is no noise padding, so we can require completely identical
+        # GSObjects (not just equal indices).
+        assert objs[i]==objs_2[i],'makeGalaxy selects random objects inconsistently'
+
+    # Finally, check for consistency with random object selected from RealGalaxyCatalog.  For this
+    # case, we need to make another COSMOSCatalog that does not flag the bad objects.
+    use_seed=31415
+    cat = galsim.COSMOSCatalog(file_name='real_galaxy_catalog_23.5_example.fits',
+                               dir=datapath, exclusion_level='none')
+    rgc = galsim.RealGalaxyCatalog(file_name='real_galaxy_catalog_23.5_example.fits',
+                                   dir=datapath)
+    ind_cc = cat.selectRandomIndices(1, rng=galsim.BaseDeviate(use_seed))
+    foo = galsim.RealGalaxy(rgc, random=True, rng=galsim.BaseDeviate(use_seed))
+    ind_rgc = foo.index
+    assert ind_cc==ind_rgc,\
+        'Different weighted random index selected from COSMOSCatalog and RealGalaxyCatalog'
+    # Also check for the unweighted case.  Just remove that info from the catalogs and redo the
+    # test.
+    del cat.real_cat
+    del rgc.weight
+    ind_cc = cat.selectRandomIndices(1, rng=galsim.BaseDeviate(use_seed))
+    foo = galsim.RealGalaxy(rgc, random=True, rng=galsim.BaseDeviate(use_seed))
+    ind_rgc = foo.index
+    assert ind_cc==ind_rgc,\
+        'Different unweighted random index selected from COSMOSCatalog and RealGalaxyCatalog'
+
 
 if __name__ == "__main__":
     test_cosmos_basic()
     test_cosmos_fluxnorm()
+    test_cosmos_random()

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -491,6 +491,13 @@ def test_rand_with_replacement():
     except ImportError:
         print("The assert_raises tests require nose")
 
+    # Make sure results come out the same whether we use _n_rng_calls or not.
+    result_1 = galsim.utilities.rand_with_replacement(n=10, rng=galsim.BaseDeviate(314159),
+                                                      n_choices=100)
+    result_2, _ = galsim.utilities.rand_with_replacement(n=10, rng=galsim.BaseDeviate(314159),
+                                                         n_choices=100, _n_rng_calls=True)
+    assert np.all(result_1==result_2),"Using _n_rng_calls results in different random numbers"
+
 if __name__ == "__main__":
     test_roll2d_circularity()
     test_roll2d_fwdbck()

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -498,6 +498,15 @@ def test_rand_with_replacement():
                                                          rng=galsim.BaseDeviate(314159),
                                                          _n_rng_calls=True)
     assert np.all(result_1==result_2),"Using _n_rng_calls results in different random numbers"
+    weight = np.zeros(100)
+    galsim.UniformDeviate(1234).generate(weight)
+    result_1 = galsim.utilities.rand_with_replacement(
+        n=10, n_choices=100, rng=galsim.BaseDeviate(314159), weight=weight)
+    assert not np.all(result_1==result_2),"Weights did not have an effect"
+    result_2, _ = galsim.utilities.rand_with_replacement(
+        n=10, n_choices=100, rng=galsim.BaseDeviate(314159),
+        weight=weight, _n_rng_calls=True)
+    assert np.all(result_1==result_2),"Using _n_rng_calls results in different random numbers"
 
 if __name__ == "__main__":
     test_roll2d_circularity()

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -460,6 +460,36 @@ def test_python_LRU_Cache():
         cache.resize(i)
         assert (newsize - (i - 1),) not in cache.cache
 
+@timer
+def test_rand_with_replacement():
+    """Test routine to select random indices with replacement."""
+    # Most aspects of this routine get tested when it's used by COSMOSCatalog.  We just check some
+    # of the exception-handling here.
+    try:
+        np.testing.assert_raises(ValueError, galsim.utilities.rand_with_replacement,
+                                 n=1.5, rng=galsim.BaseDeviate(1234), n_choices=10)
+        np.testing.assert_raises(TypeError, galsim.utilities.rand_with_replacement,
+                                 n=2, rng='foo', n_choices=10)
+        np.testing.assert_raises(ValueError, galsim.utilities.rand_with_replacement,
+                                 n=2, rng=galsim.BaseDeviate(1234), n_choices=10.5)
+        np.testing.assert_raises(ValueError, galsim.utilities.rand_with_replacement,
+                                 n=2, rng=galsim.BaseDeviate(1234), n_choices=-11)
+        np.testing.assert_raises(ValueError, galsim.utilities.rand_with_replacement,
+                                 n=-2, rng=galsim.BaseDeviate(1234), n_choices=11)
+        tmp_weights = np.arange(10).astype(float)-3
+        np.testing.assert_raises(ValueError, galsim.utilities.rand_with_replacement,
+                                 n=2, rng=galsim.BaseDeviate(1234), n_choices=10,
+                                 weight=tmp_weights)
+        tmp_weights[0] = np.nan
+        np.testing.assert_raises(ValueError, galsim.utilities.rand_with_replacement,
+                                 n=2, rng=galsim.BaseDeviate(1234), n_choices=10,
+                                 weight=tmp_weights)
+        tmp_weights[0] = np.inf
+        np.testing.assert_raises(ValueError, galsim.utilities.rand_with_replacement,
+                                 n=2, rng=galsim.BaseDeviate(1234), n_choices=10,
+                                 weight=tmp_weights)
+    except ImportError:
+        print("The assert_raises tests require nose")
 
 if __name__ == "__main__":
     test_roll2d_circularity()
@@ -471,3 +501,4 @@ if __name__ == "__main__":
     test_deInterleaveImage()
     test_interleaveImages()
     test_python_LRU_Cache()
+    test_rand_with_replacement()

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -467,35 +467,36 @@ def test_rand_with_replacement():
     # of the exception-handling here.
     try:
         np.testing.assert_raises(ValueError, galsim.utilities.rand_with_replacement,
-                                 n=1.5, rng=galsim.BaseDeviate(1234), n_choices=10)
+                                 n=1.5, n_choices=10, rng=galsim.BaseDeviate(1234))
         np.testing.assert_raises(TypeError, galsim.utilities.rand_with_replacement,
-                                 n=2, rng='foo', n_choices=10)
+                                 n=2, n_choices=10, rng='foo')
         np.testing.assert_raises(ValueError, galsim.utilities.rand_with_replacement,
-                                 n=2, rng=galsim.BaseDeviate(1234), n_choices=10.5)
+                                 n=2, n_choices=10.5, rng=galsim.BaseDeviate(1234))
         np.testing.assert_raises(ValueError, galsim.utilities.rand_with_replacement,
-                                 n=2, rng=galsim.BaseDeviate(1234), n_choices=-11)
+                                 n=2, n_choices=-11, rng=galsim.BaseDeviate(1234))
         np.testing.assert_raises(ValueError, galsim.utilities.rand_with_replacement,
-                                 n=-2, rng=galsim.BaseDeviate(1234), n_choices=11)
+                                 n=-2, n_choices=11, rng=galsim.BaseDeviate(1234))
         tmp_weights = np.arange(10).astype(float)-3
         np.testing.assert_raises(ValueError, galsim.utilities.rand_with_replacement,
-                                 n=2, rng=galsim.BaseDeviate(1234), n_choices=10,
+                                 n=2, n_choices=10, rng=galsim.BaseDeviate(1234),
                                  weight=tmp_weights)
         tmp_weights[0] = np.nan
         np.testing.assert_raises(ValueError, galsim.utilities.rand_with_replacement,
-                                 n=2, rng=galsim.BaseDeviate(1234), n_choices=10,
+                                 n=2, n_choices=10, rng=galsim.BaseDeviate(1234),
                                  weight=tmp_weights)
         tmp_weights[0] = np.inf
         np.testing.assert_raises(ValueError, galsim.utilities.rand_with_replacement,
-                                 n=2, rng=galsim.BaseDeviate(1234), n_choices=10,
+                                 n=2, n_choices=10, rng=galsim.BaseDeviate(1234),
                                  weight=tmp_weights)
     except ImportError:
         print("The assert_raises tests require nose")
 
     # Make sure results come out the same whether we use _n_rng_calls or not.
-    result_1 = galsim.utilities.rand_with_replacement(n=10, rng=galsim.BaseDeviate(314159),
-                                                      n_choices=100)
-    result_2, _ = galsim.utilities.rand_with_replacement(n=10, rng=galsim.BaseDeviate(314159),
-                                                         n_choices=100, _n_rng_calls=True)
+    result_1 = galsim.utilities.rand_with_replacement(n=10, n_choices=100,
+                                                      rng=galsim.BaseDeviate(314159))
+    result_2, _ = galsim.utilities.rand_with_replacement(n=10, n_choices=100,
+                                                         rng=galsim.BaseDeviate(314159),
+                                                         _n_rng_calls=True)
     assert np.all(result_1==result_2),"Using _n_rng_calls results in different random numbers"
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR is for functionality that enables the use of "weights" in the RealGalaxyCatalog and COSMOSCatalog.  When galaxies were selected for inclusion in the catalog, there was a mild galaxy size-dependent trend (because we excluded objects that had pixels too near the edges of the CCD, and this will happen for large galaxies that have centroids in a larger fraction of the CCD area).  Now it is possible to randomly choose a galaxy in a way that removes that bias in the postage stamp creation process, and indeed, using those weights is the default behavior.

I made demo11 use this new behavior.

Also, I added a bunch of unit tests but I suspect it's insufficient, especially in the new config functionality.  I will use the coverage report after submitting the PR to add a few more unit tests, but otherwise this is done.