### PR TITLE
- add the real second moments into the result data structure

### DIFF
--- a/galsim/hsm.py
+++ b/galsim/hsm.py
@@ -152,6 +152,9 @@ class ShapeData(object):
             self.moments_amp = data.moments_amp
             self.moments_centroid = data.moments_centroid
             self.moments_rho4 = data.moments_rho4
+            self.moments_m_xx = data.moments_m_xx
+            self.moments_m_yy = data.moments_m_yy
+            self.moments_m_xy = data.moments_m_xy
             self.moments_n_iter = data.moments_n_iter
             self.correction_status = data.correction_status
             self.corrected_e1 = data.corrected_e1
@@ -177,6 +180,9 @@ class ShapeData(object):
             self.moments_amp = -1.0
             self.moments_centroid = _galsim.PositionD()
             self.moments_rho4 = -1.0
+            self.moments_m_xx = -1.0
+            self.moments_m_yy = -1.0
+            self.moments_m_xy = -1.0
             self.moments_n_iter = 0
             self.correction_status = -1
             self.corrected_e1 = -10.
@@ -198,6 +204,9 @@ class ShapeData(object):
         self.moments_amp = kwargs.pop('moments_amp', self.moments_amp)
         self.moments_centroid = kwargs.pop('moments_centroid', self.moments_centroid)
         self.moments_rho4 = kwargs.pop('moments_rho4', self.moments_rho4)
+        self.moments_m_xx = kwargs.pop('moments_m_xx', self.moments_m_xx)
+        self.moments_m_yy = kwargs.pop('moments_m_yy', self.moments_m_yy)
+        self.moments_m_xy = kwargs.pop('moments_m_xy', self.moments_m_xy)
         self.moments_n_iter = kwargs.pop('moments_n_iter', self.moments_n_iter)
         self.correction_status = kwargs.pop('correction_status', self.correction_status)
         self.corrected_e1 = kwargs.pop('corrected_e1', self.corrected_e1)
@@ -226,6 +235,9 @@ class ShapeData(object):
         if self.moments_centroid != galsim.PositionD():
             s += ', moments_centroid=%r'%self.moments_centroid
         if self.moments_rho4 != -1: s += ', moments_rho4=%r'%self.moments_rho4
+        if self.moments_m_xx != -1: s += ', moments_m_xx=%r'%self.moments_m_xx
+        if self.moments_m_yy != -1: s += ', moments_m_yy=%r'%self.moments_m_yy
+        if self.moments_m_xy != -1: s += ', moments_m_xy=%r'%self.moments_m_xy
         if self.moments_n_iter != 0: s += ', moments_n_iter=%r'%self.moments_n_iter
         if self.correction_status != -1: s += ', correction_status=%r'%self.correction_status
         if self.corrected_e1 != -10.: s += ', corrected_e1=%r'%self.corrected_e1
