### PR TITLE
Fix memory leak in PhaseScreenPSF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Bug Fixes
 - Fixed a number of small bugs in the config processing uncovered by the
   galsim_extra FocalPlane output type. (#928)
 - Fixed python3 unicode/str mismatches in tests/SConscript (#932)
-
+- Fixed memory leak when drawing PhaseScreenPSFs using photon-shooting (#942)
 
 Deprecated Features
 -------------------

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -756,11 +756,12 @@ class PhaseScreenList(object):
         while(self._update_time_heap):
             # Get and seek to next time that has a PSF update.
             t, i = heappop(self._update_time_heap)
-            self._seek(t)
-            # Update that PSF
+            # Check if that PSF weakref is still alive
             psfref = self._pending[i]
             psf = psfref()
             if psf is not None:
+                # Update that PSF
+                self._seek(t)
                 psf._step()
                 # If that PSF's next possible update time doesn't extend past its exptime, then
                 # push it back on the heap.

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -21,6 +21,7 @@ Module containing general utilities for the GalSim software.
 from contextlib import contextmanager
 from future.utils import iteritems
 from builtins import range, object
+import weakref
 
 import numpy as np
 import galsim
@@ -1419,3 +1420,9 @@ class lazy_property(object):
         value = self.fget(obj)
         setattr(obj, self.func_name, value)
         return value
+
+
+# Assign an arbitrary ordering to weakref.ref so that it can be part of a heap.
+class OrderedWeakRef(weakref.ref):
+    def __lt__(self, other):
+        return id(self) < id(other)

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -696,6 +696,20 @@ def test_gc():
     gc.collect()
     assert not any([isinstance(it, galsim.phase_psf.PhaseScreenPSF) for it in gc.get_objects()])
 
+    # A corner case revealed in coverage tests:
+    # Make sure that everything still works if some, but not all static pending PSFs are deleted.
+    screen = galsim.OpticalScreen(diam=1.1)
+    phaseScreenList = galsim.PhaseScreenList(screen)
+    psf1 = phaseScreenList.makePSF(lam=1000.0, diam=1.1)
+    psf2 = phaseScreenList.makePSF(lam=1000.0, diam=1.1)
+    psf3 = phaseScreenList.makePSF(lam=1000.0, diam=1.1)
+    del psf2
+    psf1.drawImage(nx=10, ny=10, scale=0.2)
+    del psf1, psf3
+    assert phaseScreenList._pending == []
+    gc.collect()
+    assert not any([isinstance(it, galsim.phase_psf.PhaseScreenPSF) for it in gc.get_objects()])
+
 
 if __name__ == "__main__":
     test_aperture()

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -684,7 +684,7 @@ def test_gc():
     # If we draw one using photon-shooting, it still exists in _pending
     psf = atm.makePSF(exptime=0.02, time_step=0.01, diam=1.1, lam=1000.0)
     psf.drawImage(nx=10, ny=10, scale=0.2, method='phot', n_photons=100)
-    assert psf in [p() for p in atm._pending]
+    assert psf in [p[1]() for p in atm._pending]
 
     # If we draw even one of many using fft, _pending gets completely emptied
     psf2 = atm.makePSF(exptime=0.02, time_step=0.01, diam=1.1, lam=1000.0)

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -662,6 +662,41 @@ def test_speedup():
     assert (t1-t0) < 0.1, "Photon-shooting took too long ({0} s).".format(t1-t0)
 
 
+@timer
+def test_gc():
+    """Make sure that pending psfs don't leak memory.
+    """
+    import gc
+    atm = galsim.Atmosphere(screen_size=10.0, altitude=0, r0_500=0.15)
+
+    # First check that no PhaseScreenPSFs are known to the garbage collector
+    assert not any([isinstance(it, galsim.phase_psf.PhaseScreenPSF) for it in gc.get_objects()])
+
+    # Make a PhaseScreenPSF and check that it s known to the garbage collector
+    psf = atm.makePSF(exptime=0.02, time_step=0.01, diam=1.1, lam=1000.0)
+    assert any([isinstance(it, galsim.phase_psf.PhaseScreenPSF) for it in gc.get_objects()])
+
+    # If we delete it, it disappears everywhere
+    del psf
+    gc.collect()
+    assert not any([isinstance(it, galsim.phase_psf.PhaseScreenPSF) for it in gc.get_objects()])
+
+    # If we draw one using photon-shooting, it still exists in _pending
+    psf = atm.makePSF(exptime=0.02, time_step=0.01, diam=1.1, lam=1000.0)
+    psf.drawImage(nx=10, ny=10, scale=0.2, method='phot', n_photons=100)
+    assert psf in [p() for p in atm._pending]
+
+    # If we draw even one of many using fft, _pending gets completely emptied
+    psf2 = atm.makePSF(exptime=0.02, time_step=0.01, diam=1.1, lam=1000.0)
+    psf.drawImage(nx=10, ny=10, scale=0.2)
+    assert atm._pending == []
+
+    # And if then deleted, they again don't exist anywhere
+    del psf, psf2
+    gc.collect()
+    assert not any([isinstance(it, galsim.phase_psf.PhaseScreenPSF) for it in gc.get_objects()])
+
+
 if __name__ == "__main__":
     test_aperture()
     test_atm_screen_size()
@@ -678,3 +713,4 @@ if __name__ == "__main__":
     test_input()
     test_r0_weights()
     test_speedup()
+    test_gc()


### PR DESCRIPTION
This PR fixes the memory leak described in #942.

I decided my original plan to just delete PSFs from `_pending` after drawing them using either `method='phot'` or `method='fft'` doesn't actually work, since it ought be possible to do both in sequence without losing the speed advantage offered via `_pending`.

My new idea is to instead use the`weakref` module.  This lets a `PhaseScreenList` still refer to any dependent `PhaseScreenPSF`s in the `_pending` list, but won't keep them alive if those weak references are the only references to the PSFs, thus eliminating the memory leak.