### PR TITLE
#880 Fix error in ra,dec -> x,y for SIP convergence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Bug Fixes
   using the config functionality. (#792)
 - Fixed some handling of images with undefined bounds. (#799)
 - Fixed bug in image.subImage that could cause seg faults in some cases. (#848)
+- Fixed bug in GSFitsWCS that made `toImage` sometimes fail to converge. (#880)
 
 
 Deprecated Features

--- a/galsim/fitswcs.py
+++ b/galsim/fitswcs.py
@@ -1376,8 +1376,114 @@ class GSFitsWCS(galsim.wcs.CelestialWCS):
             assert len(dec) == 1
             return ra[0], dec[0]
 
+    def _invert_pv(self, u, v, pv):
+        # Let (u0,v0) be the current value of (u,v).  Then we want to find a new (u,v) such that
+        #
+        #       [ u0 v0 ] = [ 1 u u^2 u^3 ] pv [ 1 v v^2 v^3 ]^T
+        #
+        # Start with (u,v) = (u0,v0)
+        #
+        # Then use Newton-Raphson iteration to improve (u,v).  This is extremely fast
+        # for typical PV distortions, since the distortions are generally very small.
+        # Newton-Raphson doubles the number of significant digits in each iteration.
+
+        MAX_ITER = 10
+        TOL = 1.e-6 * galsim.arcsec / galsim.degrees   # pv always uses degrees units
+        prev_err = None
+        u0 = u.copy()
+        v0 = v.copy()
+        for iter in range(MAX_ITER):  # pragma: no branch
+            usq = u*u
+            vsq = v*v
+            upow = np.array([ 1., u, usq, usq*u ])
+            vpow = np.array([ 1., v, vsq, vsq*v ])
+
+            diff = np.dot(np.dot(pv, vpow), upow) - (u0,v0)
+
+            # Check that things are improving...
+            err = np.max(np.abs(diff))
+            if prev_err and err > prev_err:  # pragma: no cover
+                raise RuntimeError("Unable to solve for image_pos (not improving)")
+            prev_err = err
+
+            # If we are below tolerance, return this value
+            if err < TOL:
+                # Update p2 to the new value.
+                return u,v
+            else:
+                dupow = np.array([ 0., 1., 2.*u, 3.*usq ])
+                dvpow = np.array([ 0., 1., 2.*v, 3.*vsq ])
+                j1 = np.transpose([ np.dot(np.dot(pv, vpow), dupow) ,
+                                    np.dot(np.dot(pv, dvpow), upow) ])
+                dp = np.linalg.solve(j1, diff)
+                u -= dp[0]
+                v -= dp[1]
+                if np.max(np.abs(dp / (u,v))) < 1.e-15:
+                    # If we're hitting the limits of double precision, stop iterating.
+                    return u,v
+
+        if not err < TOL: # pragma: no cover
+            raise RuntimeError("Unable to solve for image_pos (max iter reached)")
+
+    def _invert_ab(self, x, y, ab, abp):
+        order = len(ab[0])-1
+        x0 = x.copy()
+        y0 = y.copy()
+
+        if abp is not None:
+            xpow = x ** np.arange(order+1)
+            ypow = y ** np.arange(order+1)
+            temp = np.dot(abp, ypow)
+            dp1 = np.sum(xpow * temp, axis=1)
+            x += dp1[0]
+            y += dp1[1]
+
+        # We do this iteration even if we have AP and BP matrices, since the inverse
+        # transformation is not always very accurate.
+        # The assumption here is that the A adn B matrices are correct and the AP and BP
+        # matrices are estimated from them, and thus are approximate at some level.
+        # Of course, in reality the A and B matrices are also approximate, but at least this
+        # way the WCS is consistent transforming in the two directions.
+        MAX_ITER = 10
+        TOL = 1.e-6 * galsim.arcsec / galsim.degrees
+        prev_err = None
+        for iter in range(MAX_ITER):  # pragma: no branch
+            # Slightly easier here than in _radec function, since we don't have to worry
+            # about the possibility of doing many x,y at once.
+            xpow = x ** np.arange(order+1)
+            ypow = y ** np.arange(order+1)
+
+            diff = np.dot(np.dot(ab, ypow), xpow) + (x,y) - (x0,y0)
+
+            # Check that things are improving...
+            err = np.max(np.abs(diff))
+            if prev_err and err > prev_err:  # pragma: no cover
+                raise RuntimeError("Unable to solve for image_pos (not improving)")
+            prev_err = err
+
+            # If we are below tolerance, return this value
+            if err < TOL:
+                # Update p1 to the new value.
+                return x,y
+            else:
+                dxpow = np.zeros(order+1)
+                dypow = np.zeros(order+1)
+                dxpow[1:] = (np.arange(order)+1.) * xpow[:-1]
+                dypow[1:] = (np.arange(order)+1.) * ypow[:-1]
+                j1 = np.transpose([ np.dot(np.dot(ab, ypow), dxpow) ,
+                                    np.dot(np.dot(ab, dypow), xpow) ])
+                j1 += np.diag([1,1])
+                dp = np.linalg.solve(j1, diff)
+                x -= dp[0]
+                y -= dp[1]
+                if np.max(np.abs(dp / (x,y))) < 1.e-15:
+                    # If we're hitting the limits of double precision, stop iterating.
+                    return x,y
+
+        if not err < TOL: # pragma: no cover
+            raise RuntimeError("Unable to solve for image_pos (max iter reached)")
+
     def _xy(self, ra, dec):
-        import numpy.linalg
 
         u, v = self.center.project_rad(ra, dec, projection=self.projection)
 
@@ -1386,126 +1492,17 @@ class GSFitsWCS(galsim.wcs.CelestialWCS):
         u *= -factor
         v *= factor
 
-        p2 = np.array( [ u, v ] )
-
         if self.pv is not None:
-            # Let (s,t) be the current value of (u,v).  Then we want to find a new (u,v) such that
-            #
-            #       [ s t ] = [ 1 u u^2 u^3 ] pv [ 1 v v^2 v^3 ]^T
-            #
-            # Start with (u,v) = (s,t)
-            #
-            # Then use Newton-Raphson iteration to improve (u,v).  This is extremely fast
-            # for typical PV distortions, since the distortions are generally very small.
-            # Newton-Raphson doubles the number of significant digits in each iteration.
+            u, v = self._invert_pv(u, v, self.pv)
 
-
-            MAX_ITER = 10
-            TOL = 1.e-8 * galsim.arcsec / galsim.degrees   # pv always uses degrees units
-            prev_err = None
-            u = p2[0]
-            v = p2[1]
-            for iter in range(MAX_ITER):
-                usq = u*u
-                vsq = v*v
-                upow = np.array([ 1., u, usq, usq*u ])
-                vpow = np.array([ 1., v, vsq, vsq*v ])
-
-                diff = np.dot(np.dot(self.pv, vpow), upow) - p2
-
-                # Check that things are improving...
-                err = np.max(np.abs(diff))
-                if prev_err:
-                    if err > prev_err:
-                        raise RuntimeError("Unable to solve for image_pos (not improving)")
-                prev_err = err
-
-                # If we are below tolerance, break out of the loop
-                if err < TOL:
-                    # Update p2 to the new value.
-                    p2 = np.array( [ u, v ] )
-                    break
-                else:
-                    dupow = np.array([ 0., 1., 2.*u, 3.*usq ])
-                    dvpow = np.array([ 0., 1., 2.*v, 3.*vsq ])
-                    j1 = np.transpose([ np.dot(np.dot(self.pv, vpow), dupow) ,
-                                        np.dot(np.dot(self.pv, dvpow), upow) ])
-                    dp = numpy.linalg.solve(j1, diff)
-                    u -= dp[0]
-                    v -= dp[1]
-                    if np.max(np.abs(dp / (u,v))) < 1.e-15:
-                        # If we're hitting the limits of double precision, stop iterating.
-                        err = 0
-                        p2 = np.array( [ u, v ] )
-                        break
-            if not err < TOL:
-                raise RuntimeError("Unable to solve for image_pos (max iter reached)")
-
-        p1 = np.dot(numpy.linalg.inv(self.cd), p2)
+        x, y = np.dot(np.linalg.inv(self.cd), [u,v])
 
         if self.ab is not None:
-            x = p1[0]
-            y = p1[1]
-            order = len(self.ab[0])-1
-            if self.abp is not None:
-                xpow = x ** np.arange(order+1)
-                ypow = y ** np.arange(order+1)
-                temp = np.dot(self.abp, ypow)
-                dp1 = np.sum(xpow * temp, axis=1)
-                x += dp1[0]
-                y += dp1[1]
+            x, y = self._invert_ab(x, y, self.ab, self.abp)
 
-            # We do this iteration even if we have AP and BP matrices, since the inverse
-            # transformation is not always very accurate.
-            # The assumption here is that the A adn B matrices are correct and the AP and BP
-            # matrices are estimated from them, and thus are approximate at some level.
-            # Of course, in reality the A and B matrices are also approximate, but at least this
-            # way the WCS is consistent transforming in the two directions.
-            MAX_ITER = 10
-            TOL = 1.e-8 * galsim.arcsec / galsim.degrees
-            prev_err = None
-            for iter in range(MAX_ITER):
-                # Slightly easier here than in _radec function, since we don't have to worry
-                # about the possibility of doing many x,y at once.
-                xpow = x ** np.arange(order+1)
-                ypow = y ** np.arange(order+1)
+        x += self.crpix[0]
+        y += self.crpix[1]
 
-                diff = np.dot(np.dot(self.ab, ypow), xpow) + np.array([x,y]) - p1
-
-                # Check that things are improving...
-                err = np.max(np.abs(diff))
-                if prev_err:
-                    if err > prev_err:
-                        raise RuntimeError("Unable to solve for image_pos (not improving)")
-                prev_err = err
-
-                # If we are below tolerance, break out of the loop
-                if err < TOL:
-                    # Update p1 to the new value.
-                    p1 = np.array( [ x, y ] )
-                    break
-                else:
-                    dxpow = np.zeros(order+1)
-                    dypow = np.zeros(order+1)
-                    dxpow[1:] = (np.arange(order)+1.) * xpow[:-1]
-                    dypow[1:] = (np.arange(order)+1.) * ypow[:-1]
-                    j1 = np.transpose([ np.dot(np.dot(self.ab, ypow), dxpow) ,
-                                        np.dot(np.dot(self.ab, dypow), xpow) ])
-                    j1 += np.diag([1,1])
-                    dp = numpy.linalg.solve(j1, diff)
-                    x -= dp[0]
-                    y -= dp[1]
-                    if np.max(np.abs(dp / (x,y))) < 1.e-15:
-                        # If we're hitting the limits of double precision, stop iterating.
-                        err = 0
-                        p1 = np.array( [ x, y ] )
-                        break
-            if not err < TOL:
-                raise RuntimeError("Unable to solve for image_pos (max iter reached)")
-
-        p1 += self.crpix
-
-        x, y = p1
         return x, y
 
     # Override the version in CelestialWCS, since we can do this more efficiently.
@@ -1713,7 +1710,6 @@ def TanWCS(affine, world_origin, units=galsim.arcsec):
 
     @returns a GSFitsWCS describing this WCS.
     """
-    import numpy.linalg
     # These will raise the appropriate errors if affine is not the right type.
     dudx = affine.dudx * units / galsim.degrees
     dudy = affine.dudy * units / galsim.degrees

--- a/galsim/fitswcs.py
+++ b/galsim/fitswcs.py
@@ -1376,115 +1376,17 @@ class GSFitsWCS(galsim.wcs.CelestialWCS):
             assert len(dec) == 1
             return ra[0], dec[0]
 
-    def _invert_pv(self, u, v, pv):
-        # Let (u0,v0) be the current value of (u,v).  Then we want to find a new (u,v) such that
-        #
-        #       [ u0 v0 ] = [ 1 u u^2 u^3 ] pv [ 1 v v^2 v^3 ]^T
-        #
-        # Start with (u,v) = (u0,v0)
-        #
-        # Then use Newton-Raphson iteration to improve (u,v).  This is extremely fast
-        # for typical PV distortions, since the distortions are generally very small.
-        # Newton-Raphson doubles the number of significant digits in each iteration.
+    def _invert_pv(self, u, v):
+        # Do this in C++ layer for speed.
+        return galsim._galsim.InvertPV(u, v, self.pv.ctypes.data)
 
-        MAX_ITER = 10
-        TOL = 1.e-6 * galsim.arcsec / galsim.degrees   # pv always uses degrees units
-        prev_err = None
-        u0 = u.copy()
-        v0 = v.copy()
-        for iter in range(MAX_ITER):  # pragma: no branch
-            usq = u*u
-            vsq = v*v
-            upow = np.array([ 1., u, usq, usq*u ])
-            vpow = np.array([ 1., v, vsq, vsq*v ])
-
-            diff = np.dot(np.dot(pv, vpow), upow) - (u0,v0)
-
-            # Check that things are improving...
-            err = np.max(np.abs(diff))
-            if prev_err and err > prev_err:  # pragma: no cover
-                raise RuntimeError("Unable to solve for image_pos (not improving)")
-            prev_err = err
-
-            # If we are below tolerance, return this value
-            if err < TOL:
-                # Update p2 to the new value.
-                return u,v
-            else:
-                dupow = np.array([ 0., 1., 2.*u, 3.*usq ])
-                dvpow = np.array([ 0., 1., 2.*v, 3.*vsq ])
-                j1 = np.transpose([ np.dot(np.dot(pv, vpow), dupow) ,
-                                    np.dot(np.dot(pv, dvpow), upow) ])
-                dp = np.linalg.solve(j1, diff)
-                u -= dp[0]
-                v -= dp[1]
-                if np.max(np.abs(dp / (u,v))) < 1.e-15:
-                    # If we're hitting the limits of double precision, stop iterating.
-                    return u,v
-
-        if not err < TOL: # pragma: no cover
-            raise RuntimeError("Unable to solve for image_pos (max iter reached)")
-
-    def _invert_ab(self, x, y, ab, abp):
-        order = len(ab[0])-1
-        x0 = x.copy()
-        y0 = y.copy()
-
-        if abp is not None:
-            xpow = x ** np.arange(order+1)
-            ypow = y ** np.arange(order+1)
-            temp = np.dot(abp, ypow)
-            dp1 = np.sum(xpow * temp, axis=1)
-            x += dp1[0]
-            y += dp1[1]
-
-        # We do this iteration even if we have AP and BP matrices, since the inverse
-        # transformation is not always very accurate.
-        # The assumption here is that the A adn B matrices are correct and the AP and BP
-        # matrices are estimated from them, and thus are approximate at some level.
-        # Of course, in reality the A and B matrices are also approximate, but at least this
-        # way the WCS is consistent transforming in the two directions.
-        MAX_ITER = 10
-        TOL = 1.e-6 * galsim.arcsec / galsim.degrees
-        prev_err = None
-        for iter in range(MAX_ITER):  # pragma: no branch
-            # Slightly easier here than in _radec function, since we don't have to worry
-            # about the possibility of doing many x,y at once.
-            xpow = x ** np.arange(order+1)
-            ypow = y ** np.arange(order+1)
-
-            diff = np.dot(np.dot(ab, ypow), xpow) + (x,y) - (x0,y0)
-
-            # Check that things are improving...
-            err = np.max(np.abs(diff))
-            if prev_err and err > prev_err:  # pragma: no cover
-                raise RuntimeError("Unable to solve for image_pos (not improving)")
-            prev_err = err
-
-            # If we are below tolerance, return this value
-            if err < TOL:
-                # Update p1 to the new value.
-                return x,y
-            else:
-                dxpow = np.zeros(order+1)
-                dypow = np.zeros(order+1)
-                dxpow[1:] = (np.arange(order)+1.) * xpow[:-1]
-                dypow[1:] = (np.arange(order)+1.) * ypow[:-1]
-                j1 = np.transpose([ np.dot(np.dot(ab, ypow), dxpow) ,
-                                    np.dot(np.dot(ab, dypow), xpow) ])
-                j1 += np.diag([1,1])
-                dp = np.linalg.solve(j1, diff)
-                x -= dp[0]
-                y -= dp[1]
-                if np.max(np.abs(dp / (x,y))) < 1.e-15:
-                    # If we're hitting the limits of double precision, stop iterating.
-                    return x,y
-
-        if not err < TOL: # pragma: no cover
-            raise RuntimeError("Unable to solve for image_pos (max iter reached)")
+    def _invert_ab(self, x, y):
+        # Do this in C++ layer for speed.
+        order = len(self.ab[0])-1
+        abp_data = 0 if self.abp is None else self.abp.ctypes.data
+        return galsim._galsim.InvertAB(x, y, self.ab.ctypes.data, order, abp_data)
 
     def _xy(self, ra, dec):
-
         u, v = self.center.project_rad(ra, dec, projection=self.projection)
 
         # Again, FITS has +u increasing to the east, not west.  Hence the - for u.
@@ -1493,12 +1395,16 @@ class GSFitsWCS(galsim.wcs.CelestialWCS):
         v *= factor
 
         if self.pv is not None:
-            u, v = self._invert_pv(u, v, self.pv)
+            u, v = self._invert_pv(u, v)
 
-        x, y = np.dot(np.linalg.inv(self.cd), [u,v])
+        if not hasattr(self, 'cdinv'):
+            self.cdinv = np.linalg.inv(self.cd)
+        # This is a bit faster than using np.dot for 2x2 matrix.
+        x = self.cdinv[0,0] * u + self.cdinv[0,1] * v
+        y = self.cdinv[1,0] * u + self.cdinv[1,1] * v
 
         if self.ab is not None:
-            x, y = self._invert_ab(x, y, self.ab, self.abp)
+            x, y = self._invert_ab(x, y)
 
         x += self.crpix[0]
         y += self.crpix[1]

--- a/galsim/fitswcs.py
+++ b/galsim/fitswcs.py
@@ -1433,6 +1433,11 @@ class GSFitsWCS(galsim.wcs.CelestialWCS):
                     dp = numpy.linalg.solve(j1, diff)
                     u -= dp[0]
                     v -= dp[1]
+                    if np.max(np.abs(dp / (u,v))) < 1.e-15:
+                        # If we're hitting the limits of double precision, stop iterating.
+                        err = 0
+                        p2 = np.array( [ u, v ] )
+                        break
             if not err < TOL:
                 raise RuntimeError("Unable to solve for image_pos (max iter reached)")
 
@@ -1476,7 +1481,7 @@ class GSFitsWCS(galsim.wcs.CelestialWCS):
 
                 # If we are below tolerance, break out of the loop
                 if err < TOL:
-                    # Update p2 to the new value.
+                    # Update p1 to the new value.
                     p1 = np.array( [ x, y ] )
                     break
                 else:
@@ -1490,6 +1495,11 @@ class GSFitsWCS(galsim.wcs.CelestialWCS):
                     dp = numpy.linalg.solve(j1, diff)
                     x -= dp[0]
                     y -= dp[1]
+                    if np.max(np.abs(dp / (x,y))) < 1.e-15:
+                        # If we're hitting the limits of double precision, stop iterating.
+                        err = 0
+                        p1 = np.array( [ x, y ] )
+                        break
             if not err < TOL:
                 raise RuntimeError("Unable to solve for image_pos (max iter reached)")
 

--- a/galsim/fitswcs.py
+++ b/galsim/fitswcs.py
@@ -776,7 +776,7 @@ class WcsToolsWCS(galsim.wcs.CelestialWCS): # pragma: no cover
             for line in lines:
                 vals = line.split()
                 if len(vals) != 5:
-                    raise RuntimeError('wcstools xy2sky returned invalid result near %f,%f'%(x0,y0))
+                    raise RuntimeError('wcstools xy2sky returned invalid result near %s'%(xy1))
                 ra.append(float(vals[0]))
                 dec.append(float(vals[1]))
 

--- a/include/galsim/WCS.h
+++ b/include/galsim/WCS.h
@@ -1,0 +1,29 @@
+/* -*- c++ -*-
+ * Copyright (c) 2012-2017 by the GalSim developers team on GitHub
+ * https://github.com/GalSim-developers
+ *
+ * This file is part of GalSim: The modular galaxy image simulation toolkit.
+ * https://github.com/GalSim-developers/GalSim
+ *
+ * GalSim is free software: redistribution and use in source and binary forms,
+ * with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions, and the disclaimer given in the accompanying LICENSE
+ *    file.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the disclaimer given in the documentation
+ *    and/or other materials provided with the distribution.
+ */
+#ifndef GalSim_WCS_H
+#define GalSim_WCS_H
+
+namespace galsim {
+
+    void InvertPV(double& u, double& v, const double* pv);
+    void InvertAB(double& x, double& y, const double* ab, int order, const double* abp);
+
+}
+
+#endif

--- a/pysrc/WCS.cpp
+++ b/pysrc/WCS.cpp
@@ -1,0 +1,51 @@
+/* -*- c++ -*-
+ * Copyright (c) 2012-2017 by the GalSim developers team on GitHub
+ * https://github.com/GalSim-developers
+ *
+ * This file is part of GalSim: The modular galaxy image simulation toolkit.
+ * https://github.com/GalSim-developers/GalSim
+ *
+ * GalSim is free software: redistribution and use in source and binary forms,
+ * with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions, and the disclaimer given in the accompanying LICENSE
+ *    file.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the disclaimer given in the documentation
+ *    and/or other materials provided with the distribution.
+ */
+
+#include "galsim/IgnoreWarnings.h"
+
+#define BOOST_NO_CXX11_SMART_PTR
+#include "boost/python.hpp"
+#include "WCS.h"
+
+namespace bp = boost::python;
+
+namespace galsim {
+
+    bp::tuple CallInvertPV(double u, double v, size_t pv_data)
+    {
+        const double* pvar = reinterpret_cast<const double*>(pv_data);
+        InvertPV(u, v, pvar);
+        return bp::make_tuple(u,v);
+    };
+
+    bp::tuple CallInvertAB(double x, double y, size_t ab_data, int order, size_t abp_data)
+    {
+        const double* abar = reinterpret_cast<const double*>(ab_data);
+        const double* abpar = reinterpret_cast<const double*>(abp_data);
+        InvertAB(x, y, abar, order, abpar);
+        return bp::make_tuple(x,y);
+    };
+
+    void pyExportWCS() {
+        bp::def("InvertPV", &CallInvertPV);
+        bp::def("InvertAB", &CallInvertAB);
+    }
+
+} // namespace galsim
+

--- a/pysrc/files.txt
+++ b/pysrc/files.txt
@@ -31,3 +31,4 @@ CorrelatedNoise.cpp
 Bessel.cpp
 CDModel.cpp
 Silicon.cpp
+WCS.cpp

--- a/pysrc/module.cpp
+++ b/pysrc/module.cpp
@@ -66,6 +66,7 @@ namespace galsim {
     void pyExportCorrelationFunction();
     void pyExportCDModel();
     void pyExportSilicon();
+    void pyExportWCS();
 
     namespace hsm {
         void pyExportHSM();
@@ -117,4 +118,5 @@ BOOST_PYTHON_MODULE(_galsim) {
     galsim::pyExportTable2D();
     galsim::bessel::pyExportBessel();
     galsim::pyExportSilicon();
+    galsim::pyExportWCS();
 }

--- a/src/WCS.cpp
+++ b/src/WCS.cpp
@@ -46,15 +46,15 @@ namespace galsim {
         tmv::ConstMatrixView<double> pvv(pvar + 16, 4, 4, 4, 1, tmv::NonConj);
 
         // Some temporary vectors/matrices we'll use within the loop below.
-        tmv::Vector<double> upow(4);
-        tmv::Vector<double> vpow(4);
-        tmv::Vector<double> pvu_vpow(4);
-        tmv::Vector<double> pvv_vpow(4);
-        tmv::Vector<double> dupow(4);
-        tmv::Vector<double> dvpow(4);
-        tmv::Matrix<double> j1(2,2);
-        tmv::Vector<double> diff(2);
-        tmv::Vector<double> duv(2);
+        tmv::SmallVector<double,4> upow;
+        tmv::SmallVector<double,4> vpow;
+        tmv::SmallVector<double,4> pvu_vpow;
+        tmv::SmallVector<double,4> pvv_vpow;
+        tmv::SmallVector<double,4> dupow;
+        tmv::SmallVector<double,4> dvpow;
+        tmv::SmallMatrix<double,2,2> j1;
+        tmv::SmallVector<double,2> diff;
+        tmv::SmallVector<double,2> duv;
 
         double prev_err = -1.;
         for (int iter=0; iter<MAX_ITER; ++iter) {
@@ -120,9 +120,9 @@ namespace galsim {
         tmv::Vector<double> aby_ypow(order+1);
         tmv::Vector<double> dxpow(order+1,0.);
         tmv::Vector<double> dypow(order+1,0.);
-        tmv::Matrix<double> j1(2,2);
-        tmv::Vector<double> diff(2);
-        tmv::Vector<double> dxy(2);
+        tmv::SmallMatrix<double,2,2> j1;
+        tmv::SmallVector<double,2> diff;
+        tmv::SmallVector<double,2> dxy;
 
         if (abpar) {
             setup_pow(x, y, xpow, ypow);

--- a/src/WCS.cpp
+++ b/src/WCS.cpp
@@ -1,0 +1,202 @@
+/* -*- c++ -*-
+ * Copyright (c) 2012-2017 by the GalSim developers team on GitHub
+ * https://github.com/GalSim-developers
+ *
+ * This file is part of GalSim: The modular galaxy image simulation toolkit.
+ * https://github.com/GalSim-developers/GalSim
+ *
+ * GalSim is free software: redistribution and use in source and binary forms,
+ * with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions, and the disclaimer given in the accompanying LICENSE
+ *    file.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the disclaimer given in the documentation
+ *    and/or other materials provided with the distribution.
+ */
+
+//#define DEBUGLOGGING
+
+#include "Std.h"
+#include "WCS.h"
+#include "TMV.h"
+
+namespace galsim {
+
+    void InvertPV(double& u, double& v, const double* pvar)
+    {
+        // Let (u0,v0) be the current value of (u,v).  Then we want to find a new (u,v) such that
+        //
+        //       [ u0 v0 ] = [ 1 u u^2 u^3 ] pv [ 1 v v^2 v^3 ]^T
+        //
+        // Start with (u,v) = (u0,v0)
+        //
+        // Then use Newton-Raphson iteration to improve (u,v).  This is extremely fast
+        // for typical PV distortions, since the distortions are generally very small.
+        // Newton-Raphson doubles the number of significant digits in each iteration.
+
+        const int MAX_ITER = 10;
+        const double TOL = 1.e-6 / 3600.;    // 1.e-6 arcsec.  pv always uses degrees units
+
+        double u0 = u;
+        double v0 = v;
+        tmv::ConstMatrixView<double> pvu(pvar, 4, 4, 4, 1, tmv::NonConj);
+        tmv::ConstMatrixView<double> pvv(pvar + 16, 4, 4, 4, 1, tmv::NonConj);
+
+        // Some temporary vectors/matrices we'll use within the loop below.
+        tmv::Vector<double> upow(4);
+        tmv::Vector<double> vpow(4);
+        tmv::Vector<double> pvu_vpow(4);
+        tmv::Vector<double> pvv_vpow(4);
+        tmv::Vector<double> dupow(4);
+        tmv::Vector<double> dvpow(4);
+        tmv::Matrix<double> j1(2,2);
+        tmv::Vector<double> diff(2);
+        tmv::Vector<double> duv(2);
+
+        double prev_err = -1.;
+        for (int iter=0; iter<MAX_ITER; ++iter) {
+            double usq = u*u;
+            double vsq = v*v;
+            upow << 1., u, usq, usq*u;
+            vpow << 1., v, vsq, vsq*v;
+
+            pvu_vpow = pvu * vpow;
+            pvv_vpow = pvv * vpow;
+            double du = upow * pvu_vpow - u0;
+            double dv = upow * pvv_vpow - v0;
+
+            // Check that things are improving...
+            double err = std::max(std::abs(du),std::abs(dv));
+
+            if (prev_err >= 0. && err > prev_err)
+                throw std::runtime_error("Unable to solve for image_pos (not improving)");
+            prev_err = err;
+
+            // If we are below tolerance, return this value
+            if (err < TOL) return;
+            else {
+                dupow << 0., 1., 2.*u, 3.*usq;
+                dvpow << 0., 1., 2.*v, 3.*vsq;
+                j1 << dupow * pvu_vpow,  upow * pvu * dvpow,
+                      dupow * pvv_vpow,  upow * pvv * dvpow;
+                diff << du, dv;
+                duv = diff / j1;
+                u -= duv[0];
+                v -= duv[1];
+                // If we're hitting the limits of double precision, stop iterating.
+                if (std::abs(duv[0]/u) < 1.e-15 || std::abs(duv[1]/v) < 1.e-15) return;
+            }
+        }
+
+        throw std::runtime_error("Unable to solve for image_pos (max iter reached)");
+    }
+
+    void setup_pow(double x, double y, tmv::Vector<double>& xpow, tmv::Vector<double>& ypow)
+    {
+        xpow[1] = x;
+        ypow[1] = y;
+        for (size_t i=2; i<xpow.size(); ++i) xpow[i] = xpow[i-1] * x;
+        for (size_t i=2; i<xpow.size(); ++i) ypow[i] = ypow[i-1] * y;
+    }
+
+    void InvertAB(double& x, double& y, const double* abar, int order, const double* abpar)
+    {
+        dbg<<"start invert_ab: "<<x<<" "<<y<<std::endl;
+        dbg<<"order = "<<order<<std::endl;
+        double x0 = x;
+        double y0 = y;
+
+        tmv::ConstMatrixView<double> abx(abar, order+1, order+1, order+1, 1, tmv::NonConj);
+        tmv::ConstMatrixView<double> aby(abar + (order+1)*(order+1), order+1, order+1, order+1, 1, tmv::NonConj);
+        dbg<<"abx = "<<abx<<std::endl;
+        dbg<<"aby = "<<aby<<std::endl;
+
+        tmv::Vector<double> xpow(order+1,1.);
+        tmv::Vector<double> ypow(order+1,1.);
+        tmv::Vector<double> abx_ypow(order+1);
+        tmv::Vector<double> aby_ypow(order+1);
+        tmv::Vector<double> dxpow(order+1,0.);
+        tmv::Vector<double> dypow(order+1,0.);
+        tmv::Matrix<double> j1(2,2);
+        tmv::Vector<double> diff(2);
+        tmv::Vector<double> dxy(2);
+
+        if (abpar) {
+            setup_pow(x, y, xpow, ypow);
+            dbg<<"xpow = "<<xpow<<std::endl;
+            dbg<<"ypow = "<<ypow<<std::endl;
+
+            tmv::ConstMatrixView<double> abpx(abpar, order+1, order+1, order+1, 1, tmv::NonConj);
+            tmv::ConstMatrixView<double> abpy(abpar + (order+1)*(order+1), order+1, order+1, order+1, 1, tmv::NonConj);
+            abx_ypow = abpx * ypow;
+            aby_ypow = abpy * ypow;
+            dbg<<"dx = "<<xpow * abx_ypow<<std::endl;
+            dbg<<"dy = "<<xpow * aby_ypow<<std::endl;
+            x += xpow * abx_ypow;
+            y += xpow * aby_ypow;
+            dbg<<"x,y = "<<x<<" "<<y<<std::endl;
+        }
+
+        // We do this iteration even if we have AP and BP matrices, since the inverse
+        // transformation is not always very accurate.
+        // The assumption here is that the A adn B matrices are correct and the AP and BP
+        // matrices are estimated from them, and thus are approximate at some level.
+        // Of course, in reality the A and B matrices are also approximate, but at least this
+        // way the WCS is consistent transforming in the two directions.
+        const int MAX_ITER = 10;
+        const double TOL = 1.e-6 / 3600.;
+
+        double prev_err = -1.;
+        for (int iter=0; iter<MAX_ITER; ++iter) {
+            dbg<<iter<<" x,y = "<<x<<" "<<y<<std::endl;
+            setup_pow(x, y, xpow, ypow);
+            dbg<<"xpow = "<<xpow<<std::endl;
+            dbg<<"ypow = "<<ypow<<std::endl;
+
+            abx_ypow = abx * ypow;
+            aby_ypow = aby * ypow;
+            double dx = xpow * abx_ypow + x - x0;
+            double dy = xpow * aby_ypow + y - y0;
+            dbg<<"diff = "<<dx<<" "<<dy<<std::endl;
+
+            // Check that things are improving...
+            double err = std::max(std::abs(dx),std::abs(dy));
+            if (prev_err >= 0. && err > prev_err) 
+                throw std::runtime_error("Unable to solve for image_pos (not improving)");
+            prev_err = err;
+            dbg<<"err = "<<err<<std::endl;
+
+            // If we are below tolerance, return this value
+            if (err < TOL) {
+                dbg<<"err < TOL\n";
+                return;
+            }
+            else {
+                for(int i=1; i<=order; ++i) dxpow[i] = i * xpow[i-1];
+                for(int i=1; i<=order; ++i) dypow[i] = i * ypow[i-1];
+                dbg<<"dxpow = "<<dxpow<<std::endl;
+                dbg<<"dypow = "<<dypow<<std::endl;
+
+                j1 << dxpow * abx_ypow,  xpow * abx * dypow,
+                      dxpow * aby_ypow,  xpow * aby * dypow;
+                j1.diag().addToAll(1.);
+                dbg<<"j1 = "<<j1<<std::endl;
+                diff << dx, dy;
+                dxy = diff / j1;
+                dbg<<"dp = "<<dxy<<std::endl;
+                x -= dxy[0];
+                y -= dxy[1];
+                // If we're hitting the limits of double precision, stop iterating.
+                if (std::abs(dxy[0]/x) < 1.e-15 && std::abs(dxy[1]/y) < 1.e-15) {
+                    dbg<<"dp too small\n";
+                    return;
+                }
+            }
+        }
+
+        throw std::runtime_error("Unable to solve for image_pos (max iter reached)");
+    }
+}

--- a/src/files.txt
+++ b/src/files.txt
@@ -32,3 +32,4 @@ CDModel.cpp
 Version.cpp
 Polygon.cpp
 Silicon.cpp
+WCS.cpp


### PR DESCRIPTION
When working on WFIrst stuff, Troxel found a bug in the GSFitsWCS class where it would sometimes not converge going from ra,dec -> x,y when the WCS included a SIP component.  Basically, the target precision (1.e-8 arcsec) was too tight to always be able to meet it in double precision.  

So I adjusted the tolerance to 1.e-6 arcsec (which should still be plenty), and now it checks if the relative changes in x,y are below 1.e-15, in which case it declares it to be converged regardless of the agreement with the sky value.

I also moved this bit to C++, since it was rather slow to do the iteration in python with numpy.linalg.  Now it uses TMV, which is quite a bit quicker.