@@ -251,6 +263,7 @@ class ShapeData(object):
 _galsim.CppShapeData.__getinitargs__ = lambda self: (
         self.image_bounds, self.moments_status, self.observed_e1, self.observed_e2,
         self.moments_sigma, self.moments_amp, self.moments_centroid, self.moments_rho4,
+        self.moments_m_xx, self.moments_m_yy, self.moments_m_xy,
         self.moments_n_iter, self.correction_status, self.corrected_e1, self.corrected_e2,
         self.corrected_g1, self.corrected_g2, self.meas_type, self.corrected_shape_err,
         self.correction_method, self.resolution_factor, self.psf_sigma,

--- a/include/galsim/hsm/PSFCorr.h
+++ b/include/galsim/hsm/PSFCorr.h
@@ -311,6 +311,15 @@ namespace hsm {
         /// @brief The weighted radial fourth moment of the image
         double moments_rho4;
 
+        /// @brief The second moment M_xx of the image
+        double moments_m_xx;
+
+        /// @brief The second moment M_yy of the image
+        double moments_m_yy;
+
+        /// @brief The second moment M_xy of the image
+        double moments_m_xy;
+
         /// @brief Number of iterations needed to get adaptive moments; 0 if not measured
         int moments_n_iter;
 
@@ -367,7 +376,8 @@ namespace hsm {
         // cf. http://stackoverflow.com/questions/4697859/mac-os-x-and-static-boost-libs-stdstring-fail
         CppShapeData() : image_bounds(galsim::Bounds<int>()), moments_status(-1),
             observed_e1(0.), observed_e2(0.), moments_sigma(-1.), moments_amp(-1.),
-            moments_centroid(galsim::Position<double>(0.,0.)), moments_rho4(-1.), moments_n_iter(0),
+            moments_centroid(galsim::Position<double>(0.,0.)), moments_rho4(-1.),
+            moments_m_xx(0.), moments_m_yy(0.), moments_m_xy(0.), moments_n_iter(0),
             correction_status(-1), corrected_e1(-10.), corrected_e2(-10.), corrected_g1(-10.),
             corrected_g2(-10.), meas_type("None"), corrected_shape_err(-1.),
             correction_method("None"), resolution_factor(-1.),

--- a/pysrc/HSM.cpp
+++ b/pysrc/HSM.cpp
@@ -19,7 +19,7 @@
 
 #include "galsim/IgnoreWarnings.h"
 
-#define BOOST_PYTHON_MAX_ARITY 22  // We have a function with 21 params here...
+#define BOOST_PYTHON_MAX_ARITY 25  // We have a function with 21 params here...
                                    // c.f. www.boost.org/libs/python/doc/v2/configuration.html
 
 #define BOOST_NO_CXX11_SMART_PTR
@@ -168,7 +168,11 @@ struct PyShapeData {
         float observed_e1, float observed_e2,
         float moments_sigma, float moments_amp,
         const galsim::Position<double>& moments_centroid,
-        double moments_rho4, int moments_n_iter,
+        double moments_rho4,
+        double moments_m_xx,
+        double moments_m_yy,
+        double moments_m_xy,
+        int moments_n_iter,
         int correction_status, float corrected_e1, float corrected_e2,
         float corrected_g1, float corrected_g2, std::string meas_type,
         float corrected_shape_err, std::string correction_method,
@@ -184,6 +188,9 @@ struct PyShapeData {
         data->moments_amp = moments_amp;
         data->moments_centroid = moments_centroid;
         data->moments_rho4 = moments_rho4;
+        data->moments_m_xx = moments_m_xx;
+        data->moments_m_yy = moments_m_yy;
+        data->moments_m_xy = moments_m_xy;
         data->moments_n_iter = moments_n_iter;
         data->correction_status = correction_status;
         data->corrected_e1 = corrected_e1;
@@ -239,7 +246,11 @@ struct PyShapeData {
                          bp::arg("observed_e1"), bp::arg("observed_e2"),
                          bp::arg("moments_sigma"), bp::arg("moments_amp"),
                          bp::arg("moments_centroid"),
-                         bp::arg("moments_rho4"), bp::arg("moments_n_iter"),
+                         bp::arg("moments_rho4"),
+                         bp::arg("moments_m_xx"),
+                         bp::arg("moments_m_yy"),
+                         bp::arg("moments_m_xy"),
+                         bp::arg("moments_n_iter"),
                          bp::arg("correction_status"),
                          bp::arg("corrected_e1"), bp::arg("corrected_e2"),
                          bp::arg("corrected_g1"), bp::arg("corrected_g2"), bp::arg("meas_type"),
@@ -257,6 +268,9 @@ struct PyShapeData {
             .def_readonly("moments_amp", &CppShapeData::moments_amp)
             .def_readonly("moments_centroid", &CppShapeData::moments_centroid)
             .def_readonly("moments_rho4", &CppShapeData::moments_rho4)
+            .def_readonly("moments_m_xx", &CppShapeData::moments_m_xx)
+            .def_readonly("moments_m_yy", &CppShapeData::moments_m_yy)
+            .def_readonly("moments_m_xy", &CppShapeData::moments_m_xy)
             .def_readonly("moments_n_iter", &CppShapeData::moments_n_iter)
             .def_readonly("correction_status", &CppShapeData::correction_status)
             .def_readonly("corrected_e1", &CppShapeData::corrected_e1)

--- a/src/hsm/PSFCorr.cpp
+++ b/src/hsm/PSFCorr.cpp
@@ -161,6 +161,9 @@ namespace hsm {
         results.moments_sigma = std::pow(m_xx*m_yy-m_xy*m_xy, 0.25);
         results.observed_e1 = (m_xx-m_yy) / (m_xx+m_yy);
         results.observed_e2 = 2.*m_xy / (m_xx+m_yy);
+        results.moments_m_xx = m_xx;
+        results.moments_m_yy = m_yy;
+        results.moments_m_xy = m_xy;
         results.moments_status = 0;
 
         // and if that worked, try doing PSF correction
@@ -256,6 +259,9 @@ namespace hsm {
             results.moments_sigma = std::pow(m_xx*m_yy-m_xy*m_xy, 0.25);
             results.observed_e1 = (m_xx-m_yy) / (m_xx+m_yy);
             results.observed_e2 = 2.*m_xy / (m_xx+m_yy);
+            results.moments_m_xx = m_xx;
+            results.moments_m_yy = m_yy;
+            results.moments_m_xy = m_xy;
             results.moments_status = 0;
         }
         catch (char *err_msg) {
@@ -264,6 +270,9 @@ namespace hsm {
             results.moments_centroid.x = 0.0;
             results.moments_centroid.y = 0.0;
             results.moments_rho4 = -1.0;
+            results.moments_m_xx = 0.0;
+            results.moments_m_yy = 0.0;
+            results.moments_m_xy = 0.0;
             results.moments_n_iter = 0;
             dbg<<"Caught an error: "<<err_msg<<std::endl;
             throw HSMError(err_msg);
@@ -1849,6 +1858,6 @@ namespace hsm {
         const BaseImage<int>& object_image, const BaseImage<int> &object_mask_image,
         double guess_sig, double precision, galsim::Position<double> guess_centroid,
         boost::shared_ptr<HSMParams> hsmparams);
-        
+
 }
 }


### PR DESCRIPTION
Hi, for some further analysis we need to have the measured 2nd order moments directly in the results structure instead of the calculated values for e1 and e2.  I simply add the m_xx, m_yy and m_xy values to the CppShape structures. Hopefully you can merge these changes in the main code! 

Cheers,
        Oliver