### PR TITLE
#861 Updates for latest numpy and astropy versions

### DIFF
--- a/galsim/catalog.py
+++ b/galsim/catalog.py
@@ -22,6 +22,7 @@ Routines for controlling catalog input/output with GalSim.
 from future.utils import iteritems, iterkeys, itervalues
 from builtins import zip
 import galsim
+import os
 import numpy as np
 
 class Catalog(object):
@@ -548,7 +549,12 @@ class OutputCatalog(object):
         @param file_name    The name of the file to write to.
         """
         tbhdu = self.writeFitsHdu()
-        tbhdu.writeto(file_name, clobber=True)
+        # Don't use astropy's clobber feature, since it's now (as of astropy version 1.3) called
+        # overwrite and dealing with two incompatible APIs is more than I want to deal with.
+        # Just do it ourselves.
+        if os.path.isfile(file_name):
+            os.remove(file_name)
+        tbhdu.writeto(file_name)
 
     def writeFitsHdu(self):
         """Write catalog to a FITS hdu.

--- a/galsim/des/des_meds.py
+++ b/galsim/des/des_meds.py
@@ -29,6 +29,7 @@ import numpy as np
 import galsim
 import galsim.config
 import sys
+import os
 
 # these image stamp sizes are available in MEDS format
 BOX_SIZES = [32,48,64,96,128,192,256]
@@ -409,7 +410,12 @@ def WriteMEDS(obj_list, file_name, clobber=True):
         seg_cutouts,
         psf_cutouts
     ])
-    hdu_list.writeto(file_name,clobber=clobber)
+    # Don't use astropy's clobber feature, since it's now (as of astropy version 1.3) called
+    # overwrite and dealing with two incompatible APIs is more than I want to deal with.
+    # Just do it ourselves.
+    if clobber and os.path.isfile(file_name):
+        os.remove(file_name)
+    hdu_list.writeto(file_name)
 
 
 # Make the class that will

--- a/galsim/interpolatedimage.py
+++ b/galsim/interpolatedimage.py
@@ -812,7 +812,7 @@ def _SBIKI_getinitargs(self):
 _galsim.SBInterpolatedKImage.__getinitargs__ = _SBIKI_getinitargs
 _galsim.SBInterpolatedKImage.__getstate__ = lambda self: None
 _galsim.SBInterpolatedKImage.__repr__ = lambda self: (
-    'galsim._galsim.SBInterpolatedKImage(%r, %r, %r, %r, %r, %r, %r, %r, %r, )'
+    'galsim._galsim.SBInterpolatedKImage(%r, %r, %r, %r, %r, %r, %r, %r, %r)'
     %self.__getinitargs__())
 
 _galsim.Interpolant.__getinitargs__ = lambda self: (self.makeStr(), self.getTol())

--- a/galsim/table.py
+++ b/galsim/table.py
@@ -524,7 +524,7 @@ def _LookupTable2D_str(self):
     y = self.getYArgs()
     f = self.getVals()
     return ("galsim._galsim._LookupTable2D(x=[%s,...,%s], y=[%s,...,%s], "
-            "f=[[%s,...,%s],...,[%s,...,%s]]), interpolant=%r"%(
+            "f=[[%s,...,%s],...,[%s,...,%s]], interpolant=%r)"%(
             x[0], x[-1], y[0], y[-1], f[0,0], f[0,-1], f[-1,0], f[-1,-1], self.getInterp()))
 
 _galsim._LookupTable2D.__getinitargs__ = lambda self: \

--- a/galsim/table.py
+++ b/galsim/table.py
@@ -535,5 +535,6 @@ _galsim._LookupTable2D.__hash__ = lambda self: \
               tuple(np.array(self.getVals()).ravel()), self.getInterp()))
 _galsim._LookupTable2D.__str__ = _LookupTable2D_str
 _galsim._LookupTable2D.__repr__ = lambda self: \
-        'galsim._galsim._LookupTable2D(array(%r), array(%r), %r, %r)'%(
-        self.getXArgs().tolist(), self.getYArgs().tolist(), self.getVals(), self.getInterp())
+        'galsim._galsim._LookupTable2D(array(%r), array(%r), array(%r), %r)'%(
+        self.getXArgs().tolist(), self.getYArgs().tolist(), self.getVals().tolist(),
+        self.getInterp())

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -34,7 +34,9 @@ def roll2d(image, shape):
     @returns the rolled image.
     """
     (iroll, jroll) = shape
-    return np.roll(np.roll(image, jroll, axis=1), iroll, axis=0)
+    # The ascontiguousarray bit didn't used to be necessary.  But starting with
+    # numpy v1.12, np.roll doesn't seem to always return a C-contiguous array.
+    return np.ascontiguousarray(np.roll(np.roll(image, jroll, axis=1), iroll, axis=0))
 
 def kxky(array_shape=(256, 256)):
     """Return the tuple `(kx, ky)` corresponding to the DFT of a unit integer-sampled array of input

