### PR TITLE
Permit zero-flux drawPhot

### DIFF
--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -1725,6 +1725,8 @@ class GSObject(object):
         #
 
         flux = self.SBProfile.getFlux()
+        if flux == 0.0:
+            return 0, 1.0
         posflux = self.SBProfile.getPositiveFlux()
         negflux = self.SBProfile.getNegativeFlux()
         eta = negflux / (posflux + negflux)

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -1012,7 +1012,7 @@ def test_shoot():
 
     # Test that shooting with 0.0 flux makes a zero-photons image.
     image4 = (obj*0).drawImage(method='phot')
-    np.testing.assert_equal(image4.array, image4.array*0)
+    np.testing.assert_equal(image4.array, 0)
 
 
 @timer

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -1010,6 +1010,10 @@ def test_shoot():
     # It's not exactly the same, since the rngs are realized in a different order.
     np.testing.assert_allclose(image3.array, image1.array, rtol=0.25)
 
+    # Test that shooting with 0.0 flux makes a zero-photons image.
+    image4 = (obj*0).drawImage(method='phot')
+    np.testing.assert_equal(image4.array, image4.array*0)
+
 
 @timer
 def test_drawImage_area_exptime():


### PR DESCRIPTION
I think drawing a zero-flux object with photon shooting should just return a 0 photon image.  This comes up occasionally when photon-shooting chromatic objects, where `sed(w)*bandpass(w)` can sometimes be zero at one of the sampled wavelengths.  (Photon-shooting chromatic objects doesn't quite work yet, but I've started thinking about it...)

This PR is just to avoid the divide-by-zero error currently encountered on master when photon-shooting a zero-flux object.