### PR TITLE
More python3 fixes

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -183,7 +183,7 @@ def ErrorExit(*args, **kwargs):
 
     import shutil
 
-    out = open("gs_error.txt","wb")
+    out = open("gs_error.txt","w")
 
     # Start with the error message to output both to the screen and to gs_error.txt:
     print()
@@ -212,7 +212,7 @@ def ErrorExit(*args, **kwargs):
     # Next put the full config.log in there.
     out.write('The full config.log file is:\n')
     out.write('==================\n')
-    shutil.copyfileobj(open("config.log","rb"),out)
+    shutil.copyfileobj(open("config.log","r"),out)
     out.write('==================\n\n')
 
     # It is sometimes helpful to see the output of the scons executables.
@@ -222,7 +222,7 @@ def ErrorExit(*args, **kwargs):
         cmd = ("ls -d .sconf_temp/conftest* | grep -v '\.out' | grep -v '\.cpp' "+
                "| grep -v '\.o' | grep -v '\_mod'")
         p = subprocess.Popen([cmd],stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
-        conftest_list = p.stdout.readlines()
+        conftest_list = [l.decode() for l in p.stdout.readlines()]
         for conftest in conftest_list:
             conftest = conftest.strip()
             if os.access(conftest, os.X_OK):
@@ -232,7 +232,7 @@ def ErrorExit(*args, **kwargs):
             cmd = PrependLibraryPaths(cmd,env)
             p = subprocess.Popen(['bash -c ' + cmd], stdout=subprocess.PIPE,
                                  stderr=subprocess.STDOUT, shell=True)
-            conftest_out = p.stdout.readlines()
+            conftest_out = [l.decode() for l in p.stdout.readlines()]
             out.write('Output of the command %s is:\n'%cmd)
             out.write(''.join(conftest_out) + '\n')
 
@@ -245,7 +245,7 @@ def ErrorExit(*args, **kwargs):
                     cmd = 'ldd ' + conftest
                 p = subprocess.Popen([cmd], stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                                      shell=True)
-                otool_out = p.stdout.readlines()
+                otool_out = [l.decode() for l in p.stdout.readlines()]
                 out.write('Output of the command %s is:\n'%cmd)
                 out.write(''.join(otool_out) + '\n')
             else:
@@ -258,7 +258,7 @@ def ErrorExit(*args, **kwargs):
                         cmd = 'ldd ' + os.path.join(conftest_mod, 'check_*.so')
                     p = subprocess.Popen([cmd], stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                                          shell=True)
-                    mod_out = p.stdout.readlines()
+                    mod_out = [l.decode() for l in p.stdout.readlines()]
                     out.write('Output of the command %s is:\n'%cmd)
                     out.write(''.join(mod_out) + '\n')
     except Exception as e:
@@ -615,7 +615,7 @@ def GetCompilerVersion(env):
         cmd = compiler + ' ' + versionflag + ' 2>&1'
         import subprocess
         p = subprocess.Popen([cmd], stdout=subprocess.PIPE, shell=True)
-        lines = p.stdout.readlines()
+        lines = [l.decode() for l in p.stdout.readlines()]
 
         # Check if g++ is a symlink for something else:
         if compilertype is 'g++':
@@ -665,7 +665,7 @@ def GetNosetestsVersion(env):
     import subprocess
     cmd = env['NOSETESTS'] + ' --version 2>&1'
     p = subprocess.Popen([cmd],stdout=subprocess.PIPE,shell=True)
-    line = p.stdout.readlines()[0]
+    line = p.stdout.readlines()[0].decode()
     version = line.split()[2]
     print('nosetests version:',version)
     env['NOSETESTSVERSION'] = version
@@ -875,7 +875,7 @@ def AltTryRun(config, text, extension):
         ok = sconf.BuildNodes(node) 
     if ok:
         # For successful execution, also return the output contents
-        outputStr = output.get_contents()
+        outputStr = output.get_text_contents()
         return 1, outputStr.strip()
     else:
         return 0, ""
@@ -1140,7 +1140,7 @@ def TryScript(config,text,pname):
 
     if ok:
         # For successful execution, also return the output contents
-        outputStr = output.get_contents()
+        outputStr = output.get_text_contents()
         return 1, outputStr.strip()
     else:
         return 0, ""
@@ -1869,7 +1869,7 @@ int main()
         major, minor = GetMacVersion()
         try:
             p = subprocess.Popen(['xcodebuild','-version'], stdout=subprocess.PIPE)
-            xcode_version = p.stdout.readlines()[0].split()[1]
+            xcode_version = p.stdout.readlines()[0].decode().split()[1]
             print('XCode version is',xcode_version)
         except:
             # Don't require the user to have xcode installed.
@@ -2040,7 +2040,7 @@ def BuildExecutableScript(target, source, env):
     for i in range(len(source)):
         f = open(str(target[i]), "w")
         f.write( '#!' + env['PYTHON'] + '\n' )
-        f.write(source[i].get_contents())
+        f.write(source[i].get_text_contents())
         f.close()
         os.chmod(str(target[i]),0o775)
 
@@ -2113,7 +2113,7 @@ if not GetOption('help'):
             cmd = "%s -c \"import distutils.sysconfig; "%(python)
             cmd += "print(distutils.sysconfig.get_python_lib(prefix='%s'))\""%(env['PREFIX'])
             p = subprocess.Popen([cmd],stdout=subprocess.PIPE,shell=True)
-            env['PYPREFIX'] = p.stdout.read().strip()
+            env['PYPREFIX'] = p.stdout.read().decode().strip()
             print('Using PYPREFIX generated from PREFIX = ',env['PYPREFIX'])
         else:
             # On Macs, the regular python lib is usually writable, so it works fine for
@@ -2121,7 +2121,7 @@ if not GetOption('help'):
             cmd = "%s -c \"import distutils.sysconfig; "%(python)
             cmd += "print(distutils.sysconfig.get_python_lib())\""
             p = subprocess.Popen([cmd],stdout=subprocess.PIPE,shell=True)
-            env['PYPREFIX'] = p.stdout.read().strip()
+            env['PYPREFIX'] = p.stdout.read().decode().strip()
             print('Using default PYPREFIX = ',env['PYPREFIX'])
 
     # Set up the configuration

--- a/src/SConscript
+++ b/src/SConscript
@@ -12,7 +12,8 @@ try:
 except:
     # If SCons is using an old python (2.4 is relatively common still), then the above may fail.
     # In this case, we need to be a little trickier.
-    execfile(os.path.join(GetBuildPath('#galsim'),'_version.py'))
+    vfilename = os.path.join(GetBuildPath('#galsim'),'_version.py')
+    exec(compile(open(vfilename, "rb").read(), vfilename, 'exec'))
     version = __version__
     version_info = __version_info__
 


### PR DESCRIPTION
This is the second batch of fixes required to build GalSim with a Python3 SCons.

I have successfully built GalSim using `scons-3.0.0.alpha.20170614.tar.gz` with Python3 but there is one issue I encountered with building of boost-python because those include files have bad Unicode in them for an author string. I've reported this upstream (and I have a local fix).