--- a/tests/galsim_test_helpers.py
+++ b/tests/galsim_test_helpers.py
@@ -383,7 +383,7 @@ def do_pickle(obj1, func = lambda x : x, irreprable=False):
         # precision for the eval string to exactly reproduce the original object, and start
         # truncating the output for relatively small size arrays.  So we temporarily bump up the
         # precision and truncation threshold for testing.
-        with galsim.utilities.printoptions(precision=18, threshold=1e6):
+        with galsim.utilities.printoptions(precision=18, threshold=np.inf):
             obj5 = eval(repr(obj1))
         f5 = func(obj5)
         assert f5 == f1, "func(obj1) = %r\nfunc(obj5) = %r"%(f1, f5)
@@ -435,7 +435,7 @@ def do_pickle(obj1, func = lambda x : x, irreprable=False):
             # Special case: can't change size of LVector or PhotonArray without changing array
             if classname in ['LVector', 'PhotonArray'] and i == 0:
                 continue
-            with galsim.utilities.printoptions(precision=18, threshold=1e6):
+            with galsim.utilities.printoptions(precision=18, threshold=np.inf):
                 try:
                     if classname in galsim._galsim.__dict__:
                         obj6 = eval('galsim._galsim.' + classname + repr(tuple(newargs)))

--- a/tests/galsim_test_helpers.py
+++ b/tests/galsim_test_helpers.py
@@ -334,7 +334,7 @@ def do_pickle(obj1, func = lambda x : x, irreprable=False):
             irreprable = True
     except:
         import pyfits
-    print('Try pickling ',obj1)
+    print('Try pickling ',str(obj1))
 
     #print('pickled obj1 = ',pickle.dumps(obj1))
     obj2 = pickle.loads(pickle.dumps(obj1))

--- a/tests/galsim_test_helpers.py
+++ b/tests/galsim_test_helpers.py
@@ -438,11 +438,13 @@ def do_pickle(obj1, func = lambda x : x, irreprable=False):
             with galsim.utilities.printoptions(precision=18, threshold=np.inf):
                 try:
                     if classname in galsim._galsim.__dict__:
-                        obj6 = eval('galsim._galsim.' + classname + repr(tuple(newargs)))
+                        eval_str = 'galsim._galsim.' + classname + repr(tuple(newargs))
                     else:
-                        obj6 = eval('galsim.' + classname + repr(tuple(newargs)))
+                        eval_str = 'galsim.' + classname + repr(tuple(newargs))
+                    obj6 = eval(eval_str)
                 except Exception as e:
-                    print('e = ',e)
+                    print('caught exception: ',e)
+                    print('eval_str = ',eval_str)
                     raise TypeError("{0} not `eval`able!".format(
                             classname + repr(tuple(newargs))))
                 else:

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -162,6 +162,8 @@ def test_output_catalog():
     np.testing.assert_almost_equal(cat.getFloat(0,16), 0.1)
 
     # Next the FITS version
+    if os.path.isfile('output/catalog.fits'):
+        os.remove('output/catalog.fits')
     out_cat.write(dir='output', file_name='catalog.fits')
     cat = galsim.Catalog(dir='output', file_name='catalog.fits')
     np.testing.assert_equal(cat.ncols, 17)
@@ -186,6 +188,17 @@ def test_output_catalog():
     np.testing.assert_almost_equal(cat.getFloat(0,'shear.g1'), 0.2)
     np.testing.assert_almost_equal(cat.getFloat(0,'shear.g2'), 0.1)
 
+    # Check that it properly overwrites an existing output file.
+    out_cat.addRow( [1.234, 4.131, 9, -3, 1, True, "He's", '"ceased', 'to', 'be"',
+                     1.2 * galsim.degrees, galsim.PositionI(5,6),
+                     galsim.PositionD(0.3,-0.4), galsim.Shear(g1=0.2, g2=0.1) ])
+    assert out_cat.rows[3] == out_cat.rows[0]
+    out_cat.write(dir='output', file_name='catalog.fits')  # Same name as above.
+    cat2 = galsim.Catalog(dir='output', file_name='catalog.fits')
+    np.testing.assert_equal(cat2.ncols, 17)
+    np.testing.assert_equal(cat2.nobjects, 4)
+    for key in names[:10]:
+        assert cat2.data[key][3] == cat2.data[key][0]
 
     # Check pickling
     do_pickle(out_cat)


### PR DESCRIPTION
Numpy version 1.12 changed how `np.roll` works slightly, which broke one of our tests.  To make sure `galsim.utilities.roll2d` always returns a C-contiguous array, we now have to coerce it.

And astropy version 1.3 changes the name of the `clobber` kwarg for `writeto` to `overwrite`.  I have no idea what compelled them to make this change, but I can't be bothered to support both APIs, so I just implement the file removal ourselves in the two places that had used `clobber`.