### PR TITLE
VonKarman profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Deprecated Features
 New Features
 ------------
 - Add option to use circular weight function in HSM adaptive moments code. (#917)
+- Add VonKarman profile GSObject.
 
 
 

--- a/galsim/__init__.py
+++ b/galsim/__init__.py
@@ -131,6 +131,7 @@ from .compound import AutoConvolve, AutoConvolution, AutoCorrelate, AutoCorrelat
 from .compound import FourierSqrt, FourierSqrtProfile
 from .compound import RandomWalk
 from .transform import Transform, Transformation, _Transform
+from .vonkarman import VonKarman
 
 # Chromatic
 from .chromatic import ChromaticObject, ChromaticAtmosphere, ChromaticSum

--- a/galsim/vonkarman.py
+++ b/galsim/vonkarman.py
@@ -55,9 +55,11 @@ class VonKarman(GSObject):
         exp(-0.5*0.172*(r0/L0)^(-5/3))
 
     In almost all cases of interest this evaluates to something tiny, often on the order of 10^-100
-    or smaller.  By default, GalSim will ignore this delta function entirely.  If for some reason
-    you want to keep the delta function, though, then you can pass the do_delta=True argument to the
-    VonKarman initializer.
+    or smaller.  By default, GalSim will ignore this delta function entirely since it usually
+    doesn't make any difference, but can complicate some calculations like drawing using
+    method='real_space' or by formally requiring huge Fourier transforms for drawing using
+    method='fft'.  If for some reason you want to keep the delta function, though, then you can pass
+    the do_delta=True argument to the VonKarman initializer.
 
     @param lam               Wavelength in nanometers
     @param r0                Fried parameter in meters.

--- a/galsim/vonkarman.py
+++ b/galsim/vonkarman.py
@@ -33,12 +33,13 @@ class VonKarman(GSObject):
     profile is that the von Karman profile includes a parameter for the outer scale of atmospheric
     turbulence, which is a physical scale beyond which fluctuations in the refractive index stop
     growing, typically between 10 and 100 meters.  Quantitatively, the von Karman phase fluctuation
-    power spectrum is proportional to
+    power spectrum at spatial frequency f is proportional to
 
-        (f^2 + L0^-2)^(-11/6)
+        r0^(-5/3) (f^2 + L0^-2)^(-11/6)
 
-    where f is a spatial frequency and L0 is the outer scale in meters.  The Kolmogorov power
-    spectrum proportional to f^(-11/3) is recovered as L0 -> infinity,
+    where r0 is the Fried parameter which sets the overall turbulence amplitude and L0 is the outer
+    scale in meters.  The Kolmogorov power spectrum proportional to r0^(-5/3) f^(-11/3) is recovered
+    as L0 -> infinity.
 
     For more information, we recommend the following references:
 

--- a/galsim/vonkarman.py
+++ b/galsim/vonkarman.py
@@ -144,7 +144,7 @@ class VonKarman(GSObject):
     def half_light_radius(self):
         return self._sbvk.getHalfLightRadius()
 
-    def structureFunction(self, rho):
+    def _structure_function(self, rho):  # pragma: nocover
         return self._sbvk.structureFunction(rho)
 
     def __eq__(self, other):
@@ -168,6 +168,8 @@ class VonKarman(GSObject):
             out += ", scale_unit=%r"%self.scale_unit
         if self.do_delta:
             out += ", do_delta=True"
+        if self._suppress_warning:
+            out += ", suppress_warning=True"
         out += ", gsparams=%r"%self.gsparams
         out += ")"
         return out

--- a/galsim/vonkarman.py
+++ b/galsim/vonkarman.py
@@ -61,7 +61,7 @@ class VonKarman(GSObject):
 
     @param lam               Wavelength in nanometers
     @param r0                Fried parameter in meters.
-    @param L0                Outer scale in meters.  [default: np.inf]
+    @param L0                Outer scale in meters.  [default: 25.0]
     @param flux              The flux (in photons/cm^2/s) of the profile. [default: 1]
     @param scale_unit        Units assumed when drawing this profile or evaluating xValue, kValue,
                              etc.  Should be a galsim.AngleUnit or a string that can be used to
@@ -77,7 +77,7 @@ class VonKarman(GSObject):
     @param gsparams          An optional GSParams argument.  See the docstring for GSParams for
                              details. [default: None]
     """
-    def __init__(self, lam, r0, L0=np.inf, flux=1, scale_unit=galsim.arcsec,
+    def __init__(self, lam, r0, L0=25.0, flux=1, scale_unit=galsim.arcsec,
                  do_delta=False, suppress_warning=False, gsparams=None):
         # We lose stability if L0 gets too large.  This should be close enough to infinity for
         # all practical purposes though.

--- a/galsim/vonkarman.py
+++ b/galsim/vonkarman.py
@@ -16,9 +16,7 @@
 #    and/or other materials provided with the distribution.
 #
 """@file base.py
-This file implements the von Karman atmospheric PSF profile.  A version which has the underlying
-turbulence power spectrum truncated below a given scale is also available as a correction when using
-geometric shooting through an atmospheric PhaseScreenPSF.
+This file implements the von Karman atmospheric PSF profile.
 """
 
 import numpy as np

--- a/galsim/vonkarman.py
+++ b/galsim/vonkarman.py
@@ -142,8 +142,8 @@ class VonKarman(GSObject):
     def half_light_radius(self):
         return self._sbvk.getHalfLightRadius()
 
-    def _structure_function(self, rho):  # pragma: nocover
-        return self._sbvk.structureFunction(rho)
+    def _structure_function(self, rho):
+        return self._sbvk.structureFunction(rho)  # pragma: nocover
 
     def __eq__(self, other):
         return (isinstance(other, galsim.VonKarman) and

--- a/galsim/vonkarman.py
+++ b/galsim/vonkarman.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2012-2017 by the GalSim developers team on GitHub
+# https://github.com/GalSim-developers
+#
+# This file is part of GalSim: The modular galaxy image simulation toolkit.
+# https://github.com/GalSim-developers/GalSim
+#
+# GalSim is free software: redistribution and use in source and binary forms,
+# with or without modification, are permitted provided that the following
+# conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions, and the disclaimer given in the accompanying LICENSE
+#    file.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions, and the disclaimer given in the documentation
+#    and/or other materials provided with the distribution.
+#
+"""@file base.py
+This file implements the von Karman atmospheric PSF profile.  A version which has the underlying
+turbulence power spectrum truncated below a given scale is also available as a correction when using
+geometric shooting through an atmospheric PhaseScreenPSF.
+"""
+
+import numpy as np
+
+import galsim
+
+from . import _galsim
+from .gsobject import GSObject
+
+
+class VonKarman(GSObject):
+    """Class describing a von Karman surface brightness profile, which represents a long exposure
+    atmospheric PSF.  The difference between the von Karman profile and the related Kolmogorov
+    profile is that the von Karman profile includes a parameter for the outer scale of atmospheric
+    turbulence, which is a physical scale beyond which fluctuations in the refractive index stop
+    growing, typically between 10 and 100 meters.  Quantitatively, the von Karman phase fluctuation
+    power spectrum is proportional to
+
+        (f^2 + L0^-2)^(-11/6)
+
+    where f is a spatial frequency and L0 is the outer scale in meters.  The Kolmogorov power
+    spectrum proportional to f^(-11/3) is recovered as L0 -> infinity,
+
+    For more information, we recommend the following references:
+
+        Martinez et al.  2010  A&A  vol. 516
+        Conan  2008  JOSA  vol. 25
+
+    Notes
+    -----
+
+    If one blindly follows the math for converting the von Karman power spectrum into a PSF, one
+    finds that the PSF contains a delta-function at the origin with fractional flux of
+
+        exp(-0.5*0.172*(r0/L0)^(-5/3))
+
+    In almost all cases of interest this evaluates to something tiny, often on the order of 10^-100
+    or smaller.  By default, GalSim will ignore this delta function entirely.  If for some reason
+    you want to keep the delta function, though, then you can pass the do_delta=True argument to the
+    VonKarman initializer.
+
+    @param lam               Wavelength in nanometers
+    @param r0                Fried parameter in meters.
+    @param L0                Outer scale in meters.  [default: np.inf]
+    @param flux              The flux (in photons/cm^2/s) of the profile. [default: 1]
+    @param scale_unit        Units assumed when drawing this profile or evaluating xValue, kValue,
+                             etc.  Should be a galsim.AngleUnit or a string that can be used to
+                             construct one (e.g., 'arcsec', 'radians', etc.).
+                             [default: galsim.arcsec]
+    @param do_delta          Include delta-function at origin? (not recommended; see above).
+                             [default: False]
+    @param suppress_warning  For some combinations of r0 and L0, it may become impossible to satisfy
+                             the gsparams.maxk_threshold criterion (see above).  In that case, the
+                             code will emit a warning alerting the user that they may have entered a
+                             non-physical regime.  However, this warning can be suppressed with this
+                             keyword.  [default: False]
+    @param gsparams          An optional GSParams argument.  See the docstring for GSParams for
+                             details. [default: None]
+    """
+    def __init__(self, lam, r0, L0=np.inf, flux=1, scale_unit=galsim.arcsec,
+                 do_delta=False, suppress_warning=False, gsparams=None):
+        # We lose stability if L0 gets too large.  This should be close enough to infinity for
+        # all practical purposes though.
+        if L0 > 1e10:
+            L0 = 1e10
+        if isinstance(scale_unit, str):
+            scale_unit = galsim.angle.get_angle_unit(scale_unit)
+        # Need _scale_unit for repr roundtriping.
+        self._scale_unit = scale_unit
+        scale = scale_unit/galsim.arcsec
+        self._sbvk = _galsim.SBVonKarman(lam, r0, L0, flux, scale, do_delta, gsparams)
+        self._delta_amplitude = self._sbvk.getDeltaAmplitude()
+        self._suppress_warning = suppress_warning
+        if not suppress_warning:
+            if self._delta_amplitude > self._sbvk.getGSParams().maxk_threshold:
+                import warnings
+                warnings.warn("VonKarman delta-function component is larger than maxk_threshold.  "
+                              "Please see docstring for information about this component and how to"
+                              " toggle it.")
+
+
+        # Add in a delta function with appropriate amplitude if requested.
+        if do_delta:
+            self._sbdelta = _galsim.SBDeltaFunction(self._delta_amplitude, gsparams=gsparams)
+            # A bit wasteful maybe, but params should be cached so not too bad to recreate _sbvk?
+            self._sbvk = _galsim.SBVonKarman(lam, r0, L0, flux-self._delta_amplitude, scale,
+                                             do_delta, gsparams)
+
+            self._sbp = _galsim.SBAdd([self._sbvk, self._sbdelta], gsparams=gsparams)
+        else:
+            self._sbp = self._sbvk
+
+    @property
+    def lam(self):
+        return self._sbvk.getLam()
+
+    @property
+    def r0(self):
+        return self._sbvk.getR0()
+
+    @property
+    def L0(self):
+        return self._sbvk.getL0()
+
+    @property
+    def scale_unit(self):
+        return self._scale_unit
+        # Type conversion makes the following not repr-roundtrip-able, so we store init input as a
+        # hidden attribute.
+        # return galsim.AngleUnit(self._sbvk.getScale())
+
+    @property
+    def do_delta(self):
+        return self._sbvk.getDoDelta()
+
+    @property
+    def delta_amplitude(self):
+        # Don't use self._sbvk.getDeltaAmplitude, since we might have rescaled the flux of the sbvk
+        # component when including a SBDeltaFunction.
+        return self._delta_amplitude
+
+    @property
+    def half_light_radius(self):
+        return self._sbvk.getHalfLightRadius()
+
+    def structureFunction(self, rho):
+        return self._sbvk.structureFunction(rho)
+
+    def __eq__(self, other):
+        return (isinstance(other, galsim.VonKarman) and
+        self.lam == other.lam and
+        self.r0 == other.r0 and
+        self.L0 == other.L0 and
+        self.flux == other.flux and
+        self.scale_unit == other.scale_unit and
+        self.do_delta == other.do_delta and
+        self.gsparams == other.gsparams)
+
+    def __hash__(self):
+        return hash(("galsim.VonKarman", self.lam, self.r0, self.L0, self.flux, self.scale_unit,
+                     self.do_delta, self.gsparams))
+
+    def __repr__(self):
+        out = "galsim.VonKarman(lam=%r, r0=%r, L0=%r"%(self.lam, self.r0, self.L0)
+        out += ", flux=%r"%self.flux
+        if self.scale_unit != galsim.arcsec:
+            out += ", scale_unit=%r"%self.scale_unit
+        if self.do_delta:
+            out += ", do_delta=True"
+        out += ", gsparams=%r"%self.gsparams
+        out += ")"
+        return out
+
+    def __str__(self):
+        return "galsim.VonKarman(lam=%r, r0=%r, L0=%r)"%(self.lam, self.r0, self.L0)
+
+_galsim.SBVonKarman.__getinitargs__ = lambda self: (
+    self.getLam(), self.getR0(), self.getL0(), self.getFlux(), self.getScale(),
+    self.getDoDelta(), self.getGSParams())
+_galsim.SBVonKarman.__getstate__ = lambda self: None
+_galsim.SBVonKarman.__repr__ = lambda self: \
+    "galsim._galsim.SBVonKarman(%r, %r, %r, %r, %r, %r, %r)"%self.__getinitargs__()

--- a/galsim/vonkarman.py
+++ b/galsim/vonkarman.py
@@ -142,8 +142,8 @@ class VonKarman(GSObject):
     def half_light_radius(self):
         return self._sbvk.getHalfLightRadius()
 
-    def _structure_function(self, rho):
-        return self._sbvk.structureFunction(rho)  # pragma: nocover
+    def _structure_function(self, rho):  # pragma: no cover
+        return self._sbvk.structureFunction(rho)
 
     def __eq__(self, other):
         return (isinstance(other, galsim.VonKarman) and

--- a/include/galsim/LRUCache.h
+++ b/include/galsim/LRUCache.h
@@ -77,6 +77,28 @@ namespace galsim {
         }
     };
 
+    template <typename Value, typename Key1, typename Key2, typename Key3, typename Key4,
+              typename Key5>
+    struct LRUCacheHelper<Value,boost::tuple<Key1,Key2,Key3,Key4,Key5> >
+    {
+        static Value* NewValue(const boost::tuple<Key1,Key2,Key3,Key4,Key5>& key)
+        {
+            return new Value(boost::get<0>(key), boost::get<1>(key), boost::get<2>(key),
+                             boost::get<3>(key), boost::get<4>(key));
+        }
+    };
+
+    template <typename Value, typename Key1, typename Key2, typename Key3, typename Key4,
+              typename Key5, typename Key6>
+    struct LRUCacheHelper<Value,boost::tuple<Key1,Key2,Key3,Key4,Key5,Key6> >
+    {
+        static Value* NewValue(const boost::tuple<Key1,Key2,Key3,Key4,Key5,Key6>& key)
+        {
+            return new Value(boost::get<0>(key), boost::get<1>(key), boost::get<2>(key),
+                             boost::get<3>(key), boost::get<4>(key), boost::get<5>(key));
+        }
+    };
+
     /**
      * @brief Least Recently Used Cache
      *
@@ -167,4 +189,3 @@ namespace galsim {
 }
 
 #endif
-

--- a/include/galsim/SBVonKarman.h
+++ b/include/galsim/SBVonKarman.h
@@ -20,8 +20,7 @@
 #ifndef GalSim_SBVonKarman_H
 #define GalSim_SBVonKarman_H
 /**
- * @file SBVonKarman.h @brief SBProfile for von Karman turbulence PSF, potentially including
- *                            truncated power spectrum.
+ * @file SBVonKarman.h @brief SBProfile for von Karman turbulence PSF.
  */
 
 #include "SBProfile.h"

--- a/include/galsim/SBVonKarman.h
+++ b/include/galsim/SBVonKarman.h
@@ -1,0 +1,83 @@
+/* -*- c++ -*-
+ * Copyright (c) 2012-2017 by the GalSim developers team on GitHub
+ * https://github.com/GalSim-developers
+ *
+ * This file is part of GalSim: The modular galaxy image simulation toolkit.
+ * https://github.com/GalSim-developers/GalSim
+ *
+ * GalSim is free software: redistribution and use in source and binary forms,
+ * with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions, and the disclaimer given in the accompanying LICENSE
+ *    file.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the disclaimer given in the documentation
+ *    and/or other materials provided with the distribution.
+ */
+
+#ifndef GalSim_SBVonKarman_H
+#define GalSim_SBVonKarman_H
+/**
+ * @file SBVonKarman.h @brief SBProfile for von Karman turbulence PSF, potentially including
+ *                            truncated power spectrum.
+ */
+
+#include "SBProfile.h"
+
+namespace galsim {
+
+    namespace sbp {
+        // How many VonKarman profiles to save in the cache
+        const int max_vonKarman_cache = 100;
+    }
+
+    class SBVonKarman : public SBProfile
+    {
+    public:
+        /**
+         * @brief Constructor.
+         *
+         * @param[in] lam          Wavelength in nm.
+         * @param[in] r0           Fried parameter in m (at given wavelength lam).
+         * @param[in] L0           Outer scale in m.
+         * @param[in] flux         Flux.
+         * @param[in] scale        Scale of 'x' in xValue in arcsec.
+         * @param[in] doDelta      Whether or not to include delta-function contribution to
+                                   encircled energy when computing stepk/maxk/HLR.
+         * @param[in] gsparams     GSParams.
+         */
+        SBVonKarman(double lam, double r0, double L0, double flux,
+                    double scale, bool doDelta, const GSParamsPtr& gsparams);
+
+        /// @brief Copy constructor
+        SBVonKarman(const SBVonKarman& rhs);
+
+        /// @brief Destructor.
+        ~SBVonKarman();
+
+        /// Getters
+        double getLam() const;
+        double getR0() const;
+        double getL0() const;
+        double getScale() const;
+        bool getDoDelta() const;
+        double getDeltaAmplitude() const;
+        double getHalfLightRadius() const;
+
+        double structureFunction(double) const;
+
+        friend class VKXIntegrand;
+
+    protected:
+
+        class SBVonKarmanImpl;
+
+    private:
+        // op= is undefined
+        void operator=(const SBVonKarman& rhs);
+    };
+}
+
+#endif

--- a/include/galsim/SBVonKarmanImpl.h
+++ b/include/galsim/SBVonKarmanImpl.h
@@ -53,11 +53,12 @@ namespace galsim {
         double structureFunction(double rho) const;
         boost::shared_ptr<PhotonArray> shoot(int N, UniformDeviate ud) const;
 
+        double kValueNoTrunc(double) const;
+        double rawXValue(double) const;
+
     private:
         VonKarmanInfo(const VonKarmanInfo& rhs); ///<Hide the copy constructor
         void operator=(const VonKarmanInfo& rhs); ///<Hide the assignment operator
-
-        double kValueNoTrunc(double) const;
 
         double _lam; // Wavelength in meters
         double _r0; // Fried parameter in meters
@@ -66,6 +67,8 @@ namespace galsim {
         double _stepk;
         double _maxk;
         double _deltaAmplitude;
+        double _deltaScale;  // 1/(1-_deltaAmplitude)
+        double _lam_arcsec;  // _lam * ARCSEC2RAD / 2pi
         bool _doDelta;
         double _hlr; // half-light-radius
 

--- a/include/galsim/SBVonKarmanImpl.h
+++ b/include/galsim/SBVonKarmanImpl.h
@@ -131,6 +131,24 @@ namespace galsim {
 
         double structureFunction(double rho) const;
 
+        // Overrides for better efficiency
+        template <typename T>
+        void fillXImage(ImageView<T> im,
+                        double x0, double dx, int izero,
+                        double y0, double dy, int jzero) const;
+        template <typename T>
+        void fillXImage(ImageView<T> im,
+                        double x0, double dx, double dxy,
+                        double y0, double dy, double dyx) const;
+        template <typename T>
+        void fillKImage(ImageView<std::complex<T> > im,
+                        double kx0, double dkx, int izero,
+                        double ky0, double dky, int jzero) const;
+        template <typename T>
+        void fillKImage(ImageView<std::complex<T> > im,
+                        double kx0, double dkx, double dkxy,
+                        double ky0, double dky, double dkyx) const;
+
         std::string serialize() const;
 
     private:

--- a/include/galsim/SBVonKarmanImpl.h
+++ b/include/galsim/SBVonKarmanImpl.h
@@ -69,11 +69,6 @@ namespace galsim {
         bool _doDelta;
         double _hlr; // half-light-radius
 
-        // Magic constants that we can compute once and store.
-        const static double magic1; // 2 gamma(11/6) / (2^(5/6) pi^(8/3)) * (24/5 gamma(6/5))^(5/6)
-        const static double magic2; // gamma(5/6) / 2^(1/6)
-        const static double magic3; // magic1 * gamma(-5/6) / 2^(11/6)
-        const static double magic4; // gamma(11/6) gamma(5/6) / pi^(8/3) * (24/5 gamma(6/5))^(5/6)
         const GSParamsPtr _gsparams;
 
         TableDD _radial;

--- a/include/galsim/SBVonKarmanImpl.h
+++ b/include/galsim/SBVonKarmanImpl.h
@@ -39,7 +39,7 @@ namespace galsim {
     class VonKarmanInfo
     {
     public:
-        VonKarmanInfo(double lam, double r0, double L0, bool doDelta, const GSParamsPtr& gsparams);
+        VonKarmanInfo(double lam, double L0, bool doDelta, const GSParamsPtr& gsparams);
 
         ~VonKarmanInfo() {}
 
@@ -60,9 +60,8 @@ namespace galsim {
         VonKarmanInfo(const VonKarmanInfo& rhs); ///<Hide the copy constructor
         void operator=(const VonKarmanInfo& rhs); ///<Hide the assignment operator
 
-        double _lam; // Wavelength in meters
-        double _r0; // Fried parameter in meters
-        double _L0; // Outer scale in meters
+        double _lam; // Wavelength in units of the Fried parameter, r0
+        double _L0; // Outer scale in units of the Fried parameter, r0
         double _r0L0m53; // (r0/L0)^(-5/3)
         double _stepk;
         double _maxk;
@@ -149,7 +148,7 @@ namespace galsim {
         SBVonKarmanImpl(const SBVonKarmanImpl& rhs);
         void operator=(const SBVonKarmanImpl& rhs);
 
-        static LRUCache<boost::tuple<double,double,double,bool,GSParamsPtr>,VonKarmanInfo> cache;
+        static LRUCache<boost::tuple<double,double,bool,GSParamsPtr>,VonKarmanInfo> cache;
     };
 }
 

--- a/include/galsim/SBVonKarmanImpl.h
+++ b/include/galsim/SBVonKarmanImpl.h
@@ -1,0 +1,158 @@
+/* -*- c++ -*-
+ * Copyright (c) 2012-2017 by the GalSim developers team on GitHub
+ * https://github.com/GalSim-developers
+ *
+ * This file is part of GalSim: The modular galaxy image simulation toolkit.
+ * https://github.com/GalSim-developers/GalSim
+ *
+ * GalSim is free software: redistribution and use in source and binary forms,
+ * with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions, and the disclaimer given in the accompanying LICENSE
+ *    file.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the disclaimer given in the documentation
+ *    and/or other materials provided with the distribution.
+ */
+
+#ifndef GalSim_SBVonKarmanImpl_H
+#define GalSim_SBVonKarmanImpl_H
+
+#include "SBProfileImpl.h"
+#include "SBVonKarman.h"
+#include "LRUCache.h"
+#include "OneDimensionalDeviate.h"
+#include "Table.h"
+
+namespace galsim {
+
+    //
+    //
+    //
+    //VonKarmanInfo
+    //
+    //
+    //
+
+    class VonKarmanInfo
+    {
+    public:
+        VonKarmanInfo(double lam, double r0, double L0, bool doDelta, const GSParamsPtr& gsparams);
+
+        ~VonKarmanInfo() {}
+
+        double stepK() const { return _stepk; }
+        double maxK() const { return _maxk; }
+        double getDeltaAmplitude() const {return _deltaAmplitude; }
+        double getHalfLightRadius() const {return _hlr; }
+
+        double kValue(double) const;
+        double xValue(double) const;
+        double structureFunction(double rho) const;
+        boost::shared_ptr<PhotonArray> shoot(int N, UniformDeviate ud) const;
+
+    private:
+        VonKarmanInfo(const VonKarmanInfo& rhs); ///<Hide the copy constructor
+        void operator=(const VonKarmanInfo& rhs); ///<Hide the assignment operator
+
+        double kValueNoTrunc(double) const;
+
+        double _lam; // Wavelength in meters
+        double _r0; // Fried parameter in meters
+        double _L0; // Outer scale in meters
+        double _r0L0m53; // (r0/L0)^(-5/3)
+        double _stepk;
+        double _maxk;
+        double _deltaAmplitude;
+        bool _doDelta;
+        double _hlr; // half-light-radius
+
+        // Magic constants that we can compute once and store.
+        const static double magic1; // 2 gamma(11/6) / (2^(5/6) pi^(8/3)) * (24/5 gamma(6/5))^(5/6)
+        const static double magic2; // gamma(5/6) / 2^(1/6)
+        const static double magic3; // magic1 * gamma(-5/6) / 2^(11/6)
+        const static double magic4; // gamma(11/6) gamma(5/6) / pi^(8/3) * (24/5 gamma(6/5))^(5/6)
+        const GSParamsPtr _gsparams;
+
+        TableDD _radial;
+        boost::shared_ptr<OneDimensionalDeviate> _sampler;
+
+        void _buildRadialFunc();
+    };
+
+    //
+    //
+    //
+    //SBVonKarmanImpl
+    //
+    //
+    //
+
+    class SBVonKarman::SBVonKarmanImpl : public SBProfileImpl
+    {
+    public:
+        SBVonKarmanImpl(double lam, double r0, double L0, double flux, double scale, bool doDelta,
+                        const GSParamsPtr& gsparams);
+        ~SBVonKarmanImpl() {}
+
+        bool isAxisymmetric() const { return true; }
+        bool hasHardEdges() const { return false; }
+        bool isAnalyticX() const { return true; }
+        bool isAnalyticK() const { return true; }
+
+        double maxK() const;
+        double stepK() const;
+        double getDeltaAmplitude() const;
+        double getHalfLightRadius() const;
+
+        Position<double> centroid() const { return Position<double>(0., 0.); }
+
+        double getFlux() const { return _flux; }
+        double getLam() const { return _lam; }
+        double getR0() const { return _r0; }
+        double getL0() const { return _L0; }
+        double getScale() const { return _scale; }
+        bool getDoDelta() const { return _doDelta; }
+        double maxSB() const { return _flux * _info->xValue(0.); }
+
+        /**
+         * @brief SBVonKarman photon-shooting is done numerically with `OneDimensionalDeviate`
+         * class.
+         *
+         * @param[in] N Total number of photons to produce.
+         * @param[in] ud UniformDeviate that will be used to draw photons from distribution.
+         * @returns PhotonArray containing all the photons' info.
+         */
+        boost::shared_ptr<PhotonArray> shoot(int N, UniformDeviate ud) const;
+
+        double xValue(const Position<double>& p) const;
+        double xValue(double r) const;
+        std::complex<double> kValue(const Position<double>& p) const;
+        double kValue(double k) const;
+
+        double structureFunction(double rho) const;
+
+        std::string serialize() const;
+
+    private:
+
+        double _lam;
+        double _r0;
+        double _L0;
+        double _flux;
+        double _scale;
+        bool _doDelta;
+
+        boost::shared_ptr<VonKarmanInfo> _info;
+
+        // Copy constructor and op= are undefined.
+        SBVonKarmanImpl(const SBVonKarmanImpl& rhs);
+        void operator=(const SBVonKarmanImpl& rhs);
+
+        static LRUCache<boost::tuple<double,double,double,bool,GSParamsPtr>,VonKarmanInfo> cache;
+    };
+}
+
+#endif

--- a/pysrc/SBVonKarman.cpp
+++ b/pysrc/SBVonKarman.cpp
@@ -1,0 +1,62 @@
+/* -*- c++ -*-
+ * Copyright (c) 2012-2017 by the GalSim developers team on GitHub
+ * https://github.com/GalSim-developers
+ *
+ * This file is part of GalSim: The modular galaxy image simulation toolkit.
+ * https://github.com/GalSim-developers/GalSim
+ *
+ * GalSim is free software: redistribution and use in source and binary forms,
+ * with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions, and the disclaimer given in the accompanying LICENSE
+ *    file.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the disclaimer given in the documentation
+ *    and/or other materials provided with the distribution.
+ */
+
+#include "galsim/IgnoreWarnings.h"
+
+#define BOOST_NO_CXX11_SMART_PTR
+#include "boost/python.hpp"
+#include "boost/python/stl_iterator.hpp"
+
+#include "SBVonKarman.h"
+
+namespace bp = boost::python;
+
+namespace galsim {
+
+    struct PySBVonKarman
+    {
+        static void wrap()
+        {
+            bp::class_<SBVonKarman,bp::bases<SBProfile> >("SBVonKarman", bp::no_init)
+                .def(bp::init<double,double,double,double,double,bool,
+                              boost::shared_ptr<GSParams> >(
+                        (bp::arg("lam"), bp::arg("r0"), bp::arg("L0"), bp::arg("flux")=1.,
+                         bp::arg("scale")=1.0, bp::arg("doDelta")=false,
+                         bp::arg("gsparams")=bp::object()))
+                )
+                .def(bp::init<const SBVonKarman &>())
+                .def("getLam", &SBVonKarman::getLam)
+                .def("getR0", &SBVonKarman::getR0)
+                .def("getL0", &SBVonKarman::getL0)
+                .def("getScale", &SBVonKarman::getScale)
+                .def("getDoDelta", &SBVonKarman::getDoDelta)
+                .def("getDeltaAmplitude", &SBVonKarman::getDeltaAmplitude)
+                .def("getHalfLightRadius", &SBVonKarman::getHalfLightRadius)
+                .def("structureFunction", &SBVonKarman::structureFunction)
+                .enable_pickling()
+                ;
+        }
+    };
+
+    void pyExportSBVonKarman()
+    {
+        PySBVonKarman::wrap();
+    }
+
+} // namespace galsim

--- a/pysrc/files.txt
+++ b/pysrc/files.txt
@@ -22,6 +22,7 @@ SBKolmogorov.cpp
 SBSpergel.cpp
 SBInclinedExponential.cpp
 SBInclinedSersic.cpp
+SBVonKarman.cpp
 Random.cpp
 Noise.cpp
 HSM.cpp

--- a/pysrc/module.cpp
+++ b/pysrc/module.cpp
@@ -59,6 +59,7 @@ namespace galsim {
     void pyExportSBInclinedExponential();
     void pyExportSBInclinedSersic();
     void pyExportSBDeltaFunction();
+    void pyExportSBVonKarman();
     void pyExportRandom();
     void pyExportNoise();
     void pyExportTable();
@@ -110,6 +111,7 @@ BOOST_PYTHON_MODULE(_galsim) {
     galsim::pyExportSBInclinedExponential();
     galsim::pyExportSBInclinedSersic();
     galsim::pyExportSBDeltaFunction();
+    galsim::pyExportSBVonKarman();
     galsim::pyExportRandom();
     galsim::pyExportNoise();
     galsim::pyExportInterpolant();

--- a/src/SBVonKarman.cpp
+++ b/src/SBVonKarman.cpp
@@ -400,4 +400,128 @@ namespace galsim {
         return result;
     }
 
+    template <typename T>
+    void SBVonKarman::SBVonKarmanImpl::fillXImage(ImageView<T> im,
+                                                  double x0, double dx, int izero,
+                                                  double y0, double dy, int jzero) const
+    {
+        dbg<<"SBVonKarman fillXImage\n";
+        dbg<<"x = "<<x0<<" + i * "<<dx<<", izero = "<<izero<<std::endl;
+        dbg<<"y = "<<y0<<" + j * "<<dy<<", jzero = "<<jzero<<std::endl;
+        if (izero != 0 || jzero != 0) {
+            xdbg<<"Use Quadrant\n";
+            fillXImageQuadrant(im,x0,dx,izero,y0,dy,jzero);
+        } else {
+            xdbg<<"Non-Quadrant\n";
+            const int m = im.getNCol();
+            const int n = im.getNRow();
+            T* ptr = im.getData();
+            const int skip = im.getNSkip();
+            assert(im.getStep() == 1);
+
+            x0 *= _scale;
+            dx *= _scale;
+            y0 *= _scale;
+            dy *= _scale;
+
+            for (int j=0; j<n; ++j,y0+=dy,ptr+=skip) {
+                double x = x0;
+                double ysq = y0*y0;
+                for (int i=0; i<m; ++i,x+=dx)
+                    *ptr++ = _flux * _info->xValue(sqrt(x*x + ysq));
+            }
+        }
+    }
+
+    template <typename T>
+    void SBVonKarman::SBVonKarmanImpl::fillXImage(ImageView<T> im,
+                                                  double x0, double dx, double dxy,
+                                                  double y0, double dy, double dyx) const
+    {
+        dbg<<"SBVonKarman fillXImage\n";
+        dbg<<"x = "<<x0<<" + i * "<<dx<<" + j * "<<dxy<<std::endl;
+        dbg<<"y = "<<y0<<" + i * "<<dyx<<" + j * "<<dy<<std::endl;
+        const int m = im.getNCol();
+        const int n = im.getNRow();
+        T* ptr = im.getData();
+        const int skip = im.getNSkip();
+        assert(im.getStep() == 1);
+
+        x0 *= _scale;
+        dx *= _scale;
+        dxy *= _scale;
+        y0 *= _scale;
+        dy *= _scale;
+        dyx *= _scale;
+
+        for (int j=0; j<n; ++j,x0+=dxy,y0+=dy,ptr+=skip) {
+            double x = x0;
+            double y = y0;
+            for (int i=0; i<m; ++i,x+=dx,y+=dyx)
+                *ptr++ = _flux * _info->xValue(sqrt(x*x + y*y));
+        }
+    }
+
+    template <typename T>
+    void SBVonKarman::SBVonKarmanImpl::fillKImage(ImageView<std::complex<T> > im,
+                                                  double kx0, double dkx, int izero,
+                                                  double ky0, double dky, int jzero) const
+    {
+        dbg<<"SBVonKarman fillKImage\n";
+        dbg<<"kx = "<<kx0<<" + i * "<<dkx<<", izero = "<<izero<<std::endl;
+        dbg<<"ky = "<<ky0<<" + j * "<<dky<<", jzero = "<<jzero<<std::endl;
+        if (izero != 0 || jzero != 0) {
+            xdbg<<"Use Quadrant\n";
+            fillKImageQuadrant(im,kx0,dkx,izero,ky0,dky,jzero);
+        } else {
+            xdbg<<"Non-Quadrant\n";
+            const int m = im.getNCol();
+            const int n = im.getNRow();
+            std::complex<T>* ptr = im.getData();
+            int skip = im.getNSkip();
+            assert(im.getStep() == 1);
+
+            kx0 /= _scale;
+            dkx /= _scale;
+            ky0 /= _scale;
+            dky /= _scale;
+
+            for (int j=0; j<n; ++j,ky0+=dky,ptr+=skip) {
+                double kx = kx0;
+                double kysq = ky0*ky0;
+                for (int i=0;i<m;++i,kx+=dkx)
+                    *ptr++ = _flux * _info->kValue(kx*kx+kysq);
+            }
+        }
+    }
+
+    template <typename T>
+    void SBVonKarman::SBVonKarmanImpl::fillKImage(ImageView<std::complex<T> > im,
+                                                  double kx0, double dkx, double dkxy,
+                                                  double ky0, double dky, double dkyx) const
+    {
+        dbg<<"SBVonKarman fillKImage\n";
+        dbg<<"kx = "<<kx0<<" + i * "<<dkx<<" + j * "<<dkxy<<std::endl;
+        dbg<<"ky = "<<ky0<<" + i * "<<dkyx<<" + j * "<<dky<<std::endl;
+        const int m = im.getNCol();
+        const int n = im.getNRow();
+        std::complex<T>* ptr = im.getData();
+        int skip = im.getNSkip();
+        assert(im.getStep() == 1);
+
+        kx0 /= _scale;
+        dkx /= _scale;
+        dkxy /= _scale;
+        ky0 /= _scale;
+        dky /= _scale;
+        dkyx /= _scale;
+
+        for (int j=0; j<n; ++j,kx0+=dkxy,ky0+=dky,ptr+=skip) {
+            double kx = kx0;
+            double ky = ky0;
+            for (int i=0; i<m; ++i,kx+=dkx,ky+=dkyx)
+                *ptr++ = _flux * _info->kValue(kx*kx+ky*ky);
+        }
+    }
+
 }

--- a/src/SBVonKarman.cpp
+++ b/src/SBVonKarman.cpp
@@ -111,14 +111,6 @@ namespace galsim {
     //
     //
 
-    const double VonKarmanInfo::magic1 = 2*boost::math::tgamma(11./6)/(pow(2, 5./6)*pow(M_PI, 8./3))
-                                    * pow(24/5.*boost::math::tgamma(6./5), 5./6);
-    const double VonKarmanInfo::magic2 = boost::math::tgamma(5./6)/pow(2., 1./6);
-    const double VonKarmanInfo::magic3 = VonKarmanInfo::magic1*boost::math::tgamma(-5./6)/pow(2., 11./6);
-    const double VonKarmanInfo::magic4 = boost::math::tgamma(11./6)*boost::math::tgamma(5./6)
-                                    / pow(M_PI,8./3)
-                                    * pow(24./5*boost::math::tgamma(6./5),5./6);
-
     class VKIkValueResid {
     public:
         VKIkValueResid(const VonKarmanInfo& vki, double mkt) : _vki(vki), _mkt(mkt) {}
@@ -131,6 +123,9 @@ namespace galsim {
         const double _mkt;
         const VonKarmanInfo& _vki;
     };
+
+    // gamma(11/6) gamma(5/6) / pi^(8/3) * (24/5 gamma(6/5))^(5/6)
+    const double magic4 = 0.1726286598236691505;
 
     VonKarmanInfo::VonKarmanInfo(double lam, double r0, double L0, bool doDelta,
                                  const GSParamsPtr& gsparams) :
@@ -171,6 +166,14 @@ namespace galsim {
 
     double VonKarmanInfo::structureFunction(double rho) const {
     // rho in meters
+
+        // 2 gamma(11/6) / (2^(5/6) pi^(8/3)) * (24/5 gamma(6/5))^(5/6)
+        static const double magic1 = 0.1716613621245708932;
+        // gamma(5/6) / 2^(1/6)
+        static const double magic2 = 1.005634917998590172;
+        // magic1 * gamma(-5/6) / 2^(11/6)
+        static const double magic3 = -0.3217609479366896341;
+
         double rhoL0 = rho/_L0;
         if (rhoL0 < 1e-6) {
             return -magic3*fast_pow(2*M_PI*rho/_r0, 5./3);

--- a/src/SBVonKarman.cpp
+++ b/src/SBVonKarman.cpp
@@ -276,12 +276,10 @@ namespace galsim {
         double R = 0.;
         _hlr = 0.;
         const double maxR = 60.0; // hard cut at 1 arcminute.
-        double prev_val=val;
         for(double logr=log(r0); logr<log(maxR) && sum < thresh2; logr+=dlogr) {
             double r = exp(logr);
             val = rawXValue(r);
             xdbg<<"f("<<r<<") = "<<val<<std::endl;
-            prev_val = val;
             _radial.addEntry(r, val);
 
             // Accumulate integral int(r f(r) dr) = int(r^2 f(r) dlogr), but without dlogr factor,

--- a/src/SBVonKarman.cpp
+++ b/src/SBVonKarman.cpp
@@ -273,7 +273,7 @@ namespace galsim {
         _stepk = M_PI / R;
         dbg<<"stepk = "<<_stepk<<" arcsec^-1\n";
         dbg<<"sum = "<<sum<<"   (should be ~= 0.997)\n";
-        if (sum < 0.997)
+        if (sum < 1-_gsparams->folding_threshold)
             throw SBError("Could not find folding_threshold");
 
         std::vector<double> range(2, 0.);

--- a/src/SBVonKarman.cpp
+++ b/src/SBVonKarman.cpp
@@ -1,0 +1,395 @@
+/* -*- c++ -*-
+ * Copyright (c) 2012-2017 by the GalSim developers team on GitHub
+ * https://github.com/GalSim-developers
+ *
+ * This file is part of GalSim: The modular galaxy image simulation toolkit.
+ * https://github.com/GalSim-developers/GalSim
+ *
+ * GalSim is free software: redistribution and use in source and binary forms,
+ * with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions, and the disclaimer given in the accompanying LICENSE
+ *    file.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the disclaimer given in the documentation
+ *    and/or other materials provided with the distribution.
+ */
+
+// #define DEBUGLOGGING
+
+#include "galsim/IgnoreWarnings.h"
+
+#define BOOST_NO_CXX11_SMART_PTR
+#include <boost/math/special_functions/gamma.hpp>
+#include <boost/math/special_functions/bessel.hpp>
+
+#include "SBVonKarman.h"
+#include "SBVonKarmanImpl.h"
+#include "fmath/fmath.hpp"
+#include "Solve.h"
+#include "bessel/Roots.h"
+
+namespace galsim {
+
+    const double ARCSEC2RAD = 180.*60*60/M_PI;  // ~206265
+    const double MOCK_INF = 1.e300;
+
+    inline double fast_pow(double x, double y)
+    { return fmath::expd(y * std::log(x)); }
+
+    //
+    //
+    //
+    //SBVonKarman
+    //
+    //
+    //
+
+    SBVonKarman::SBVonKarman(double lam, double r0, double L0, double flux,
+                             double scale, bool doDelta, const GSParamsPtr& gsparams) :
+        SBProfile(new SBVonKarmanImpl(lam, r0, L0, flux, scale, doDelta, gsparams)) {}
+
+    SBVonKarman::SBVonKarman(const SBVonKarman &rhs) : SBProfile(rhs) {}
+
+    SBVonKarman::~SBVonKarman() {}
+
+    double SBVonKarman::getLam() const
+    {
+        assert(dynamic_cast<const SBVonKarmanImpl*>(_pimpl.get()));
+        return static_cast<const SBVonKarmanImpl&>(*_pimpl).getLam();
+    }
+
+    double SBVonKarman::getR0() const
+    {
+        assert(dynamic_cast<const SBVonKarmanImpl*>(_pimpl.get()));
+        return static_cast<const SBVonKarmanImpl&>(*_pimpl).getR0();
+    }
+
+    double SBVonKarman::getL0() const
+    {
+        assert(dynamic_cast<const SBVonKarmanImpl*>(_pimpl.get()));
+        return static_cast<const SBVonKarmanImpl&>(*_pimpl).getL0();
+    }
+
+    double SBVonKarman::getScale() const
+    {
+        assert(dynamic_cast<const SBVonKarmanImpl*>(_pimpl.get()));
+        return static_cast<const SBVonKarmanImpl&>(*_pimpl).getScale();
+    }
+
+    bool SBVonKarman::getDoDelta() const
+    {
+        assert(dynamic_cast<const SBVonKarmanImpl*>(_pimpl.get()));
+        return static_cast<const SBVonKarmanImpl&>(*_pimpl).getDoDelta();
+    }
+
+    double SBVonKarman::getDeltaAmplitude() const
+    {
+        assert(dynamic_cast<const SBVonKarmanImpl*>(_pimpl.get()));
+        return static_cast<const SBVonKarmanImpl&>(*_pimpl).getDeltaAmplitude();
+    }
+
+    double SBVonKarman::getHalfLightRadius() const
+    {
+        assert(dynamic_cast<const SBVonKarmanImpl*>(_pimpl.get()));
+        return static_cast<const SBVonKarmanImpl&>(*_pimpl).getHalfLightRadius();
+    }
+
+    double SBVonKarman::structureFunction(double rho) const
+    {
+        assert(dynamic_cast<const SBVonKarmanImpl*>(_pimpl.get()));
+        return static_cast<const SBVonKarmanImpl&>(*_pimpl).structureFunction(rho);
+    }
+
+    //
+    //
+    //
+    //VonKarmanInfo
+    //
+    //
+    //
+
+    const double VonKarmanInfo::magic1 = 2*boost::math::tgamma(11./6)/(pow(2, 5./6)*pow(M_PI, 8./3))
+                                    * pow(24/5.*boost::math::tgamma(6./5), 5./6);
+    const double VonKarmanInfo::magic2 = boost::math::tgamma(5./6)/pow(2., 1./6);
+    const double VonKarmanInfo::magic3 = VonKarmanInfo::magic1*boost::math::tgamma(-5./6)/pow(2., 11./6);
+    const double VonKarmanInfo::magic4 = boost::math::tgamma(11./6)*boost::math::tgamma(5./6)
+                                    / pow(M_PI,8./3)
+                                    * pow(24./5*boost::math::tgamma(6./5),5./6);
+
+    class VKIkValueResid {
+    public:
+        VKIkValueResid(const VonKarmanInfo& vki, double mkt) : _vki(vki), _mkt(mkt) {}
+        double operator()(double k) const {
+            double val = _vki.kValue(k)-_mkt;
+            xdbg<<"resid(k="<<k<<")="<<val<<'\n';
+            return val;
+         }
+    private:
+        const double _mkt;
+        const VonKarmanInfo& _vki;
+    };
+
+    VonKarmanInfo::VonKarmanInfo(double lam, double r0, double L0, bool doDelta,
+                                 const GSParamsPtr& gsparams) :
+        _lam(lam), _r0(r0), _L0(L0), _r0L0m53(pow(r0/L0, -5./3)), _gsparams(gsparams),
+        _deltaAmplitude(exp(-0.5*magic4*_r0L0m53)),
+        _doDelta(doDelta),
+        _radial(TableDD::spline)
+    {
+        // determine maxK
+        // want kValue(maxK)/kValue(0.0) = _gsparams->maxk_threshold;
+        // note that kValue(0.0) = 1.
+        double mkt = _gsparams->maxk_threshold;
+        if (_doDelta) {
+            if (mkt < _deltaAmplitude) {
+                // If the delta function amplitude is too large, then no matter how far out in k we
+                // go, kValue never drops below that amplitude.
+                // _maxk = std::numeric_limits<double>::infinity();
+                _maxk = MOCK_INF;
+            } else {
+                mkt = mkt*(1-_deltaAmplitude)+_deltaAmplitude;
+            }
+        }
+        // if (_maxk != std::numeric_limits<double>::infinity()) {
+        if (_maxk != MOCK_INF) {
+            VKIkValueResid vkikvr(*this, mkt);
+            Solve<VKIkValueResid> solver(vkikvr, 0.1, 1);
+            solver.bracket();
+            solver.setMethod(Brent);
+            _maxk = solver.root();
+        }
+        dbg<<"_maxk = "<<_maxk<<" arcsec^-1\n";
+        dbg<<"SB(maxk) = "<<kValue(_maxk)<<'\n';
+        dbg<<"_deltaAmplitude = "<<_deltaAmplitude<<'\n';
+
+        // build the radial function, and along the way, set _stepk, _hlr.
+        _buildRadialFunc();
+    }
+
+    double VonKarmanInfo::structureFunction(double rho) const {
+    // rho in meters
+        double rhoL0 = rho/_L0;
+        if (rhoL0 < 1e-6) {
+            return -magic3*fast_pow(2*M_PI*rho/_r0, 5./3);
+        } else {
+            double x = 2*M_PI*rhoL0;
+            return magic1*_r0L0m53*(magic2-fast_pow(x, 5./6)*boost::math::cyl_bessel_k(5./6, x));
+        }
+    }
+
+    double VonKarmanInfo::kValueNoTrunc(double k) const {
+    // k in inverse arcsec
+        return fmath::expd(-0.5*structureFunction(_lam*k*ARCSEC2RAD/(2*M_PI)));
+    }
+
+    double VonKarmanInfo::kValue(double k) const {
+    // k in inverse arcsec
+    // We're subtracting the asymptotic kValue limit here so that kValue->0 as k->inf.
+    // This means we should also rescale by (1-_deltaAmplitude) though, so we still retain
+    // kValue(0)=1.
+        double val = (kValueNoTrunc(k) - _deltaAmplitude)/(1-_deltaAmplitude);
+        if (std::abs(val) < std::numeric_limits<double>::epsilon())
+            return 0.0;
+        return val;
+    }
+
+    class VKIXIntegrand : public std::unary_function<double,double>
+    {
+    public:
+        VKIXIntegrand(double r, const VonKarmanInfo& vki) : _r(r), _vki(vki) {}
+        double operator()(double k) const { return _vki.kValue(k)*j0(k*_r)*k; }
+    private:
+        const double _r;  //arcsec
+        const VonKarmanInfo& _vki;
+    };
+
+    double VonKarmanInfo::xValue(double r) const {
+    // r in arcsec
+        VKIXIntegrand I(r, *this);
+        integ::IntRegion<double> reg(0, integ::MOCK_INF);
+        return integ::int1d(I, reg,
+                            _gsparams->integration_relerr,
+                            _gsparams->integration_abserr)/(2.*M_PI);
+    }
+
+    void VonKarmanInfo::_buildRadialFunc() {
+        // set_verbose(2);
+        double r = 0.0;
+        double val = xValue(0.0); // This is the value without the delta function (clearly).
+        _radial.addEntry(r, val);
+        dbg<<"f(0) = "<<val<<" arcsec^-2\n";
+
+        double r0 = 0.05*_gsparams->table_spacing * sqrt(sqrt(_gsparams->xvalue_accuracy / 10.));
+        double logr = log(r0);
+        double dr = 0;
+        double dlogr = 0.1*_gsparams->table_spacing * sqrt(sqrt(_gsparams->xvalue_accuracy / 10.));
+        dbg<<"r0 = "<<r0<<" arcsec\n";
+        dbg<<"dlogr = "<<dlogr<<"\n";
+
+        double sum = 0.0;
+        if (_doDelta) sum += _deltaAmplitude;
+
+        xdbg<<"sum = "<<sum<<'\n';
+
+        double thresh1 = (1.-_gsparams->folding_threshold);
+        double thresh2 = (1.-_gsparams->folding_threshold/2);
+        double R = 1e10;
+        _hlr = 1e10;
+        double maxR = 60.0; // hard cut at 1 arcminute.
+        for(r = exp(logr);
+            (r < _gsparams->stepk_minimum_hlr*_hlr) || (r < R) || (sum < thresh2);
+            logr += dlogr, r=exp(logr), dr=r*(1-exp(-dlogr)))
+        {
+            val = xValue(r);
+            xdbg<<"f("<<r<<") = "<<val<<'\n';
+            _radial.addEntry(r, val);
+
+            sum += 2*M_PI*val*r*dr;
+            xdbg<<"dr = "<<dr<<'\n';
+            xdbg<<"sum = "<<sum<<'\n';
+
+            if (_hlr == 1e10 && sum > 0.5) {
+                _hlr = r;
+                dbg<<"hlr = "<<_hlr<<" arcsec\n";
+            }
+            if (R == 1e10 && sum > thresh1) R=r;
+            if (r >= maxR) {
+                if (_hlr == 1e10)
+                    throw SBError("Cannot find von Karman half-light-radius.");
+                R = maxR;
+                break;
+            }
+        }
+        dbg<<"Finished building radial function.\n";
+        dbg<<"R = "<<R<<" arcsec\n";
+        dbg<<"HLR = "<<_hlr<<" arcsec\n";
+        R = std::max(R, _gsparams->stepk_minimum_hlr*_hlr);
+        _stepk = M_PI / R;
+        dbg<<"stepk = "<<_stepk<<" arcsec^-1\n";
+        dbg<<"sum = "<<sum<<"   (should be ~= 0.997)\n";
+        if (sum < 0.997)
+            throw SBError("Could not find folding_threshold");
+
+        std::vector<double> range(2, 0.);
+        range[1] = _radial.argMax();
+        _sampler.reset(new OneDimensionalDeviate(_radial, range, true, _gsparams));
+    }
+
+    boost::shared_ptr<PhotonArray> VonKarmanInfo::shoot(int N, UniformDeviate ud) const
+    {
+        assert(_sampler.get());
+        return _sampler->shoot(N,ud);
+    }
+
+    LRUCache<boost::tuple<double,double,double,bool,GSParamsPtr>,VonKarmanInfo>
+        SBVonKarman::SBVonKarmanImpl::cache(sbp::max_vonKarman_cache);
+
+    //
+    //
+    //
+    //SBVonKarmanImpl
+    //
+    //
+    //
+
+    SBVonKarman::SBVonKarmanImpl::SBVonKarmanImpl(double lam, double r0, double L0, double flux,
+                                                  double scale, bool doDelta,
+                                                  const GSParamsPtr& gsparams) :
+        SBProfileImpl(gsparams),
+        _lam(lam),
+        _r0(r0),
+        _L0(L0),
+        _flux(flux),
+        _scale(scale),
+        _doDelta(doDelta),
+        _info(cache.get(boost::make_tuple(1e-9*lam, r0, L0, doDelta, this->gsparams.duplicate())))
+    { }
+
+    double SBVonKarman::SBVonKarmanImpl::maxK() const
+    { return _info->maxK()*_scale; }
+
+    double SBVonKarman::SBVonKarmanImpl::stepK() const
+    { return _info->stepK()*_scale; }
+
+    double SBVonKarman::SBVonKarmanImpl::getDeltaAmplitude() const
+    { return _info->getDeltaAmplitude()*_flux; }
+
+    double SBVonKarman::SBVonKarmanImpl::getHalfLightRadius() const
+    { return _info->getHalfLightRadius()/_scale; }
+
+    std::string SBVonKarman::SBVonKarmanImpl::serialize() const
+    {
+        std::ostringstream oss(" ");
+        oss.precision(std::numeric_limits<double>::digits10 + 4);
+        oss << "galsim._galsim.SBVonKarman("
+            <<getLam()<<", "
+            <<getR0()<<", "
+            <<getL0()<<", "
+            <<getFlux()<<", "
+            <<getScale()<<", "
+            <<getDoDelta()<<", "
+            <<"galsim.GSParams("<<*gsparams<<"))";
+        return oss.str();
+    }
+
+    double SBVonKarman::SBVonKarmanImpl::structureFunction(double rho) const
+    {
+        xdbg<<"rho = "<<rho<<'\n';
+        return _info->structureFunction(rho);
+    }
+
+    double SBVonKarman::SBVonKarmanImpl::kValue(double k) const
+    // this kValue assumes k is in inverse arcsec
+    {
+        return _info->kValue(k)*_flux;
+    }
+
+    std::complex<double> SBVonKarman::SBVonKarmanImpl::kValue(const Position<double>& p) const
+    // k in units of _scale.
+    {
+        return kValue(sqrt(p.x*p.x+p.y*p.y)/_scale);
+    }
+
+    class VKXIntegrand : public std::unary_function<double,double>
+    {
+    public:
+        VKXIntegrand(double r, const SBVonKarman::SBVonKarmanImpl& sbvki) :
+            _r(r), _sbvki(sbvki)
+        {}
+
+        double operator()(double k) const { return _sbvki.kValue(k)*k*j0(k*_r); }
+    private:
+        double _r;
+        const SBVonKarman::SBVonKarmanImpl& _sbvki;
+    };
+
+    double SBVonKarman::SBVonKarmanImpl::xValue(double r) const {
+    // r in arcsec.
+        VKXIntegrand I(r, *this);
+        return integ::int1d(I, 0.0, integ::MOCK_INF,
+                            gsparams->integration_relerr, gsparams->integration_abserr)/(2*M_PI);
+    }
+
+    double SBVonKarman::SBVonKarmanImpl::xValue(const Position<double>& p) const
+    // r in units of _scale
+    {
+        return xValue(sqrt(p.x*p.x+p.y*p.y)*_scale);
+    }
+
+    boost::shared_ptr<PhotonArray> SBVonKarman::SBVonKarmanImpl::shoot(
+        int N, UniformDeviate ud) const
+    {
+        dbg<<"VonKarman shoot: N = "<<N<<std::endl;
+        dbg<<"Target flux = "<<getFlux()<<std::endl;
+        // Get photons from the VonKarmanInfo structure, rescale flux and size for this instance
+        boost::shared_ptr<PhotonArray> result = _info->shoot(N,ud);
+        result->scaleFlux(_flux);
+        result->scaleXY(_scale);
+        dbg<<"VonKarman Realized flux = "<<result->getTotalFlux()<<std::endl;
+        return result;
+    }
+
+}

--- a/src/files.txt
+++ b/src/files.txt
@@ -25,6 +25,7 @@ SBKolmogorov.cpp
 SBSpergel.cpp
 SBInclinedExponential.cpp
 SBInclinedSersic.cpp
+SBVonKarman.cpp
 Table.cpp
 RealSpaceConvolve.cpp
 Random.cpp

--- a/tests/galsim_test_helpers.py
+++ b/tests/galsim_test_helpers.py
@@ -251,7 +251,7 @@ def do_shoot(prof, img, name):
     # even for slow convergers like Airy (which needs a _very_ large image) or Sersic.
     if 'Airy' in name:
         img = galsim.ImageD(2048,2048, scale=dx)
-    elif 'Sersic' in name or 'DeVauc' in name or 'Spergel' in name:
+    elif 'Sersic' in name or 'DeVauc' in name or 'Spergel' in name or 'VonKarman' in name:
         img = galsim.ImageD(512,512, scale=dx)
     else:
         img = galsim.ImageD(128,128, scale=dx)

--- a/tests/galsim_test_helpers.py
+++ b/tests/galsim_test_helpers.py
@@ -617,10 +617,10 @@ else:
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
                 yield w
-            assert len(w) >= 1, \
-                    "Calling %s did not raise a warning with %s, %s"%(f, args, kwargs)
+            assert len(w) >= 1, "Expected warning %s was not raised."%(wtype)
             assert issubclass(w[0].category, wtype), \
-                    "%s with %s, %s raised the wrong warning type"%(f, args, kwargs)
+                    "Warning raised was the wrong type (got %s, expected %s)"%(
+                    w[0].category, wtype)
         else:
             # When used as a regular function
             func = args[0]

--- a/tests/test_vonkarman.py
+++ b/tests/test_vonkarman.py
@@ -52,6 +52,10 @@ def test_vk(slow=False):
                 for do_delta in do_deltas:
                     kwargs = {'lam':lam, 'r0':r0, 'L0':L0, 'do_delta':do_delta}
                     print(kwargs)
+                    delta_amp = np.exp(-0.5*0.172629*(r0/L0)**(-5./3.))
+                    if delta_amp > 1.e-3:
+                        print("Skip this combination, since delta > maxk_threshold")
+                        continue
 
                     vk = galsim.VonKarman(flux=2.2, gsparams=gsp, **kwargs)
                     np.testing.assert_almost_equal(vk.flux, 2.2)

--- a/tests/test_vonkarman.py
+++ b/tests/test_vonkarman.py
@@ -34,6 +34,7 @@ except ImportError:
 def test_vk(slow=False):
     """Test the generation of VonKarman profiles
     """
+    gsp = galsim.GSParams(maximum_fft_size=8192)
     if __name__ == '__main__' and slow:
         lams = [300.0, 500.0, 1100.0]
         r0_500s = [0.05, 0.15, 0.3]
@@ -52,7 +53,7 @@ def test_vk(slow=False):
                     kwargs = {'lam':lam, 'r0':r0, 'L0':L0, 'do_delta':do_delta}
                     print(kwargs)
 
-                    vk = galsim.VonKarman(flux=2.2, **kwargs)
+                    vk = galsim.VonKarman(flux=2.2, gsparams=gsp, **kwargs)
                     np.testing.assert_almost_equal(vk.flux, 2.2)
 
                     check_basic(vk, "VonKarman")
@@ -61,8 +62,9 @@ def test_vk(slow=False):
                     do_pickle(vk._sbp, lambda x: (x.getFlux(), x.getGSParams()))
 
                     img = galsim.Image(16, 16, scale=0.2)
-                    do_shoot(vk, img, "VonKarman")
-                    do_kvalue(vk, img, "VonKarman")
+                    if not do_delta:
+                        do_shoot(vk, img, "VonKarman")
+                        do_kvalue(vk, img, "VonKarman")
 
 
 @timer

--- a/tests/test_vonkarman.py
+++ b/tests/test_vonkarman.py
@@ -70,14 +70,12 @@ def test_vk_delta():
     """Test a VonKarman with a significant delta-function amplitude"""
     kwargs = {'lam':1100.0, 'r0':0.8, 'L0':5.0, 'flux':2.2}
     # Try to see if we can catch the warning first
-    try:
-        if 'assert_warns' in np.testing.__dict__:
-            np.testing.assert_warns(galsim.VonKarman, **kwargs)
-    except ImportError:
-        print('The assert_raises tests require nose')
+    with assert_warns(UserWarning):
+        vk = galsim.VonKarman(**kwargs)
 
     kwargs['suppress_warning'] = True
     vk = galsim.VonKarman(**kwargs)
+    do_pickle(vk)
 
     # This profile has more than 15% of its flux in the delta-function component.
     np.testing.assert_array_less(0.15, vk.delta_amplitude/vk.flux)
@@ -85,6 +83,7 @@ def test_vk_delta():
     np.testing.assert_almost_equal(vk.kValue(1e10, 0).real, 0.0)
     # But if we use do_delta=True, then the asymptotic kValue should be that of the delta function.
     vkd = galsim.VonKarman(do_delta=True, **kwargs)
+    do_pickle(vkd)
     np.testing.assert_almost_equal(vkd.kValue(1e10, 0).real, vkd.delta_amplitude)
 
     # Either way, the fluxes should be the same.
@@ -100,7 +99,8 @@ def test_vk_scale():
     """Test vk scale argument"""
     kwargs = {'lam':500, 'r0':0.2, 'L0':25.0, 'flux':2.2}
     vk_arcsec = galsim.VonKarman(scale_unit=galsim.arcsec, **kwargs)
-    vk_arcmin = galsim.VonKarman(scale_unit=galsim.arcmin, **kwargs)
+    vk_arcmin = galsim.VonKarman(scale_unit='arcmin', **kwargs)
+    do_pickle(vk_arcmin)
 
     np.testing.assert_almost_equal(vk_arcsec.flux, vk_arcmin.flux)
     np.testing.assert_almost_equal(vk_arcsec.kValue(0.0, 0.0), vk_arcmin.kValue(0.0, 0.0))
@@ -118,7 +118,7 @@ def test_vk_ne():
 
     objs = [galsim.VonKarman(lam=500.0, r0=0.2, L0=25.0),
             galsim.VonKarman(lam=500.0, r0=0.2, L0=25.0, flux=2.2),
-            galsim.VonKarman(lam=500.0, r0=0.2, L0=20.0),
+            galsim.VonKarman(lam=500.0, r0=0.2, L0=1e11),
             galsim.VonKarman(lam=500.0, r0=0.1, L0=20.0),
             galsim.VonKarman(lam=550.0, r0=0.1, L0=20.0),
             galsim.VonKarman(lam=550.0, r0=0.1, L0=20.0, do_delta=True),
@@ -158,6 +158,7 @@ def vk_benchmark():
         vk.drawImage(nx=16, ny=16, scale=0.2, method='phot', n_photons=50000)
     t3 = time.time()
     print("Time to photon-shoot 100 more with 50000 photons each: {:6.3f}s".format(t3-t2))
+
 
 if __name__ == "__main__":
     from argparse import ArgumentParser

--- a/tests/test_vonkarman.py
+++ b/tests/test_vonkarman.py
@@ -35,7 +35,7 @@ def test_vk(slow=False):
     """Test the generation of VonKarman profiles
     """
     gsp = galsim.GSParams(maximum_fft_size=8192)
-    if __name__ == '__main__' and slow:
+    if slow:
         lams = [300.0, 500.0, 1100.0]
         r0_500s = [0.05, 0.15, 0.3]
         L0s = [1e10, 25.0, 10.0]
@@ -216,7 +216,7 @@ def vk_benchmark():
 if __name__ == "__main__":
     from argparse import ArgumentParser
     parser = ArgumentParser()
-    parser.add_argument("--slow", action='store_true', help="Run slow tests")
+    parser.add_argument("--slow", action='store', default=1, help="Run slow tests")
     parser.add_argument("--benchmark", action='store_true', help="Run timing benchmark")
     parser.add_argument("--profile", action='store_true', help="Profile the tests")
     args = parser.parse_args()

--- a/tests/test_vonkarman.py
+++ b/tests/test_vonkarman.py
@@ -1,0 +1,175 @@
+# Copyright (c) 2012-2017 by the GalSim developers team on GitHub
+# https://github.com/GalSim-developers
+#
+# This file is part of GalSim: The modular galaxy image simulation toolkit.
+# https://github.com/GalSim-developers/GalSim
+#
+# GalSim is free software: redistribution and use in source and binary forms,
+# with or without modification, are permitted provided that the following
+# conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions, and the disclaimer given in the accompanying LICENSE
+#    file.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions, and the disclaimer given in the documentation
+#    and/or other materials provided with the distribution.
+#
+
+from __future__ import print_function
+import numpy as np
+import os
+import sys
+
+from galsim_test_helpers import *
+
+try:
+    import galsim
+except ImportError:
+    sys.path.append(os.path.abspath(os.path.join(path, "..")))
+    import galsim
+
+
+@timer
+def test_vk(slow=False):
+    """Test the generation of VonKarman profiles
+    """
+    if __name__ == '__main__' and slow:
+        lams = [300.0, 500.0, 1100.0]
+        r0_500s = [0.05, 0.15, 0.3]
+        L0s = [1e10, 25.0, 10.0]
+        do_deltas = [False, True]
+    else:
+        lams = [500.0]
+        r0_500s = [0.2]
+        L0s = [25.0]
+        do_deltas = [False]
+    for lam in lams:
+        for r0_500 in r0_500s:
+            r0 = r0_500*(lam/500)**(6./5)
+            for L0 in L0s:
+                for do_delta in do_deltas:
+                    kwargs = {'lam':lam, 'r0':r0, 'L0':L0, 'do_delta':do_delta}
+                    print(kwargs)
+
+                    vk = galsim.VonKarman(flux=2.2, **kwargs)
+                    np.testing.assert_almost_equal(vk.flux, 2.2)
+
+                    check_basic(vk, "VonKarman")
+                    do_pickle(vk)
+                    do_pickle(vk._sbp)
+                    do_pickle(vk._sbp, lambda x: (x.getFlux(), x.getGSParams()))
+
+                    img = galsim.Image(16, 16, scale=0.2)
+                    do_shoot(vk, img, "VonKarman")
+                    do_kvalue(vk, img, "VonKarman")
+
+
+@timer
+def test_vk_delta():
+    """Test a VonKarman with a significant delta-function amplitude"""
+    kwargs = {'lam':1100.0, 'r0':0.8, 'L0':5.0, 'flux':2.2}
+    # Try to see if we can catch the warning first
+    try:
+        if 'assert_warns' in np.testing.__dict__:
+            np.testing.assert_warns(galsim.VonKarman, **kwargs)
+    except ImportError:
+        print('The assert_raises tests require nose')
+
+    kwargs['suppress_warning'] = True
+    vk = galsim.VonKarman(**kwargs)
+
+    # This profile has more than 15% of its flux in the delta-function component.
+    np.testing.assert_array_less(0.15, vk.delta_amplitude/vk.flux)
+    # If do_delta is False (the default), then the asymptotic kValue should still be zero.
+    np.testing.assert_almost_equal(vk.kValue(1e10, 0).real, 0.0)
+    # But if we use do_delta=True, then the asymptotic kValue should be that of the delta function.
+    vkd = galsim.VonKarman(do_delta=True, **kwargs)
+    np.testing.assert_almost_equal(vkd.kValue(1e10, 0).real, vkd.delta_amplitude)
+
+    # Either way, the fluxes should be the same.
+    np.testing.assert_almost_equal(vk.flux, vkd.flux)
+    assert vk != vkd
+    # The half-light-radius of the profile with do_delta=True should be smaller though, as we're
+    # accounting for the 15% flux at r=0 in this case
+    assert vkd.half_light_radius < vk.half_light_radius
+
+
+@timer
+def test_vk_scale():
+    """Test vk scale argument"""
+    kwargs = {'lam':500, 'r0':0.2, 'L0':25.0, 'flux':2.2}
+    vk_arcsec = galsim.VonKarman(scale_unit=galsim.arcsec, **kwargs)
+    vk_arcmin = galsim.VonKarman(scale_unit=galsim.arcmin, **kwargs)
+
+    np.testing.assert_almost_equal(vk_arcsec.flux, vk_arcmin.flux)
+    np.testing.assert_almost_equal(vk_arcsec.kValue(0.0, 0.0), vk_arcmin.kValue(0.0, 0.0))
+    np.testing.assert_almost_equal(vk_arcsec.kValue(0.0, 10.0), vk_arcmin.kValue(0.0, 600.0))
+    np.testing.assert_almost_equal(vk_arcsec.xValue(0.0, 6.0), vk_arcmin.xValue(0.0, 0.1))
+
+    img1 = vk_arcsec.drawImage(nx=32, ny=32, scale=0.2)
+    img2 = vk_arcmin.drawImage(nx=32, ny=32, scale=0.2/60.0)
+    np.testing.assert_almost_equal(img1.array, img2.array)
+
+
+@timer
+def test_vk_ne():
+    gsp = galsim.GSParams(maxk_threshold=1.1e-3, folding_threshold=5.1e-3)
+
+    objs = [galsim.VonKarman(lam=500.0, r0=0.2, L0=25.0),
+            galsim.VonKarman(lam=500.0, r0=0.2, L0=25.0, flux=2.2),
+            galsim.VonKarman(lam=500.0, r0=0.2, L0=20.0),
+            galsim.VonKarman(lam=500.0, r0=0.1, L0=20.0),
+            galsim.VonKarman(lam=550.0, r0=0.1, L0=20.0),
+            galsim.VonKarman(lam=550.0, r0=0.1, L0=20.0, do_delta=True),
+            galsim.VonKarman(lam=550.0, r0=0.1, L0=20.0, scale_unit=galsim.arcmin),
+            galsim.VonKarman(lam=550.0, r0=0.1, L0=20.0, gsparams=gsp)]
+    all_obj_diff(objs)
+
+
+@timer
+def test_vk_eq_kolm():
+    lam = 500.0
+    r0 = 0.2
+    L0 = 3e5  # Need to make this surprisingly large to make vk -> kolm.
+    flux = 3.3
+    kolm = galsim.Kolmogorov(lam=lam, r0=r0, flux=flux)
+    vk = galsim.VonKarman(lam=lam, r0=r0, L0=L0, flux=flux)
+
+    np.testing.assert_allclose(kolm.xValue(0,0), vk.xValue(0,0), rtol=1e-3, atol=0)
+
+    kolm_img = kolm.drawImage(nx=24, ny=24, scale=0.2)
+    vk_img = vk.drawImage(nx=24, ny=24, scale=0.2)
+    np.testing.assert_allclose(kolm_img.array, vk_img.array, atol=flux*1e-5, rtol=0)
+
+
+def vk_benchmark():
+    import time
+    t0 = time.time()
+    vk = galsim.VonKarman(lam=700, r0=0.1, L0=24.3)
+    vk.drawImage(nx=16, ny=16, scale=0.2)
+    t1 = time.time()
+    print("Time to create/draw first time: {:6.3f}s".format(t1-t0))
+    for i in range(10):
+        vk.drawImage(nx=16, ny=16, scale=0.2)
+    t2 = time.time()
+    print("Time to draw 10 more: {:6.3f}s".format(t2-t1))
+    for i in range(100):
+        vk.drawImage(nx=16, ny=16, scale=0.2, method='phot', n_photons=50000)
+    t3 = time.time()
+    print("Time to photon-shoot 100 more with 50000 photons each: {:6.3f}s".format(t3-t2))
+
+if __name__ == "__main__":
+    from argparse import ArgumentParser
+    parser = ArgumentParser()
+    parser.add_argument("--slow", action='store_true', help="Run slow tests")
+    parser.add_argument("--benchmark", action='store_true', help="Run timing benchmark")
+    args = parser.parse_args()
+
+    test_vk(args.slow)
+    test_vk_delta()
+    test_vk_scale()
+    test_vk_ne()
+    test_vk_eq_kolm()
+    if args.benchmark:
+        vk_benchmark()

--- a/tests/test_vonkarman.py
+++ b/tests/test_vonkarman.py
@@ -122,10 +122,10 @@ def test_vk_scale():
 def test_vk_ne():
     gsp = galsim.GSParams(maxk_threshold=1.1e-3, folding_threshold=5.1e-3)
 
-    objs = [galsim.VonKarman(lam=500.0, r0=0.2, L0=25.0),
-            galsim.VonKarman(lam=500.0, r0=0.2, L0=25.0, flux=2.2),
+    objs = [galsim.VonKarman(lam=500.0, r0=0.2),
+            galsim.VonKarman(lam=500.0, r0=0.2, L0=20.0),
+            galsim.VonKarman(lam=500.0, r0=0.2, L0=20.0, flux=2.2),
             galsim.VonKarman(lam=500.0, r0=0.2, L0=1e11),
-            galsim.VonKarman(lam=500.0, r0=0.1, L0=20.0),
             galsim.VonKarman(lam=550.0, r0=0.1, L0=20.0),
             galsim.VonKarman(lam=550.0, r0=0.1, L0=20.0, do_delta=True),
             galsim.VonKarman(lam=550.0, r0=0.1, L0=20.0, scale_unit=galsim.arcmin),

--- a/tests/test_vonkarman.py
+++ b/tests/test_vonkarman.py
@@ -177,6 +177,20 @@ def test_vk_fitting_formulae():
         np.testing.assert_allclose(FWHM_ratio, predicted_FWHM_ratio(r0, L0), rtol=0.015)
 
 
+def test_vk_gsp():
+    """Test that we can construct a vK with non-standard folding_threshold.
+    """
+    # default folding_threshold is 5e-3.
+    # We can't go too much smaller than this for such a flat asymptotic profile, but check a little
+    # bit further works.
+    gsp1 = galsim.GSParams(folding_threshold=1e-2)
+    gsp2 = galsim.GSParams(folding_threshold=2e-3)
+
+    # Just testing that these construct successfully
+    galsim.VonKarman(lam=700, r0=0.1, L0=24.3, gsparams=gsp1)
+    galsim.VonKarman(lam=700, r0=0.1, L0=24.3, gsparams=gsp2)
+
+
 def vk_benchmark():
     import time
     t0 = time.time()
@@ -207,5 +221,6 @@ if __name__ == "__main__":
     test_vk_ne()
     test_vk_eq_kolm()
     test_vk_fitting_formulae()
+    test_vk_gsp()
     if args.benchmark:
         vk_benchmark()

--- a/tests/test_vonkarman.py
+++ b/tests/test_vonkarman.py
@@ -181,6 +181,7 @@ def test_vk_fitting_formulae():
         np.testing.assert_allclose(FWHM_ratio, predicted_FWHM_ratio(r0, L0), rtol=0.015)
 
 
+@timer
 def test_vk_gsp():
     """Test that we can construct a vK with non-standard folding_threshold.
     """
@@ -217,7 +218,13 @@ if __name__ == "__main__":
     parser = ArgumentParser()
     parser.add_argument("--slow", action='store_true', help="Run slow tests")
     parser.add_argument("--benchmark", action='store_true', help="Run timing benchmark")
+    parser.add_argument("--profile", action='store_true', help="Profile the tests")
     args = parser.parse_args()
+
+    if args.profile:
+        import cProfile, pstats
+        pr = cProfile.Profile()
+        pr.enable()
 
     test_vk(args.slow)
     test_vk_delta()
@@ -228,3 +235,8 @@ if __name__ == "__main__":
     test_vk_gsp()
     if args.benchmark:
         vk_benchmark()
+
+    if args.profile:
+        pr.disable()
+        ps = pstats.Stats(pr).sort_stats('tottime')
+        ps.print_stats(30)

--- a/tests/test_vonkarman.py
+++ b/tests/test_vonkarman.py
@@ -80,7 +80,7 @@ def test_vk_delta():
     do_pickle(vk)
 
     # This profile has more than 15% of its flux in the delta-function component.
-    np.testing.assert_array_less(0.15, vk.delta_amplitude/vk.flux)
+    assert vk.delta_amplitude > 0.15 * vk.flux
     # If do_delta is False (the default), then the asymptotic kValue should still be zero.
     np.testing.assert_almost_equal(vk.kValue(1e10, 0).real, 0.0)
     # But if we use do_delta=True, then the asymptotic kValue should be that of the delta function.
@@ -183,15 +183,15 @@ def vk_benchmark():
     vk = galsim.VonKarman(lam=700, r0=0.1, L0=24.3)
     vk.drawImage(nx=16, ny=16, scale=0.2)
     t1 = time.time()
-    print("Time to create/draw first time: {:6.3f}s".format(t1-t0))
+    print("Time to create/draw first time: {:6.3f}s".format(t1-t0))  # ~0.7s
     for i in range(10):
         vk.drawImage(nx=16, ny=16, scale=0.2)
     t2 = time.time()
-    print("Time to draw 10 more: {:6.3f}s".format(t2-t1))
+    print("Time to draw 10 more: {:6.3f}s".format(t2-t1))  # ~0.07s
     for i in range(100):
         vk.drawImage(nx=16, ny=16, scale=0.2, method='phot', n_photons=50000)
     t3 = time.time()
-    print("Time to photon-shoot 100 more with 50000 photons each: {:6.3f}s".format(t3-t2))
+    print("Time to photon-shoot 100 more with 50000 photons each: {:6.3f}s".format(t3-t2))  # ~0.9s
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds the VonKarman profile, which is a generalization of a Kolmogorov profile that adds an outer scale to the modeled atmospheric turbulence power spectrum.

This code emerged as part of the effort to implement a "second kick" profile that would help with photon shooting an atmospheric phase screen PSF.  Rather than trying to cherry-pick specific commits from that development branch, I found it easier to just copy the appropriate subset of files into a new branch and make a single commit.  So I'm afraid reviewers won't get to see my normal set of false-starts and other fumblings on this PR, (though they're still available in the `secondkick` branch).

The main surprise I encountered with the VonKarman profile was the realization that at its center, there's formally a delta-function component.  By default, the code doesn't actually implement this, since for most parameter combinations its fractional amplitude is ~10^-100 or smaller.  If the user really does want to acknowledge the delta-function though, it's possible via a keyword.