### PR TITLE
Add explicit split points for the VK rawXValue integral

### DIFF
--- a/src/SBVonKarman.cpp
+++ b/src/SBVonKarman.cpp
@@ -216,9 +216,19 @@ namespace galsim {
     // _radial lookup table is built, use that.
     double VonKarmanInfo::rawXValue(double r) const
     {
+        xdbg<<"rawXValue at r = "<<r<<std::endl;
         // r in arcsec
         VKXIntegrand I(r, *this);
         integ::IntRegion<double> reg(0, integ::MOCK_INF);
+        if (r > 0.) {
+            // Add explicit splits at first several roots of J0.
+            // This tends to make the integral more accurate.
+            for (int s=1; s<=10; ++s) {
+                double root = bessel::getBesselRoot0(s);
+                xdbg<<"Add split at "<<root/r<<std::endl;
+                reg.addSplit(root/r);
+            }
+        }
         return integ::int1d(I, reg,
                             _gsparams->integration_relerr,
                             _gsparams->integration_abserr)/(2.*M_PI);
@@ -303,7 +313,7 @@ namespace galsim {
         sum *= 2.*M_PI * dlogr;
         dbg<<"sum = "<<sum<<"   (should be > 0.995)\n";
         if (sum < 1-_gsparams->folding_threshold)
-            throw SBError("Could not find folding_threshold");
+            throw SBError("Could determine appropriate stepk, given folding_threshold");
 
         std::vector<double> range(2, 0.);
         range[1] = _radial.argMax();

--- a/src/SBVonKarman.cpp
+++ b/src/SBVonKarman.cpp
@@ -313,7 +313,7 @@ namespace galsim {
         sum *= 2.*M_PI * dlogr;
         dbg<<"sum = "<<sum<<"   (should be > 0.995)\n";
         if (sum < 1-_gsparams->folding_threshold)
-            throw SBError("Could determine appropriate stepk, given folding_threshold");
+            throw SBError("Could not determine appropriate stepk, given folding_threshold");
 
         std::vector<double> range(2, 0.);
         range[1] = _radial.argMax();

--- a/tests/test_vonkarman.py
+++ b/tests/test_vonkarman.py
@@ -212,6 +212,16 @@ def vk_benchmark():
     t3 = time.time()
     print("Time to photon-shoot 100 more with 50000 photons each: {:6.3f}s".format(t3-t2))  # ~0.9s
 
+def test_vk_r0():
+    """Test a special r0 value that resulted in an error, reported in issue #957.
+    """
+    r0 = 0.146068884
+    vk = galsim.VonKarman(L0=25.,lam=700.,r0=r0)
+    # Note: the resolution of the bug was to add explicit split points for the first several
+    # j0 zeros.  Without that, the integral in rawXValue can spuriously fail badly, leading to
+    # an invalid estimate of the total integrated flux within R=pi/stepk.
+    check_basic(vk, "VonKarman, r0=%s"%r0)
+
 
 if __name__ == "__main__":
     from argparse import ArgumentParser
@@ -233,6 +243,7 @@ if __name__ == "__main__":
     test_vk_eq_kolm()
     test_vk_fitting_formulae()
     test_vk_gsp()
+    test_vk_r0()
     if args.benchmark:
         vk_benchmark()
 


### PR DESCRIPTION
Fix the bug @areshernandez found for certain r0 values in initializing a VonKarman profile, reported in #957.

The resolution was to add explicit split points for the GKP integration at the zeros of the Bessel function.  This is a trick we've employed for both Moffat and Sersic with similar integrals that involve Bessel functions.  In general, forcing splits at the first few zeros of an oscillating function makes the integral much more stable in my experience.