### PR TITLE
#917

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Deprecated Features
 
 New Features
 ------------
+- Use circular weight function in HSM adaptive moments code. (#917)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Deprecated Features
 
 New Features
 ------------
-- Use circular weight function in HSM adaptive moments code. (#917)
+- Add option to use circular weight function in HSM adaptive moments code. (#917)
 
 
 

--- a/galsim/hsm.py
+++ b/galsim/hsm.py
@@ -465,7 +465,7 @@ def EstimateShear(gal_image, PSF_image, weight=None, badpix=None, sky_var=0.0,
     return ShapeData(result)
 
 def FindAdaptiveMom(object_image, weight=None, badpix=None, guess_sig=5.0, precision=1.0e-6,
-                    guess_centroid=None, strict=True, hsmparams=None):
+                    guess_centroid=None, strict=True, round_moments=False, hsmparams=None):
     """Measure adaptive moments of an object.
 
     This method estimates the best-fit elliptical Gaussian to the object (see Hirata & Seljak 2003
@@ -544,6 +544,8 @@ def FindAdaptiveMom(object_image, weight=None, badpix=None, guess_sig=5.0, preci
                             `RuntimeError` exception if shear estimation fails.  If set to `False`,
                             then information about failures will be silently stored in the output
                             ShapeData object. [default: True]
+    @param round_moments    Use a circular weight function instead of elliptical.
+                            [default: False]
     @param hsmparams        The hsmparams keyword can be used to change the settings used by
                             FindAdaptiveMom when estimating moments; see HSMParams documentation
                             using help(galsim.hsm.HSMParams) for more information. [default: None]
@@ -561,6 +563,7 @@ def FindAdaptiveMom(object_image, weight=None, badpix=None, guess_sig=5.0, preci
         result = _galsim._FindAdaptiveMomView(object_image_view, weight_view,
                                               guess_sig = guess_sig, precision =  precision,
                                               guess_centroid = guess_centroid,
+                                              round_moments = round_moments,
                                               hsmparams = hsmparams)
     except RuntimeError as err:
         if (strict == True):

--- a/include/galsim/hsm/PSFCorr.h
+++ b/include/galsim/hsm/PSFCorr.h
@@ -450,6 +450,7 @@ namespace hsm {
         const BaseImage<T> &object_image, const BaseImage<int> &object_mask_image,
         double guess_sig = 5.0, double precision = 1.0e-6,
         galsim::Position<double> guess_centroid = galsim::Position<double>(-1000.,-1000.),
+        bool round_moments = false,
         boost::shared_ptr<HSMParams> hsmparams = boost::shared_ptr<HSMParams>());
 
     /**

--- a/pysrc/HSM.cpp
+++ b/pysrc/HSM.cpp
@@ -204,13 +204,13 @@ struct PyShapeData {
     template <typename U, typename V>
     static void wrapTemplates() {
         typedef CppShapeData (*FAM_func)(const BaseImage<U>&, const BaseImage<int>&,
-                                         double, double, Position<double>,
+                                         double, double, Position<double>, bool, 
                                          boost::shared_ptr<HSMParams>);
         bp::def("_FindAdaptiveMomView",
                 FAM_func(&FindAdaptiveMomView),
                 (bp::arg("object_image"), bp::arg("object_mask_image"), bp::arg("guess_sig")=5.0,
                  bp::arg("precision")=1.0e-6, bp::arg("guess_centroid")=Position<double>(0.,0.),
-                 bp::arg("hsmparams")=bp::object()),
+                 bp::arg("round_moments")=false, bp::arg("hsmparams")=bp::object()),
                 "Find adaptive moments of an image (with some optional args).");
 
         typedef CppShapeData (*ESH_func)(const BaseImage<U>&, const BaseImage<V>&,

--- a/src/hsm/PSFCorr.cpp
+++ b/src/hsm/PSFCorr.cpp
@@ -1874,5 +1874,6 @@ namespace hsm {
         const BaseImage<int>& object_image, const BaseImage<int> &object_mask_image,
         double guess_sig, double precision, galsim::Position<double> guess_centroid,
         bool round_moments, boost::shared_ptr<HSMParams> hsmparams);
+
 }
 }

--- a/src/hsm/PSFCorr.cpp
+++ b/src/hsm/PSFCorr.cpp
@@ -276,8 +276,8 @@ namespace hsm {
                   dbg<<"Repackaging find_mom_2 results"<<std::endl;
                   results.moments_amp =  3.544907701811*sig*moments(0,0);
                   results.moments_sigma = sig;
-                  results.observed_e1 = (moments(2,0)-moments(0,2)) / moments(0,0);
-                  results.observed_e2 =(1./std::sqrt(2.))*(moments(1,1)) / moments(0,0);
+                  results.observed_e1 = 0.5*(moments(2,0)-moments(0,2)) / moments(0,0);
+                  results.observed_e2 = (1./std::sqrt(2.))*(moments(1,1)) / moments(0,0);
                   results.moments_status = 0;
              }
         }

--- a/src/hsm/PSFCorr.cpp
+++ b/src/hsm/PSFCorr.cpp
@@ -270,7 +270,7 @@ namespace hsm {
                   dbg<<"About to get moments using find_mom_2"<<std::endl;
                   tmv::Matrix<double> moments(3,3);
                   double sig = guess_sig;
-                  find_mom_2(masked_object_image_cview, moments, 3,
+                  find_mom_2(masked_object_image_cview, moments, 2,
                              results.moments_centroid.x, results.moments_centroid.y, sig,
                              hsmparams->convergence_threshold, results.moments_n_iter, hsmparams);
                   dbg<<"Repackaging find_mom_2 results"<<std::endl;

--- a/src/hsm/PSFCorr.cpp
+++ b/src/hsm/PSFCorr.cpp
@@ -67,6 +67,12 @@ namespace hsm {
         double& Mxx, double& Mxy, double& Myy, double& rho4, double convergence_threshold,
         int& num_iter, boost::shared_ptr<HSMParams> hsmparams);
 
+      void find_mom_2(
+        ConstImageView<double> data,
+        tmv::Matrix<double>& moments, int max_order,
+        double& x0, double& y0, double& sigma, double convergence_threshold, int& num_iter,
+        boost::shared_ptr<HSMParams> hsmparams);
+
     // Make a masked_image based on the input image and mask.  The returned ImageView is a
     // sub-image of the given masked_image.  It is the smallest sub-image that contains all the
     // non-zero elements in the masked_image, so subsequent operations can safely use this
@@ -211,7 +217,7 @@ namespace hsm {
     CppShapeData FindAdaptiveMomView(
         const BaseImage<T>& object_image, const BaseImage<int>& object_mask_image,
         double guess_sig, double precision, galsim::Position<double> guess_centroid,
-        boost::shared_ptr<HSMParams> hsmparams)
+        bool round_moments, boost::shared_ptr<HSMParams> hsmparams)
     {
         dbg<<"Start FindAdaptiveMomView"<<std::endl;
         dbg<<"Setting defaults and so on before calling find_ellipmom_2"<<std::endl;
@@ -247,18 +253,33 @@ namespace hsm {
         // call find_ellipmom_2
         results.image_bounds = object_image.getBounds();
         try {
-            dbg<<"About to get moments using find_ellipmom_2"<<std::endl;
-            find_ellipmom_2(masked_object_image_cview, amp, results.moments_centroid.x,
-                            results.moments_centroid.y, m_xx, m_xy, m_yy, results.moments_rho4,
-                            precision, results.moments_n_iter, hsmparams);
-            dbg<<"Repackaging find_ellipmom_2 results"<<std::endl;
+             if (!round_moments) {
+                  dbg<<"About to get moments using find_ellipmom_2"<<std::endl;
+                  find_ellipmom_2(masked_object_image_cview, amp, results.moments_centroid.x,
+                                  results.moments_centroid.y, m_xx, m_xy, m_yy, results.moments_rho4,
+                                  precision, results.moments_n_iter, hsmparams);
+                  dbg<<"Repackaging find_ellipmom_2 results"<<std::endl;
 
-            // repackage outputs from find_ellipmom_2 to the output CppShapeData struct
-            results.moments_amp = 2.0*amp;
-            results.moments_sigma = std::pow(m_xx*m_yy-m_xy*m_xy, 0.25);
-            results.observed_e1 = (m_xx-m_yy) / (m_xx+m_yy);
-            results.observed_e2 = 2.*m_xy / (m_xx+m_yy);
-            results.moments_status = 0;
+                  // repackage outputs from find_ellipmom_2 to the output CppShapeData struct
+                  results.moments_amp = 2.0*amp;
+                  results.moments_sigma = std::pow(m_xx*m_yy-m_xy*m_xy, 0.25);
+                  results.observed_e1 = (m_xx-m_yy) / (m_xx+m_yy);
+                  results.observed_e2 = 2.*m_xy / (m_xx+m_yy);
+                  results.moments_status = 0;
+             } else {
+                  dbg<<"About to get moments using find_mom_2"<<std::endl;
+                  tmv::Matrix<double> moments(3,3);
+                  double sig;
+                  find_mom_2(masked_object_image_cview, moments, 3,
+                             results.moments_centroid.x, results.moments_centroid.y, sig,
+                             hsmparams->convergence_threshold, results.moments_n_iter, hsmparams);
+                  dbg<<"Repackaging find_mom_2 results"<<std::endl;
+                  results.moments_amp =  moments(0,0);
+                  results.moments_sigma = sig;
+                  results.observed_e1 = 0;
+                  results.observed_e2 = 0;
+                  results.moments_status = 0;
+             }
         }
         catch (char *err_msg) {
             results.error_message = err_msg;
@@ -1844,15 +1865,14 @@ namespace hsm {
     template CppShapeData FindAdaptiveMomView(
         const BaseImage<float>& object_image, const BaseImage<int> &object_mask_image,
         double guess_sig, double precision, galsim::Position<double> guess_centroid,
-        boost::shared_ptr<HSMParams> hsmparams);
+        bool round_moments, boost::shared_ptr<HSMParams> hsmparams);
     template CppShapeData FindAdaptiveMomView(
         const BaseImage<double>& object_image, const BaseImage<int> &object_mask_image,
         double guess_sig, double precision, galsim::Position<double> guess_centroid,
-        boost::shared_ptr<HSMParams> hsmparams);
+        bool round_moments, boost::shared_ptr<HSMParams> hsmparams);
     template CppShapeData FindAdaptiveMomView(
         const BaseImage<int>& object_image, const BaseImage<int> &object_mask_image,
         double guess_sig, double precision, galsim::Position<double> guess_centroid,
-        boost::shared_ptr<HSMParams> hsmparams);
-        
+        bool round_moments, boost::shared_ptr<HSMParams> hsmparams);
 }
 }

--- a/src/hsm/PSFCorr.cpp
+++ b/src/hsm/PSFCorr.cpp
@@ -276,8 +276,9 @@ namespace hsm {
                   dbg<<"Repackaging find_mom_2 results"<<std::endl;
                   results.moments_amp =  3.544907701811 * sig * moments(0,0);
                   results.moments_sigma = sig;
-                  results.observed_e1 = 0;
-                  results.observed_e2 = 0;
+                  std::cout<<moments<<std::endl;
+                  results.observed_e1 = (moments(2,0)-moments(0,2)) / moments(0,0);
+                  results.observed_e2 =(1./std::sqrt(2.))*(moments(1,1)) / moments(0,0);
                   results.moments_status = 0;
              }
         }

--- a/src/hsm/PSFCorr.cpp
+++ b/src/hsm/PSFCorr.cpp
@@ -274,6 +274,7 @@ namespace hsm {
                              results.moments_centroid.x, results.moments_centroid.y, sig,
                              hsmparams->convergence_threshold, results.moments_n_iter, hsmparams);
                   dbg<<"Repackaging find_mom_2 results"<<std::endl;
+                  // flux calculation taken from formula in psf_corr_ksb_1
                   results.moments_amp =  3.544907701811*sig*moments(0,0);
                   results.moments_sigma = sig;
                   results.observed_e1 = std::sqrt(2.)*0.5*(moments(2,0)-moments(0,2)) / moments(0,0);

--- a/src/hsm/PSFCorr.cpp
+++ b/src/hsm/PSFCorr.cpp
@@ -269,12 +269,12 @@ namespace hsm {
              } else {
                   dbg<<"About to get moments using find_mom_2"<<std::endl;
                   tmv::Matrix<double> moments(3,3);
-                  double sig;
+                  double sig = guess_sig;
                   find_mom_2(masked_object_image_cview, moments, 3,
                              results.moments_centroid.x, results.moments_centroid.y, sig,
                              hsmparams->convergence_threshold, results.moments_n_iter, hsmparams);
                   dbg<<"Repackaging find_mom_2 results"<<std::endl;
-                  results.moments_amp =  moments(0,0);
+                  results.moments_amp =  3.544907701811 * sig * moments(0,0);
                   results.moments_sigma = sig;
                   results.observed_e1 = 0;
                   results.observed_e2 = 0;

--- a/src/hsm/PSFCorr.cpp
+++ b/src/hsm/PSFCorr.cpp
@@ -276,8 +276,8 @@ namespace hsm {
                   dbg<<"Repackaging find_mom_2 results"<<std::endl;
                   results.moments_amp =  3.544907701811*sig*moments(0,0);
                   results.moments_sigma = sig;
-                  results.observed_e1 = 0.5*(moments(2,0)-moments(0,2)) / moments(0,0);
-                  results.observed_e2 = (1./std::sqrt(2.))*(moments(1,1)) / moments(0,0);
+                  results.observed_e1 = std::sqrt(2.)*0.5*(moments(2,0)-moments(0,2)) / moments(0,0);
+                  results.observed_e2 = (moments(1,1)) / moments(0,0);
                   results.moments_status = 0;
              }
         }

--- a/src/hsm/PSFCorr.cpp
+++ b/src/hsm/PSFCorr.cpp
@@ -274,7 +274,7 @@ namespace hsm {
                              results.moments_centroid.x, results.moments_centroid.y, sig,
                              hsmparams->convergence_threshold, results.moments_n_iter, hsmparams);
                   dbg<<"Repackaging find_mom_2 results"<<std::endl;
-                  results.moments_amp =  3.544907701811 * sig * moments(0,0);
+                  results.moments_amp =  3.544907701811*sig*moments(0,0);
                   results.moments_sigma = sig;
                   std::cout<<moments<<std::endl;
                   results.observed_e1 = (moments(2,0)-moments(0,2)) / moments(0,0);

--- a/src/hsm/PSFCorr.cpp
+++ b/src/hsm/PSFCorr.cpp
@@ -276,7 +276,6 @@ namespace hsm {
                   dbg<<"Repackaging find_mom_2 results"<<std::endl;
                   results.moments_amp =  3.544907701811*sig*moments(0,0);
                   results.moments_sigma = sig;
-                  std::cout<<moments<<std::endl;
                   results.observed_e1 = (moments(2,0)-moments(0,2)) / moments(0,0);
                   results.observed_e2 =(1./std::sqrt(2.))*(moments(1,1)) / moments(0,0);
                   results.moments_status = 0;

--- a/tests/test_hsm.py
+++ b/tests/test_hsm.py
@@ -139,6 +139,24 @@ def test_moments_basic():
                 np.testing.assert_almost_equal(result.observed_shape.e2,
                                                distortion_2, err_msg = "- incorrect e2",
                                                decimal = decimal_shape)
+
+                # test for moments with a circular weight function
+                result_round = gal_image.FindAdaptiveMom(round_moments=True)
+                q = np.exp(-2.*math.atanh(total_shear))
+                theta = 0.5*math.atan2(g2, g1)
+                e_round = (1 - q**2)/(1 + q**2 + 2*q)
+                e1_round = e_round*math.cos(2*theta)
+                e2_round = e_round*math.sin(2*theta)
+
+                np.testing.assert_almost_equal(np.fabs(result_round.moments_sigma-sig/pixel_scale), 0.0,
+                                               err_msg = "- incorrect round dsigma", decimal = decimal)
+                np.testing.assert_almost_equal(result_round.observed_shape.e1,
+                                               e1_round, err_msg = "- incorrect round e1",
+                                               decimal = decimal_shape)
+                np.testing.assert_almost_equal(result_round.observed_shape.e2,
+                                               e2_round, err_msg = "- incorrect round e2",
+                                               decimal = decimal_shape)
+
                 # if this is the first time through this loop, just make sure it runs and gives the
                 # same result for ImageView and ConstImageViews:
                 if first_test:

--- a/tests/test_hsm.py
+++ b/tests/test_hsm.py
@@ -142,6 +142,10 @@ def test_moments_basic():
 
                 # test for moments with a circular weight function
                 result_round = gal_image.FindAdaptiveMom(round_moments=True)
+
+                # The ellipticities calculated here are we expect when integrating an
+                # elliptical Gaussian light profile with a round Gaussian weight function
+                # with the same sigma.
                 q = np.exp(-2.*math.atanh(total_shear))
                 theta = 0.5*math.atan2(g2, g1)
                 e_round = (1 - q**2)/(1 + q**2 + 2*q)
@@ -149,7 +153,7 @@ def test_moments_basic():
                 e2_round = e_round*math.sin(2*theta)
 
                 np.testing.assert_almost_equal(np.fabs(result_round.moments_sigma-sig/pixel_scale), 0.0,
-                                               err_msg = "- incorrect round dsigma", decimal = decimal)
+                                               err_msg = "- incorrect round sigma", decimal = decimal)
                 np.testing.assert_almost_equal(result_round.observed_shape.e1,
                                                e1_round, err_msg = "- incorrect round e1",
                                                decimal = decimal_shape)


### PR DESCRIPTION
I've added the option to compute the HSM adaptive moments using a circular weight function.  The code to do this was already in PSFCorr.cpp, but it was not accessible to the outside.  I've added a simple argument to FindAdaptiveMom to specify if you want to use a round weight function.