### PR TITLE
Refactored image integrators to use less RAM.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ API Changes
   If you want a view, you should use the more intuitive image.view().  (#873)
 - Changed behaviour of the `preload` option in RealGalaxyCatalog and
   COSMOSCatalog to preload data in memory, not just the fits HDUs (#884)
+- Changed the type of acceptable integration rules for
+  galsim.integ.ImageIntegrator subclasses.  This should be transparent if you
+  have been using strings to specify integrators for chromatic object
+  drawImage.  (#887).
 
 
 Dependency Changes

--- a/tests/test_chromatic.py
+++ b/tests/test_chromatic.py
@@ -164,7 +164,7 @@ def test_draw_add_commutativity():
     chromatic_kimage = galsim.ImageCD(stamp_size, stamp_size, scale=pixel_scale)
     # use chromatic parent class to draw without ChromaticConvolution acceleration...
     t4 = time.time()
-    integrator = galsim.integ.ContinuousIntegrator(galsim.integ.midpt, N=N, use_endpoints=False)
+    integrator = galsim.integ.ContinuousIntegrator(galsim.integ.midptRule, N=N, use_endpoints=False)
     # NB. You cannot use ChromaticObject.drawImage() here, since it will automatically farm out to
     #     the ChromaticConvolution version of drawImage rather than respecting the
     #     ChromaticObject specification.  Using super() doesn't seem to work either.  So I just
@@ -178,6 +178,20 @@ def test_draw_add_commutativity():
     t5 = time.time()
     print('ChromaticObject drawImage, drawKImage took {0} seconds.'.format(t5-t4))
     # plotme(chromatic_image)
+
+    # Check error handling of too few sample points
+    try:
+        integrator = galsim.integ.ContinuousIntegrator(galsim.integ.midptRule, N=1,
+                                                       use_endpoints=False)
+        np.testing.assert_raises(ValueError, chromatic_final.drawImage, bandpass,
+                                 integrator=integrator)
+        integrator = galsim.integ.ContinuousIntegrator(galsim.integ.trapzRule, N=1,
+                                                       use_endpoints=False)
+        np.testing.assert_raises(ValueError, chromatic_final.drawImage, bandpass,
+                                 integrator=integrator)
+    except ImportError:
+        print("The assert_raises tests require nose")
+
 
     peak = chromatic_image.array.max()
     printval(GS_image, chromatic_image)


### PR DESCRIPTION
I modified the code that integrates `ChromaticObject`s over wavelength so that it accumulates monochromatic images into a result image as it iterates over wavelengths instead of storing all of the monochromatic images in memory before adding them together.  For my test script below, memory usage decreased from ~1.7GB to ~0.1GB.

```python
import galsim
sed = galsim.SED("CWW_E_ext.sed", wave_type="A", flux_type="flambda")
bandpass = galsim.Bandpass("LSST_r.dat", wave_type="nm")
obj = galsim.Gaussian(fwhm=0.1)+galsim.Gaussian(fwhm=10.0)
obj = galsim.ChromaticObject(obj).dilate(lambda w: (w/500)**1.05)*sed
image = obj.drawImage(bandpass)
```