### PR TITLE
#952 Fix error in findExtremum not preserving intended invariants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -311,9 +311,17 @@ Changes from v1.5.0 to v1.5.1
 New Feature
 -----------
 
-- Add option to use circular weight function in HSM adaptive moments code. (#917)
+- Add option to use circular weight function in HSM adaptive moments code.
+  (#917)
 
 Bug Fix
 -------
 
 - Fixed a build problem for Anaconda on Macs using Python 3.6. (#924)
+
+
+Change from v1.5.1 to v1.5.2
+============================
+
+- Fixed bug that could cause Kolmogorov (and probably some other classes) to
+  go into an endless loop. (#952)

--- a/src/OneDimensionalDeviate.cpp
+++ b/src/OneDimensionalDeviate.cpp
@@ -84,23 +84,24 @@ namespace galsim {
         xdbg<<"f("<<x2<<") = "<<f2<<" = "<<function(x2)<<std::endl;
         xdbg<<"f("<<x3<<") = "<<f3<<" = "<<function(x3)<<std::endl;
 
-        // First guess is that minimum is in half of bracket with lowest gradient
-        bool fatLeft = std::abs(df1) < std::abs(df2);
+        // Fat left tells which side is the fatter one.  Keep splitting the fatter side.
+        bool fatLeft = (x2-x1) > (x3-x2);
 
         // Then use golden sections to localize - could use Brent's method for speed.
+        // Based on Numerical Recipes 10.1.
         const double GOLDEN = 2./(1+sqrt(5.));
         while (std::abs(x3-x1) > xTolerance) {
             xdbg<<"x1,x2,x3 = "<<x1<<','<<x2<<','<<x3<<std::endl;
             xdbg<<"f1,f2,f3 = "<<f1<<','<<f2<<','<<f3<<std::endl;
             xdbg<<"df1,df2 = "<<df1<<','<<df2<<std::endl;
-            xdbg<<"fatleft = "<<fatLeft<<"  "<<std::abs(df1)<<" <? "<<std::abs(df2)<<std::endl;
+            xdbg<<"fatleft = "<<fatLeft<<"  "<<x2-x1<<" >? "<<x3-x2<<std::endl;
             // Loop invariants:
             xassert(x1 < x2);
             xassert(x2 < x3);
             xassert(df1 == f2 - f1);
             xassert(df2 == f3 - f2);
             xassert(df1 * df2 < 0.);
-            xassert(fatLeft == (std::abs(df1) < std::abs(df2)));
+            xassert(fatLeft == (x2-x1) > (x3-x2));
 
             if (fatLeft) {
                 xdbg<<"fat left\n";
@@ -115,6 +116,7 @@ namespace galsim {
                     x1 = xTrial;
                     f1 = fTrial;
                     df1 = dfTrial;
+                    fatLeft = (x2-x1) > (x3-x2);
                 } else {
                     xdbg<<"1/trial/2\n";
                     // Now bracketed in 1 / trial / 2
@@ -124,6 +126,7 @@ namespace galsim {
                     f2 = fTrial;
                     df1 = f2 - f1;
                     df2 = dfTrial;
+                    fatLeft = true;
                 }
             } else {
                 xdbg<<"fat right\n";
@@ -138,6 +141,7 @@ namespace galsim {
                     x3 = xTrial;
                     f3 = fTrial;
                     df2 = dfTrial;
+                    fatLeft = (x2-x1) > (x3-x2);
                 } else {
                     xdbg<<"2/trial/3\n";
                     // Now bracketed in 2 / trial / 3
@@ -147,11 +151,12 @@ namespace galsim {
                     f2 = fTrial;
                     df1 = dfTrial;
                     df2 = f3 - f2;
+                    fatLeft = false;
                 }
             }
-            fatLeft = std::abs(df1) < std::abs(df2);
         }
         extremum = x2;
+        xdbg<<"Found extrumum at "<<extremum<<std::endl;
         return true;
     }
 

--- a/src/OneDimensionalDeviate.cpp
+++ b/src/OneDimensionalDeviate.cpp
@@ -155,7 +155,15 @@ namespace galsim {
                 }
             }
         }
-        extremum = x2;
+
+        // Finish with a single quadratic step to tighten up the accuracy.
+        double dx1 = x2-x1;
+        double dx2 = x3-x2;
+        xassert(dx1 > 0);
+        xassert(dx2 > 0);
+        xassert(df1 * df2 < 0);
+        extremum = x2 + 0.5 * (df1*dx2*dx2 + df2*dx1*dx1) / (df1*dx2 - df2*dx1);
+
         xdbg<<"Found extrumum at "<<extremum<<std::endl;
         return true;
     }

--- a/src/SBKolmogorov.cpp
+++ b/src/SBKolmogorov.cpp
@@ -401,6 +401,7 @@ namespace galsim {
         std::vector<double> range(2,0.);
         range[1] = _radial.argMax();
         _sampler.reset(new OneDimensionalDeviate(_radial, range, true, gsparams));
+        dbg<<"made sampler\n";
 
 #ifdef SOLVE_FWHM_HLR
         // Improve upon the conversion between lam_over_r0 and fwhm:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1982,6 +1982,34 @@ def test_kolmogorov_flux_scaling():
 
 
 @timer
+def test_kolmogorov_folding_threshold():
+    """Test Kolmogorov with low folding_threshold.
+    """
+    # This test reproduces a bug reported by Jim Chiang when Kolmogorov has a less than
+    # default folding_threshold.  Reported in Issue #952.
+    # It turned out the problem was in OneDimensionalDeviate's findExtremum going into an
+    # endless loop, mostly because it didn't preserve the intended invariant that x1 < x2 < x3.
+    # In this case, x1 became the largest of the three values and ended up getting larger and
+    # larger indefinitely, thus resulting in an endless loop.
+
+    # The test is really just to construct the object in finite time, but we do a few sanity
+    # checks afterward for good measure.
+
+    fwhm = 0.55344217545630736
+    folding_threshold=0.0008316873626901008
+    gsparams = galsim.GSParams(folding_threshold=folding_threshold)
+
+    obj = galsim.Kolmogorov(fwhm=fwhm, gsparams=gsparams)
+    print('obj = ',obj)
+
+    assert obj.flux == 1.0
+    assert obj.fwhm == fwhm
+    assert obj.gsparams.folding_threshold == folding_threshold
+    check_basic(obj, 'Kolmogorov with low folding_threshold')
+    do_pickle(obj)
+
+
+@timer
 def test_spergel():
     """Test the generation of a specific Spergel profile against a known result.
     """
@@ -2554,6 +2582,7 @@ if __name__ == "__main__":
     test_kolmogorov_properties()
     test_kolmogorov_radii()
     test_kolmogorov_flux_scaling()
+    test_kolmogorov_folding_threshold()
     test_spergel()
     test_spergel_properties()
     test_spergel_radii()


### PR DESCRIPTION
@jchiang87 reported in #952 a combination of input parameters that sent Kolmogorov into an endless loop.  Turns out the problem was in OneDimensionalDeviate.  Specifically the `findExtremum` call ended up having x1 increase without bound until it was inf (and then kept looping unchanged).

The underlying problem seems to be the fatRight case not being properly set up.  It set new values for x1,x2,x3 that didn't preserve the intended invariance that x1 < x2 < x3.  In fact, I'm not even sure how this code used to function properly (which apparently it usually did).

Anyway, I restructured the algorithm a bit and added (when DEBUGLOGGING is enabled) some assert statements to make sure the loop invariants are preserved properly.  It does seem to be working properly now.

TODO on merge:
* [ ] Release version 1.5.2 with this bug fix
* [ ] Cherry pick this commit to master
* [ ] Cherry pick this commit to noboost (new test will be in test_kolmogorov.py there)