### PR TITLE
Fix photon shooting bug reported in #866

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 branches:
   only:
     - master
+    - releases/1.4
 language: python
 compiler:
   - g++

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,3 +199,12 @@ Bug fix
 
 - Fixed bug when whitening noise in images based on COSMOS training datasets using 
   the config functionality, and other minor config bug. (#792)
+
+Changes from v1.4.2 to v1.4.3
+=============================
+
+Bug fix
+-------
+
+- Fixed bug in the photon shooting code that could occasionally lead to an assert
+  failure due to rounding errors if the numbers came out just right. (#866)

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ development.  For details of algorithms and code validation, please see
 Distribution
 ------------
 
-The current released version of GalSim is version 1.4.2.  To get the code, you
+The current released version of GalSim is version 1.4.3.  To get the code, you
 can grab the tarball (or zip file) from
 
-    https://github.com/GalSim-developers/GalSim/releases/tag/v1.4.2
+    https://github.com/GalSim-developers/GalSim/releases/tag/v1.4.3
 
 Also, feel free to fork the repository:
 
@@ -45,7 +45,7 @@ Or clone the repository with either of the following:
 although after doing so, if you are not a developer, you should probably
 checkout the latest release tag, rather than use the master branch:
 
-    git checkout v1.4.2
+    git checkout v1.4.3
 
 The code is also distributed via Fink, Macports, and Homebrew for Mac users.
 See INSTALL.md for more information.
@@ -210,7 +210,7 @@ at one time or another.
 The version of the code at any given snapshot can be downloaded from our
 GitHub webpage, or checked out from the repository using the tag name, e.g.:
 
-    git checkout v1.4.2
+    git checkout v1.4.3
 
 This will then update your directory tree to the snapshot of the code at the
 milestone requested.  (You will also get a message about being in a "detached"

--- a/galsim/_version.py
+++ b/galsim/_version.py
@@ -15,5 +15,5 @@
 #    this list of conditions, and the disclaimer given in the documentation
 #    and/or other materials provided with the distribution.
 #
-__version__ = '1.4.2'
+__version__ = '1.4.3'
 __version_info__ = tuple(map(int, __version__.split('.')))

--- a/src/SBProfile.cpp
+++ b/src/SBProfile.cpp
@@ -951,7 +951,7 @@ namespace galsim {
             xdbg<<"N -> "<<N<<std::endl;
 
             // This is always a reason to break out.
-            if (N < 1.) break;
+            if (N < 0.5) break;
 
             if (max_extra_noise > 0.) {
                 xdbg<<"Check the noise level\n";
@@ -1000,9 +1000,8 @@ namespace galsim {
             if (arrays.size() > 0) {
                 // If using arrays, rescale the flux in each
                 for (size_t k=0; k<arrays.size(); ++k) arrays[k]->scaleFlux(factor);
-            } else {
+            } else if (!add_to_image) {
                 // Otherwise, rescale the image itself
-                assert(!add_to_image);
                 img *= T(factor);
                 // Also fix the added_flux value
                 added_flux *= factor;
@@ -1012,6 +1011,10 @@ namespace galsim {
                 negative_flux *= factor;
 #endif
             }
+            // else don't do anything.
+            // Shouldn't be able to get here if add_to_image is False, but rounding errors might
+            // get you here, in which case everything should be fine, so don't do anything.
+            // cf. Issue #866
         }
 
         if (arrays.size() > 0) {

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -986,6 +986,32 @@ def test_offset():
                 im.array, im2.array, 6,
                 "obj.drawImage(im, offset=%f,%f) different from use_true_center=False")
 
+def test_shoot():
+    """Test drawImage(..., method='phot')
+
+    Most tests of the photon shooting method are done using the `do_shoot` function calls
+    in various places.  Here we test other aspects of photon shooting that are not fully
+    covered by these other tests.
+    """
+    # This test comes from a bug report by Jim Chiang on issue #866.  There was a rounding
+    # problem when the number of photons to shoow came out to 100,000 + 1.  It did the first
+    # 100,000 and then was left with 1, but rounding errors (since it is a double, not an int)
+    # was 1 - epsilon, and it ended up in a place where it shouldn't have been able to get to
+    # in exact arithmetic.  We had an assert there which blew up in a not very nice way.
+    obj =  galsim.Gaussian(sigma=0.2398318) + 0.1*galsim.Gaussian(sigma=0.47966352)
+    obj = obj.withFlux(100001)
+    image1 = galsim.ImageF(32,32, init_value=100)
+    rng = galsim.BaseDeviate(1234)
+    obj.drawImage(image1, method='phot', poisson_flux=False, add_to_image=True, rng=rng)
+
+    # The test here is really just that it doesn't crash.
+    # But let's do something to check correctness.
+    image2 = galsim.ImageF(32,32)
+    rng = galsim.BaseDeviate(1234)
+    obj.drawImage(image2, method='phot', poisson_flux=False, add_to_image=False, rng=rng)
+    image2 += 100
+    np.testing.assert_almost_equal(image1.array, image2.array, decimal=12)
+
 
 if __name__ == "__main__":
     test_drawImage()
@@ -994,3 +1020,4 @@ if __name__ == "__main__":
     test_drawKImage_Gaussian()
     test_drawKImage_Exponential_Moffat()
     test_offset()
+    test_shoot()

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -994,7 +994,7 @@ def test_shoot():
     covered by these other tests.
     """
     # This test comes from a bug report by Jim Chiang on issue #866.  There was a rounding
-    # problem when the number of photons to shoow came out to 100,000 + 1.  It did the first
+    # problem when the number of photons to shoot came out to 100,000 + 1.  It did the first
     # 100,000 and then was left with 1, but rounding errors (since it is a double, not an int)
     # was 1 - epsilon, and it ended up in a place where it shouldn't have been able to get to
     # in exact arithmetic.  We had an assert there which blew up in a not very nice way.


### PR DESCRIPTION
@jchiang87 reported an occasional assert failure in issue #866.  It turns out that when the flux to be shot was 100001, it would shoot the first batch of 100000 and be left with 1 photon, which could with numerical rounding sometimes be 1 - epsilon.  This led to it going down a branch that I had thought was not possible, so it hit an assertion failure.

To address this, I both fixed the logic of that branch to use `N < 0.5` rather than `N < 1`, which is probably more appropriate.  And I also just don't do anything if `add_to_image == true` rather than assert that it should be `false` in case there is some other case that could hit this branch, so we don't have the possibility of an assert failure here.

Once merged into releases/1.4, this will be released as v1.4.3, so I included the version changes here as well.