### PR TITLE
Use char * rather than std::string in C++ interfaces

### DIFF
--- a/include/galsim/Noise.h
+++ b/include/galsim/Noise.h
@@ -50,7 +50,7 @@ namespace galsim {
          * @param[in] rng   The BaseDeviate to use for the random number generation.
          */
         BaseNoise(boost::shared_ptr<BaseDeviate> rng) : _rng(rng)
-        { if (!_rng) _rng.reset(new BaseDeviate(0)); }
+        { if (!_rng) _rng.reset(new BaseDeviate( (long)0)); }
 
         /**
          * @brief Copy constructor shares the underlying rng.

--- a/include/galsim/Random.h
+++ b/include/galsim/Random.h
@@ -132,8 +132,14 @@ namespace galsim {
         /**
          * @brief Construct a new BaseDeviate from a serialization string
          */
-        BaseDeviate(const std::string& str) : _rng(new rng_type())
+        BaseDeviate(const char * str_c) : _rng(new rng_type())
         {
+            std::string str;
+            if (str_c==NULL) {
+                str="";
+            } else {
+                str=str_c;
+            }
             std::istringstream iss(str);
             iss >> *_rng;
         }
@@ -162,7 +168,7 @@ namespace galsim {
          * Both this and the returned duplicate will produce identical sequences of values.
          */
         BaseDeviate duplicate()
-        { return BaseDeviate(serialize()); }
+        { return BaseDeviate(serialize().c_str()); }
 
         /**
          * @brief Return a string that can act as the repr in python
@@ -294,7 +300,7 @@ namespace galsim {
         UniformDeviate(const UniformDeviate& rhs) : BaseDeviate(rhs), _urd(0.,1.) {}
 
         /// @brief Construct a new UniformDeviate from a serialization string
-        UniformDeviate(const std::string& str) : BaseDeviate(str), _urd(0.,1.) {}
+        UniformDeviate(const char* str_c) : BaseDeviate(str_c), _urd(0.,1.) {}
 
         /**
          * @brief Construct a duplicate of this UniformDeviate object.
@@ -302,7 +308,7 @@ namespace galsim {
          * Both this and the returned duplicate will produce identical sequences of values.
          */
         UniformDeviate duplicate()
-        { return UniformDeviate(serialize()); }
+        { return UniformDeviate(serialize().c_str()); }
 
         /**
          * @brief Clear the internal cache
@@ -358,8 +364,8 @@ namespace galsim {
         GaussianDeviate(const GaussianDeviate& rhs) : BaseDeviate(rhs), _normal(rhs._normal) {}
 
         /// @brief Construct a new GaussianDeviate from a serialization string
-        GaussianDeviate(const std::string& str, double mean, double sigma) :
-            BaseDeviate(str), _normal(mean,sigma) {}
+        GaussianDeviate(const char* str_c, double mean, double sigma) :
+            BaseDeviate(str_c), _normal(mean,sigma) {}
 
         /**
          * @brief Construct a duplicate of this GaussianDeviate object.
@@ -367,7 +373,7 @@ namespace galsim {
          * Both this and the returned duplicate will produce identical sequences of values.
          */
         GaussianDeviate duplicate()
-        { return GaussianDeviate(serialize(),getMean(),getSigma()); }
+        { return GaussianDeviate(serialize().c_str(),getMean(),getSigma()); }
 
         /**
          * @brief Get current distribution mean
@@ -456,7 +462,7 @@ namespace galsim {
         BinomialDeviate(const BinomialDeviate& rhs) : BaseDeviate(rhs), _bd(rhs._bd) {}
 
         /// @brief Construct a new BinomialDeviate from a serialization string
-        BinomialDeviate(const std::string& str, int N, double p) : BaseDeviate(str), _bd(N,p) {}
+        BinomialDeviate(const char* str_c, int N, double p) : BaseDeviate(str_c), _bd(N,p) {}
 
         /**
          * @brief Construct a duplicate of this BinomialDeviate object.
@@ -464,7 +470,7 @@ namespace galsim {
          * Both this and the returned duplicate will produce identical sequences of values.
          */
         BinomialDeviate duplicate()
-        { return BinomialDeviate(serialize(),getN(),getP()); }
+        { return BinomialDeviate(serialize().c_str(),getN(),getP()); }
 
         /**
          * @brief Report current value of N
@@ -553,8 +559,8 @@ namespace galsim {
             BaseDeviate(rhs), _getValue(rhs._getValue), _pd(rhs._pd), _gd(rhs._gd) {}
 
         /// @brief Construct a new PoissonDeviate from a serialization string
-        PoissonDeviate(const std::string& str, double mean) :
-            BaseDeviate(str), _getValue(&PoissonDeviate::getPDValue)
+        PoissonDeviate(const char* str_c, double mean) :
+            BaseDeviate(str_c), _getValue(&PoissonDeviate::getPDValue)
         { setMean(mean); }
 
         /**
@@ -563,7 +569,7 @@ namespace galsim {
          * Both this and the returned duplicate will produce identical sequences of values.
          */
         PoissonDeviate duplicate()
-        { return PoissonDeviate(serialize(),getMean()); }
+        { return PoissonDeviate(serialize().c_str(),getMean()); }
 
         /**
          * @brief Report current distribution mean
@@ -648,8 +654,8 @@ namespace galsim {
         WeibullDeviate(const WeibullDeviate& rhs) : BaseDeviate(rhs), _weibull(rhs._weibull) {}
 
         /// @brief Construct a new WeibullDeviate from a serialization string
-        WeibullDeviate(const std::string& str, double a, double b) :
-            BaseDeviate(str), _weibull(a,b) {}
+        WeibullDeviate(const char* str_c, double a, double b) :
+            BaseDeviate(str_c), _weibull(a,b) {}
 
         /**
          * @brief Construct a duplicate of this WeibullDeviate object.
@@ -657,7 +663,7 @@ namespace galsim {
          * Both this and the returned duplicate will produce identical sequences of values.
          */
         WeibullDeviate duplicate()
-        { return WeibullDeviate(serialize(),getA(),getB()); }
+        { return WeibullDeviate(serialize().c_str(),getA(),getB()); }
 
         /**
          * @brief Get current distribution shape parameter a.
@@ -751,8 +757,8 @@ namespace galsim {
         GammaDeviate(const GammaDeviate& rhs) : BaseDeviate(rhs), _gamma(rhs._gamma) {}
 
         /// @brief Construct a new GammaDeviate from a serialization string
-        GammaDeviate(const std::string& str, double k, double theta) :
-            BaseDeviate(str), _gamma(k,theta) {}
+        GammaDeviate(const char* str_c, double k, double theta) :
+            BaseDeviate(str_c), _gamma(k,theta) {}
 
         /**
          * @brief Construct a duplicate of this GammaDeviate object.
@@ -760,7 +766,7 @@ namespace galsim {
          * Both this and the returned duplicate will produce identical sequences of values.
          */
         GammaDeviate duplicate()
-        { return GammaDeviate(serialize(),getK(),getTheta()); }
+        { return GammaDeviate(serialize().c_str(),getK(),getTheta()); }
 
         /**
          * @brief Get current distribution shape parameter k.
@@ -852,7 +858,7 @@ namespace galsim {
         Chi2Deviate(const Chi2Deviate& rhs) : BaseDeviate(rhs), _chi_squared(rhs._chi_squared) {}
 
         /// @brief Construct a new Chi2Deviate from a serialization string
-        Chi2Deviate(const std::string& str, double n) : BaseDeviate(str), _chi_squared(n) {}
+        Chi2Deviate(const char* str_c, double n) : BaseDeviate(str_c), _chi_squared(n) {}
 
         /**
          * @brief Construct a duplicate of this Chi2Deviate object.
@@ -860,7 +866,7 @@ namespace galsim {
          * Both this and the returned duplicate will produce identical sequences of values.
          */
         Chi2Deviate duplicate()
-        { return Chi2Deviate(serialize(),getN()); }
+        { return Chi2Deviate(serialize().c_str(),getN()); }
 
         /**
          * @brief Get current distribution degrees-of-freedom parameter n.

--- a/include/galsim/Random.h
+++ b/include/galsim/Random.h
@@ -134,14 +134,13 @@ namespace galsim {
          */
         BaseDeviate(const char * str_c) : _rng(new rng_type())
         {
-            std::string str;
             if (str_c==NULL) {
-                str="";
+                seed(0);
             } else {
-                str=str_c;
+                std::string str=str_c;
+                std::istringstream iss(str);
+                iss >> *_rng;
             }
-            std::istringstream iss(str);
-            iss >> *_rng;
         }
 
         /**

--- a/include/galsim/hsm/PSFCorr.h
+++ b/include/galsim/hsm/PSFCorr.h
@@ -416,7 +416,7 @@ namespace hsm {
         const BaseImage<T> &gal_image, const BaseImage<U> &PSF_image,
         const BaseImage<int> &gal_mask_image,
         float sky_var = 0.0, const char *shear_est = "REGAUSS",
-        const std::string& recompute_flux = "FIT",
+        const char* recompute_flux = "FIT",
         double guess_sig_gal = 5.0, double guess_sig_PSF = 3.0, double precision = 1.0e-6,
         galsim::Position<double> guess_centroid = galsim::Position<double>(-1000.,-1000.),
         boost::shared_ptr<HSMParams> hsmparams = boost::shared_ptr<HSMParams>());
@@ -475,7 +475,7 @@ namespace hsm {
     unsigned int general_shear_estimator(
         ConstImageView<double> gal_image, ConstImageView<double> PSF_image,
         ObjectData& gal_data, ObjectData& PSF_data,
-        const std::string& shear_est, unsigned long flags,
+        const char* shear_est, unsigned long flags,
         boost::shared_ptr<HSMParams> hsmparams = boost::shared_ptr<HSMParams>());
 
     /**

--- a/pysrc/HSM.cpp
+++ b/pysrc/HSM.cpp
@@ -170,10 +170,10 @@ struct PyShapeData {
         const galsim::Position<double>& moments_centroid,
         double moments_rho4, int moments_n_iter,
         int correction_status, float corrected_e1, float corrected_e2,
-        float corrected_g1, float corrected_g2, std::string meas_type,
-        float corrected_shape_err, std::string correction_method,
+        float corrected_g1, float corrected_g2, const char* meas_type,
+        float corrected_shape_err, const char* correction_method,
         float resolution_factor, float psf_sigma,
-        float psf_e1, float psf_e2, std::string error_message)
+        float psf_e1, float psf_e2, const char* error_message)
     {
         CppShapeData* data = new CppShapeData();
         data->image_bounds = image_bounds;
@@ -215,7 +215,7 @@ struct PyShapeData {
 
         typedef CppShapeData (*ESH_func)(const BaseImage<U>&, const BaseImage<V>&,
                                          const BaseImage<int>&, float, const char *,
-                                         const std::string&, double, double, double, Position<double>,
+                                         const char*, double, double, double, Position<double>,
                                          boost::shared_ptr<HSMParams>);
         bp::def("_EstimateShearView",
                 ESH_func(&EstimateShearView),

--- a/pysrc/Interpolant.cpp
+++ b/pysrc/Interpolant.cpp
@@ -31,8 +31,10 @@ namespace galsim {
     struct PyInterpolant
     {
 
-        static Interpolant* ConstructInterpolant(std::string str, double tol)
+        static Interpolant* ConstructInterpolant(const char* str_c, double tol)
         {
+            std::string str = str_c;
+
             // Make it lowercase
             std::transform(str.begin(), str.end(), str.begin(), ::tolower);
 

--- a/pysrc/Random.cpp
+++ b/pysrc/Random.cpp
@@ -133,7 +133,7 @@ namespace galsim {
         static UniformDeviate* construct(const bp::object& seed) {
             if (seed.ptr() != Py_None)
                 throw std::runtime_error("Cannot construct UniformDeviate from given seed.");
-            return new UniformDeviate(0);
+            return new UniformDeviate( (long)0);
         }
 
         static void wrap() {
@@ -158,7 +158,7 @@ namespace galsim {
         static GaussianDeviate* construct(const bp::object& seed, double mean, double sigma) {
             if (seed.ptr() != Py_None)
                 throw std::runtime_error("Cannot construct GaussianDeviate from given seed.");
-            return new GaussianDeviate(0, mean, sigma);
+            return new GaussianDeviate( (long)0, mean, sigma);
         }
 
         static void wrap() {
@@ -194,7 +194,7 @@ namespace galsim {
         static BinomialDeviate* construct(const bp::object& seed, int N, double p) {
             if (seed.ptr() != Py_None)
                 throw std::runtime_error("Cannot construct BinomialDeviate from given seed.");
-            return new BinomialDeviate(0, N, p);
+            return new BinomialDeviate( (long)0, N, p);
         }
 
         static void wrap() {
@@ -230,7 +230,7 @@ namespace galsim {
         static PoissonDeviate* construct(const bp::object& seed, double mean) {
             if (seed.ptr() != Py_None)
                 throw std::runtime_error("Cannot construct PoissonDeviate from given seed.");
-            return new PoissonDeviate(0, mean);
+            return new PoissonDeviate( (long)0, mean);
         }
 
         static void wrap() {
@@ -264,7 +264,7 @@ namespace galsim {
         static WeibullDeviate* construct(const bp::object& seed, double a, double b) {
             if (seed.ptr() != Py_None)
                 throw std::runtime_error("Cannot construct WeibullDeviate from given seed.");
-            return new WeibullDeviate(0, a, b);
+            return new WeibullDeviate( (long)0, a, b);
         }
 
         static void wrap() {
@@ -301,7 +301,7 @@ namespace galsim {
         static GammaDeviate* construct(const bp::object& seed, double k, double theta) {
             if (seed.ptr() != Py_None)
                 throw std::runtime_error("Cannot construct GammaDeviate from given seed.");
-            return new GammaDeviate(0, k, theta);
+            return new GammaDeviate( (long)0, k, theta);
         }
 
         static void wrap() {
@@ -337,7 +337,7 @@ namespace galsim {
         static Chi2Deviate* construct(const bp::object& seed, double n) {
             if (seed.ptr() != Py_None)
                 throw std::runtime_error("Cannot construct Chi2Deviate from given seed.");
-            return new Chi2Deviate(0, n);
+            return new Chi2Deviate( (long)0, n);
         }
 
         static void wrap() {

--- a/pysrc/Random.cpp
+++ b/pysrc/Random.cpp
@@ -40,7 +40,7 @@ namespace galsim {
     public:
         BaseDeviateCallBack(long lseed=0) : BaseDeviate(lseed) {}
         BaseDeviateCallBack(const BaseDeviate& rhs) : BaseDeviate(rhs) {}
-        BaseDeviateCallBack(std::string& str) : BaseDeviate(str) {}
+        BaseDeviateCallBack(const char * str) : BaseDeviate(str) {}
         ~BaseDeviateCallBack() {}
 
     protected:
@@ -72,7 +72,7 @@ namespace galsim {
         static BaseDeviateCallBack* construct(const bp::object& seed) {
             if (seed.ptr() != Py_None)
                 throw std::runtime_error("Cannot construct BaseDeviate from given seed.");
-            return new BaseDeviateCallBack(0);
+            return new BaseDeviateCallBack( (long)0);
         }
 
         static void wrap() {
@@ -83,7 +83,7 @@ namespace galsim {
                     &construct, bp::default_call_policies(), (bp::arg("seed"))))
                 .def(bp::init<long>(bp::arg("seed")=0))
                 .def(bp::init<const BaseDeviate&>(bp::arg("seed")))
-                .def(bp::init<std::string>(bp::arg("seed")))
+                .def(bp::init<const char *>(bp::arg("seed")))
                 .def("seed", (void (BaseDeviate::*) (long) )&BaseDeviate::seed,
                      (bp::arg("seed")=0))
                 .def("reset", (void (BaseDeviate::*) (long) )&BaseDeviate::reset,
@@ -144,7 +144,7 @@ namespace galsim {
                     &construct, bp::default_call_policies(), (bp::arg("seed"))))
                 .def(bp::init<long>(bp::arg("seed")=0))
                 .def(bp::init<const BaseDeviate&>(bp::arg("seed")))
-                .def(bp::init<std::string>(bp::arg("seed")))
+                .def(bp::init<const char *>(bp::arg("seed")))
                 .def("duplicate", &UniformDeviate::duplicate)
                 .def("__call__", &UniformDeviate::operator())
                 .enable_pickling()
@@ -174,7 +174,7 @@ namespace galsim {
                 .def(bp::init<const BaseDeviate&, double, double>(
                         (bp::arg("seed"), bp::arg("mean")=0., bp::arg("sigma")=1.)
                 ))
-                .def(bp::init<std::string, double, double>(
+                .def(bp::init<const char *, double, double>(
                         (bp::arg("seed"), bp::arg("mean")=0., bp::arg("sigma")=1.)
                 ))
                 .def("duplicate", &GaussianDeviate::duplicate)
@@ -210,7 +210,7 @@ namespace galsim {
                 .def(bp::init<const BaseDeviate&, int, double>(
                         (bp::arg("seed"), bp::arg("N")=1, bp::arg("p")=0.5)
                 ))
-                .def(bp::init<std::string, int, double>(
+                .def(bp::init<const char *, int, double>(
                         (bp::arg("seed")=0, bp::arg("N")=1, bp::arg("p")=0.5)
                 ))
                 .def("duplicate", &BinomialDeviate::duplicate)
@@ -246,7 +246,7 @@ namespace galsim {
                 .def(bp::init<const BaseDeviate&, double>(
                         (bp::arg("seed"), bp::arg("mean")=1.)
                 ))
-                .def(bp::init<std::string, double>(
+                .def(bp::init<const char *, double>(
                         (bp::arg("seed")=0, bp::arg("mean")=1.)
                 ))
                 .def("duplicate", &PoissonDeviate::duplicate)
@@ -281,7 +281,7 @@ namespace galsim {
                 .def(bp::init<const BaseDeviate&, double, double>(
                         (bp::arg("seed"), bp::arg("a")=1., bp::arg("b")=1.)
                 ))
-                .def(bp::init<std::string, double, double>(
+                .def(bp::init<const char *, double, double>(
                         (bp::arg("seed")=0, bp::arg("a")=1., bp::arg("b")=1.)
                 ))
                 .def("duplicate", &WeibullDeviate::duplicate)
@@ -317,7 +317,7 @@ namespace galsim {
                 .def(bp::init<const BaseDeviate&, double, double>(
                         (bp::arg("seed"), bp::arg("k")=1., bp::arg("theta")=1.)
                 ))
-                .def(bp::init<std::string, double, double>(
+                .def(bp::init<const char *, double, double>(
                         (bp::arg("seed")=0, bp::arg("k")=1., bp::arg("theta")=1.)
                 ))
                 .def("duplicate", &GammaDeviate::duplicate)
@@ -353,7 +353,7 @@ namespace galsim {
                 .def(bp::init<const BaseDeviate&, double>(
                         (bp::arg("seed"), bp::arg("n")=1.)
                 ))
-                .def(bp::init<std::string, double>(
+                .def(bp::init<const char *, double>(
                         (bp::arg("seed")=0, bp::arg("n")=1.)
                 ))
                 .def("duplicate", &Chi2Deviate::duplicate)

--- a/pysrc/Table.cpp
+++ b/pysrc/Table.cpp
@@ -153,8 +153,11 @@ namespace {
     struct PyTable2D{
         static Table2D<double, double>* makeTable2D(
             const bp::object& x, const bp::object& y, const bp::object& f,
-            const std::string& interp)
+            const char* interp_c)
         {
+
+            const std::string interp = interp_c;
+
             const int Nx = GetNumpyArrayDim(f.ptr(), 0);
             const int Ny = GetNumpyArrayDim(f.ptr(), 1);
             const int Nx2 = GetNumpyArrayDim(x.ptr(), 0);

--- a/pysrc/Table.cpp
+++ b/pysrc/Table.cpp
@@ -35,8 +35,11 @@ namespace {
     struct PyTable {
 
         static Table<double,double>* makeTable(
-            const bp::object& args, const bp::object& vals, const std::string& interp)
+            const bp::object& args, const bp::object& vals, const char * interp_c)
         {
+
+            const std::string interp = interp_c;
+
             std::vector<double> vargs, vvals;
             try {
                 bp::stl_input_iterator<double> args_it(args);

--- a/src/hsm/PSFCorr.cpp
+++ b/src/hsm/PSFCorr.cpp
@@ -59,7 +59,7 @@ namespace hsm {
 
     unsigned int general_shear_estimator(
         ConstImageView<double> gal_image, ConstImageView<double> PSF_image,
-        ObjectData& gal_data, ObjectData& PSF_data, const std::string& shear_est,
+        ObjectData& gal_data, ObjectData& PSF_data, const char* shear_est_c,
         unsigned long flags, boost::shared_ptr<HSMParams> hsmparams);
 
     void find_ellipmom_2(
@@ -96,7 +96,7 @@ namespace hsm {
     CppShapeData EstimateShearView(
         const BaseImage<T>& gal_image, const BaseImage<U>& PSF_image,
         const BaseImage<int>& gal_mask_image,
-        float sky_var, const char* shear_est, const std::string& recompute_flux,
+        float sky_var, const char* shear_est, const char* recompute_flux_c,
         double guess_sig_gal, double guess_sig_PSF,
         double precision, galsim::Position<double> guess_centroid,
         boost::shared_ptr<HSMParams> hsmparams)
@@ -106,6 +106,8 @@ namespace hsm {
         ObjectData gal_data, PSF_data;
         double amp, m_xx, m_xy, m_yy;
         unsigned long flags=0;
+
+        const std::string recompute_flux = recompute_flux_c;
 
         if (!hsmparams.get()) hsmparams = hsm::default_hsmparams;
 
@@ -1720,7 +1722,7 @@ namespace hsm {
 
     unsigned int general_shear_estimator(
         ConstImageView<double> gal_image, ConstImageView<double> PSF_image,
-        ObjectData& gal_data, ObjectData& PSF_data, const std::string& shear_est,
+        ObjectData& gal_data, ObjectData& PSF_data, const char* shear_est_c,
         unsigned long flags, boost::shared_ptr<HSMParams> hsmparams)
     {
         unsigned int status = 0;
@@ -1728,6 +1730,8 @@ namespace hsm {
         double x0, y0, R;
         double A_gal, Mxx_gal, Mxy_gal, Myy_gal, rho4_gal;
         double A_psf, Mxx_psf, Mxy_psf, Myy_psf, rho4_psf;
+
+        const std::string shear_est = shear_est_c;
 
         if (shear_est == "BJ" || shear_est == "LINEAR" || shear_est == "KSB") {
             /* Measure the PSF so its size and shape can get propagated up to python layer */
@@ -1815,25 +1819,25 @@ namespace hsm {
     template CppShapeData EstimateShearView(
         const BaseImage<float>& gal_image, const BaseImage<float>& PSF_image,
         const BaseImage<int>& gal_mask_image,
-        float sky_var, const char* shear_est, const std::string& recompute_flux,
+        float sky_var, const char* shear_est, const char* recompute_flux,
         double guess_sig_gal, double guess_sig_PSF, double precision,
         galsim::Position<double> guess_centroid, boost::shared_ptr<HSMParams> hsmparams);
     template CppShapeData EstimateShearView(
         const BaseImage<double>& gal_image, const BaseImage<double>& PSF_image,
         const BaseImage<int>& gal_mask_image,
-        float sky_var, const char* shear_est, const std::string& recompute_flux,
+        float sky_var, const char* shear_est, const char* recompute_flux,
         double guess_sig_gal, double guess_sig_PSF, double precision,
         galsim::Position<double> guess_centroid, boost::shared_ptr<HSMParams> hsmparams);
     template CppShapeData EstimateShearView(
         const BaseImage<float>& gal_image, const BaseImage<double>& PSF_image,
         const BaseImage<int>& gal_mask_image,
-        float sky_var, const char* shear_est, const std::string& recompute_flux,
+        float sky_var, const char* shear_est, const char* recompute_flux,
         double guess_sig_gal, double guess_sig_PSF, double precision,
         galsim::Position<double> guess_centroid, boost::shared_ptr<HSMParams> hsmparams);
     template CppShapeData EstimateShearView(
         const BaseImage<double>& gal_image, const BaseImage<float>& PSF_image,
         const BaseImage<int>& gal_mask_image,
-        float sky_var, const char* shear_est, const std::string& recompute_flux,
+        float sky_var, const char* shear_est, const char* recompute_flux,
         double guess_sig_gal, double guess_sig_PSF, double precision,
         galsim::Position<double> guess_centroid, boost::shared_ptr<HSMParams> hsmparams);
 


### PR DESCRIPTION
This addresses an incompatibility found when python/boost/numpy etc. are compiled with gcc `7.2.0` and galsim is compiled with `6.2.0`.  This is an issue for interfaces between the C++ and python generated by boost-python

With these changes the tests all pass.

I only modified the interfaces for which a test failed, I did not exhaustively change all interefaces.  There could be some not covered by tests which would still exhibit this error.