### PR TITLE
#923 - documentation and minor code updates

### DIFF
--- a/galsim/wfirst/wfirst_bandpass.py
+++ b/galsim/wfirst/wfirst_bandpass.py
@@ -129,6 +129,12 @@ def getBandpasses(AB_zeropoint=True, default_thin_trunc=True, **kwargs):
         # Set the zeropoint if requested by the user:
         if AB_zeropoint:
             bp = bp.withZeropoint('AB')
+            # The zeropoint that is calculated by default is for a flux of 1 photon/cm^2/sec through
+            # the bandpass.  We want to set this for the actual WFIRST collecting area.
+            d_eff = 100. * galsim.wfirst.diameter * np.sqrt(1.-galsim.wfirst.obscuration**2)
+            area_eff = np.pi * d_eff**2
+            translation_fac = 2.5 * np.log10(area_eff)
+            bp = bp.withZeropoint(bp.zeropoint + translation_fac)
 
         # Store the sky level information as an attribute.
         bp._ecliptic_lat = ecliptic_lat

--- a/galsim/wfirst/wfirst_bandpass.py
+++ b/galsim/wfirst/wfirst_bandpass.py
@@ -50,13 +50,11 @@ def getBandpasses(AB_zeropoint=True, default_thin_trunc=True, **kwargs):
     flux is 1 photon/sec for that instrument.  The difference between the two can be calculated as
     follows:
 
-            # Calculate effective diameter given the obscuration, then get the collecting area in
-            # cm^2.
-            d_eff = 100. * galsim.wfirst.diameter * np.sqrt(1.-galsim.wfirst.obscuration**2)
-            area_eff = np.pi * (d_eff/2.)**2
+            # Shift zeropoint based on effective collecting area in cm^2.
+            area_eff = galsim.wfirst.collecting_area
             delta_zp = 2.5 * np.log10(area_eff)
 
-    delta_zp will be a positive number that should be added to the GalSim zeropoints to compare with
+    `delta_zp` will be a positive number that should be added to the GalSim zeropoints to compare with
     externally calculated instrumental zeropoints.  When using the GalSim zeropoints for
     normalization of fluxes, the `area` kwarg to drawImage can be used to get the right
     normalization (giving it the quantity `area_eff` calculated using the lines of code above).

--- a/galsim/wfirst/wfirst_bandpass.py
+++ b/galsim/wfirst/wfirst_bandpass.py
@@ -25,7 +25,7 @@ import galsim
 import numpy as np
 import os
 
-def getBandpasses(AB_zeropoint=True, exptime=None, default_thin_trunc=True, **kwargs):
+def getBandpasses(AB_zeropoint=True, default_thin_trunc=True, **kwargs):
     """Utility to get a dictionary containing the WFIRST bandpasses used for imaging.
 
     This routine reads in a file containing a list of wavelengths and throughput for all WFIRST
@@ -45,9 +45,7 @@ def getBandpasses(AB_zeropoint=True, exptime=None, default_thin_trunc=True, **kw
     if thinning is not desired, truncation is recommended.
 
     By default, the routine will set an AB zeropoint using the WFIRST effective diameter and default
-    exposure time.  Setting the zeropoint can be avoided by setting `AB_zeropoint=False`; changing
-    the exposure time that is used for the zeropoint calculation can be used by setting the
-    `exptime` keyword.
+    exposure time.  Setting the zeropoint can be avoided by setting `AB_zeropoint=False`.
 
     This routine also loads information about sky backgrounds in each filter, to be used by the
     galsim.wfirst.getSkyLevel() routine.  The sky background information is saved as an attribute in

--- a/galsim/wfirst/wfirst_bandpass.py
+++ b/galsim/wfirst/wfirst_bandpass.py
@@ -132,7 +132,7 @@ def getBandpasses(AB_zeropoint=True, default_thin_trunc=True, **kwargs):
             # The zeropoint that is calculated by default is for a flux of 1 photon/cm^2/sec through
             # the bandpass.  We want to set this for the actual WFIRST collecting area.
             d_eff = 100. * galsim.wfirst.diameter * np.sqrt(1.-galsim.wfirst.obscuration**2)
-            area_eff = np.pi * d_eff**2
+            area_eff = np.pi * (d_eff/2.)**2
             translation_fac = 2.5 * np.log10(area_eff)
             bp = bp.withZeropoint(bp.zeropoint + translation_fac)
 

--- a/tests/test_wfirst.py
+++ b/tests/test_wfirst.py
@@ -330,8 +330,7 @@ def test_wfirst_bandpass():
     # They calculated instrumental zero points, defined such that the flux is 1 photon/sec (taking
     # into account the WFIRST collecting area).  We convert ours to their definition by adding
     # `delta_zp` calculated below:
-    d_eff = 100. * galsim.wfirst.diameter * np.sqrt(1.-galsim.wfirst.obscuration**2)
-    area_eff = np.pi * (d_eff/2.)**2
+    area_eff = galsim.wfirst.collecting_area
     delta_zp = 2.5 * np.log10(area_eff)
     # Define the zeropoints that they calculated:
     ref_zp = {

--- a/tests/test_wfirst.py
+++ b/tests/test_wfirst.py
@@ -325,6 +325,26 @@ def test_wfirst_bandpass():
             err_msg="Count rate for stellar model not as expected for bandpass "
             "{0}".format(filter_name))
 
+    # Finally, compare against some external zeropoint calculations from the WFIRST microlensing
+    # group: https://wfirst.ipac.caltech.edu/sims/MABuLS_sim.html
+    # They calculated instrumental zero points, defined such that the flux is 1 photon/sec (taking
+    # into account the WFIRST collecting area).  We convert ours to their definition by adding
+    # `delta_zp` calculated below:
+    d_eff = 100. * galsim.wfirst.diameter * np.sqrt(1.-galsim.wfirst.obscuration**2)
+    area_eff = np.pi * (d_eff/2.)**2
+    delta_zp = 2.5 * np.log10(area_eff)
+    # Define the zeropoints that they calculated:
+    ref_zp = {
+        'W149': 27.554,
+        'Z087': 26.163
+        }
+    for key in ref_zp.keys():
+        galsim_zp = bp[key].zeropoint + delta_zp
+        # They use slightly different versions of the bandpasses, so we only require agreement to
+        # 0.1 mag.
+        np.testing.assert_almost_equal(galsim_zp, ref_zp[key], decimal=1,
+                                       err_msg="Zeropoint not as expected for bandpass "
+                                       "{0}".format(key))
 
 @timer
 def test_wfirst_detectors():


### PR DESCRIPTION
This PR has some documentation updates and a minor code update that cleans up `wfirst_bandpass.py` (during the change from v1.4->1.5, some lines of code should have been removed, but were not, so there was a kwarg that did nothing).  Since there is no actual new functionality or bug fix in the usual sense, I did not update CHANGELOG.

As discussed in the last comment on issue #923, I will open an issue for the more general zeropoint issue (definition and need for demos) once this PR is merged.
