### PR TITLE
#898 Two fixes to make GalSim run at Nersc

### DIFF
--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -1757,9 +1757,10 @@ class ChromaticSum(ChromaticObject):
         # impossible to identify if two SEDs are proportional (or even equal) unless they point to
         # the same memory, so we just accept this limitation.
 
-        # Each input summand will either end up in norm_dict if it's separable, or in self.objlist
-        # if it's inseparable.
-        SED_dict = {}
+        # Each input summand will either end up in SED_dict if it's separable, or in self.objlist
+        # if it's inseparable.  Use an OrderedDict to ensure deterministic results.
+        from collections import OrderedDict
+        SED_dict = OrderedDict()
         self.objlist = []
         for obj in args:
             if obj.separable:

--- a/galsim/real.py
+++ b/galsim/real.py
@@ -1294,8 +1294,13 @@ class ChromaticRealGalaxy(ChromaticSum):
             NSED, Nim, nk, nk)
 
         # Reorder these so they correspond to (NSED, nky, nkx) and (NSED, NSED, nky, nkx) shapes.
-        coef = np.moveaxis(coef, (0,1,2), (1,2,0))
-        Sigma = np.moveaxis(Sigma, (0,1,2,3), (2,3,0,1))
+        try:
+            coef = np.moveaxis(coef, (0,1,2), (1,2,0))
+            Sigma = np.moveaxis(Sigma, (0,1,2,3), (2,3,0,1))
+        except AttributeError:  # pragma: no cover (numpy < 1.11)
+            # I think this prob less efficient, so only use the workaround for old numpy versions
+            coef = np.swapaxes(np.swapaxes(coef,1,2), 0,1)
+            Sigma = np.swapaxes(np.swapaxes(Sigma, 0,2), 1,3)
 
         # Set up objlist as required of ChromaticSum subclass.
         objlist = []

--- a/galsim/real.py
+++ b/galsim/real.py
@@ -1294,13 +1294,8 @@ class ChromaticRealGalaxy(ChromaticSum):
             NSED, Nim, nk, nk)
 
         # Reorder these so they correspond to (NSED, nky, nkx) and (NSED, NSED, nky, nkx) shapes.
-        try:
-            coef = np.moveaxis(coef, (0,1,2), (1,2,0))
-            Sigma = np.moveaxis(Sigma, (0,1,2,3), (2,3,0,1))
-        except AttributeError:  # pragma: no cover (numpy < 1.11)
-            # I think this prob less efficient, so only use the workaround for old numpy versions
-            coef = np.swapaxes(np.swapaxes(coef,1,2), 0,1)
-            Sigma = np.swapaxes(np.swapaxes(Sigma, 0,2), 1,3)
+        coef = np.transpose(coef, (2,0,1))
+        Sigma = np.transpose(Sigma, (2,3,0,1))
 
         # Set up objlist as required of ChromaticSum subclass.
         objlist = []

--- a/galsim/sed.py
+++ b/galsim/sed.py
@@ -154,16 +154,17 @@ class SED(object):
         # Finish re-evaluating __init__() here.
         if _wave_list is not None:
             self.wave_list = _wave_list
-            self.blue_limit = _blue_limit
-            self.red_limit = _red_limit
+            # Cast numpy.float to python float for more consistent reprs
+            self.blue_limit = None if _blue_limit is None else float(_blue_limit)
+            self.red_limit = None if _blue_limit is None else float(_red_limit)
             return
 
         if isinstance(self._spec, galsim.LookupTable):
             self.wave_list = ((self._spec.getArgs() * self.wave_type)
                               .to(units.nm, units.spectral()).value)
             self.wave_list *= (1.0 + self.redshift)
-            self.blue_limit = np.min(self.wave_list)
-            self.red_limit = np.max(self.wave_list)
+            self.blue_limit = float(np.min(self.wave_list))
+            self.red_limit = float(np.max(self.wave_list))
         else:
             self.blue_limit = None
             self.red_limit = None

--- a/src/RealGalaxy.cpp
+++ b/src/RealGalaxy.cpp
@@ -77,7 +77,6 @@ namespace galsim
         */
 
         int npix = nkx * nky;
-        int npsf = nsed * nband;
         int nsedsq = nsed * nsed;
         tmv::Matrix<std::complex<double> > A(nband, nsed);
         tmv::Vector<std::complex<double> > b(nband);

--- a/tests/test_sed.py
+++ b/tests/test_sed.py
@@ -22,6 +22,7 @@ import numpy as np
 from galsim_test_helpers import timer, do_pickle, all_obj_diff
 import sys
 from astropy import units
+from astropy import constants
 
 try:
     import galsim
@@ -38,8 +39,8 @@ sedpath = os.path.join(galsim.meta_data.share_dir, "SEDs")
 def test_SED_basic():
     """Basic tests of SED functionality
     """
-    c = 2.99792458e17  # speed of light in nm/s
-    h = 6.62606957e-27 # Planck's constant in erg seconds
+    c = constants.c.to('nm / s').value # speed of light
+    h = constants.h.to('erg s').value # Plank's constant
     nm_w = np.arange(10,1002,10)
     A_w = np.arange(100,10002,100)
 


### PR DESCRIPTION
1. Don't use `np.moveaxis` if it doesn't exist.  I think the workaround (using two `swapaxes` calls) may be equally efficient, but I'm not sure, so I left in the `moveaxis` version to use when possible and only do the workaround if necessary.

2. I was getting a failure in the test of the `retry_io` feature.  It worked fine when running `python test_config_output.py` or `nosetests`, but not `scons tests` which runs nosetests in multiprocessing mode.  I still don't completely understand why it was not working properly, but I switched the test to setup the rng more like how we normally do things in config, using `galsim.config.GetRNG` rather than using a local variable.  That made it work, so I don't think there is any bug in the backend code.  Just the test seems to have been a bit fragile.