### PR TITLE
Analytic Zernike Gradients #832

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Deprecated Features
 
 New Features
 ------------
+- Add Zernike submodule. (#832, #951)
 - Add SecondKick profile GSObject. (#864)
 - Automatically include SecondKick objects when drawing PhaseScreenPSFs using
   geometric photon shooting. (#864)

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -837,10 +837,12 @@ class PhaseScreenList(object):
             return self._layers[0]._wavefront(u, v, t, theta)
 
     def _wavefront_gradient(self, u, v, t, theta):
-        if len(self._layers) > 1:
-            return np.sum([layer._wavefront_gradient(u, v, t, theta) for layer in self], axis=0)
-        else:
-            return self._layers[0]._wavefront_gradient(u, v, t, theta)
+        gradx, grady = self._layers[0]._wavefront_gradient(u, v, t, theta)
+        for layer in self._layers[1:]:
+            gx, gy = layer._wavefront_gradient(u, v, t, theta)
+            gradx[...] += gx
+            grady[...] += gy
+        return gradx, grady
 
     def makePSF(self, lam, **kwargs):
         """Create a PSF from the current PhaseScreenList.

--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -768,16 +768,8 @@ class OpticalScreen(object):
         return self._wavefront_gradient(u, v, t, theta)
 
 
-    # def _wavefront_gradient(self, u, v, t, theta):
-    #     # Same as wavefront(), but no argument checking.
-    #     # Note, this phase screen is actually independent of time and theta.
-    #     du = dv = 0.01*self.diam
-    #     w0 = self._wavefront(u, v, t, theta)
-    #     gradu = (self._wavefront(u+du, v, t, theta) - w0) / du
-    #     gradv = (self._wavefront(u, v+dv, t, theta) - w0) / dv
-    #     return gradu, gradv
-
-
     def _wavefront_gradient(self, u, v, t, theta):
+        # Same as wavefront(), but no argument checking.
+        # Note, this phase screen is actually independent of time and theta.
         gradx, grady = self._zernike.evalCartesianGrad(u, v)
         return gradx * self.lam_0, grady * self.lam_0

--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -768,11 +768,16 @@ class OpticalScreen(object):
         return self._wavefront_gradient(u, v, t, theta)
 
 
+    # def _wavefront_gradient(self, u, v, t, theta):
+    #     # Same as wavefront(), but no argument checking.
+    #     # Note, this phase screen is actually independent of time and theta.
+    #     du = dv = 0.01*self.diam
+    #     w0 = self._wavefront(u, v, t, theta)
+    #     gradu = (self._wavefront(u+du, v, t, theta) - w0) / du
+    #     gradv = (self._wavefront(u, v+dv, t, theta) - w0) / dv
+    #     return gradu, gradv
+
+
     def _wavefront_gradient(self, u, v, t, theta):
-        # Same as wavefront(), but no argument checking.
-        # Note, this phase screen is actually independent of time and theta.
-        du = dv = 0.01*self.diam
-        w0 = self._wavefront(u, v, t, theta)
-        gradu = (self._wavefront(u+du, v, t, theta) - w0) / du
-        gradv = (self._wavefront(u, v+dv, t, theta) - w0) / dv
-        return gradu, gradv
+        gradx, grady = self._zernike.evalCartesianGrad(u, v)
+        return gradx * self.lam_0, grady * self.lam_0

--- a/galsim/zernike.py
+++ b/galsim/zernike.py
@@ -464,7 +464,9 @@ class Zernike(object):
         return _coef_array_xy
 
     @lazy_property
-    def _gradX(self):
+    def gradX(self):
+        """The x-derivative of this Zernike as a new Zernike object.
+        """
         j = len(self.coef)-1
         newCoef = np.hstack([
             [0],
@@ -479,7 +481,9 @@ class Zernike(object):
         return Zernike(newCoef, R_outer=self.R_outer, R_inner=self.R_inner)
 
     @lazy_property
-    def _gradY(self):
+    def gradY(self):
+        """The y-derivative of this Zernike as a new Zernike object.
+        """
         j = len(self.coef)-1
         newCoef = np.hstack([
             [0],
@@ -514,21 +518,7 @@ class Zernike(object):
         return horner2d(x, y, self._coef_array_xy)
 
     def evalCartesianGrad(self, x, y):
-        return self.gradX().evalCartesian(x, y), self.gradY().evalCartesian(x, y)
-
-    def gradX(self):
-        """Compute the x-derivative of this Zernike.
-
-        @returns  d(Zernike)/dx as new Zernike object.
-        """
-        return self._gradX
-
-    def gradY(self):
-        """Compute the y-derivative of this Zernike.
-
-        @returns  d(Zernike)/dy as new Zernike object.
-        """
-        return self._gradY
+        return self.gradX.evalCartesian(x, y), self.gradY.evalCartesian(x, y)
 
     def rotate(self, theta):
         """Return new Zernike polynomial series rotated by angle theta.  For example:

--- a/galsim/zernike.py
+++ b/galsim/zernike.py
@@ -417,6 +417,20 @@ class Zernike(object):
         self.R_outer = float(R_outer)
         self.R_inner = float(R_inner)
 
+    # This exists in support of the deprecated OpticalPSF.coef_array attribute.  It can be deleted
+    # in version 2.0.
+    @lazy_property
+    def _coef_array(self):
+        _coef_array = np.dot(
+            _noll_coef_array(len(self.coef)-1, self.R_inner/self.R_outer),
+            self.coef[1:]
+        )
+
+        if self.R_outer != 1.0:
+            shape = _coef_array.shape
+            _coef_array /= self.R_outer**np.sum(np.mgrid[0:2*shape[0]:2, 0:shape[1]], axis=0)
+
+
     @lazy_property
     def _coef_array_xygradx(self):
         _coef_array_xygradx = np.dot(

--- a/galsim/zernike.py
+++ b/galsim/zernike.py
@@ -435,27 +435,21 @@ class Zernike(object):
     # It can be deleted in version 2.0.
     @lazy_property
     def _coef_array(self):
-        _coef_array = np.dot(
-            _noll_coef_array(len(self.coef)-1, self.R_inner/self.R_outer),
-            self.coef[1:]
-        )
+        arr = _noll_coef_array(len(self.coef)-1, self.R_inner/self.R_outer).dot(self.coef[1:])
 
         if self.R_outer != 1.0:
-            shape = _coef_array.shape
-            _coef_array /= self.R_outer**np.sum(np.mgrid[0:2*shape[0]:2, 0:shape[1]], axis=0)
-        return _coef_array
+            shape = arr.shape
+            arr /= self.R_outer**np.sum(np.mgrid[0:2*shape[0]:2, 0:shape[1]], axis=0)
+        return arr
 
     @lazy_property
     def _coef_array_xy(self):
-        _coef_array_xy = np.dot(
-            _noll_coef_array_xy(len(self.coef)-1, self.R_inner/self.R_outer),
-            self.coef[1:]
-        )
+        arr = _noll_coef_array_xy(len(self.coef)-1, self.R_inner/self.R_outer).dot(self.coef[1:])
 
         if self.R_outer != 1.0:
-            shape = _coef_array_xy.shape
-            _coef_array_xy /= self.R_outer**(np.sum(np.mgrid[0:shape[0], 0:shape[1]], axis=0))
-        return _coef_array_xy
+            shape = arr.shape
+            arr /= self.R_outer**(np.sum(np.mgrid[0:shape[0], 0:shape[1]], axis=0))
+        return arr
 
     @lazy_property
     def gradX(self):
@@ -464,10 +458,7 @@ class Zernike(object):
         j = len(self.coef)-1
         newCoef = np.hstack([
             [0],
-            np.dot(
-                _noll_coef_array_gradx(j, self.R_inner/self.R_outer),
-                self.coef[1:]
-            )
+            _noll_coef_array_gradx(j, self.R_inner/self.R_outer).dot(self.coef[1:])
         ])
         # Handle R_outer with
         # df/dx = df/d(x/R) * d(x/R)/dx = df/d(x/R) * 1/R
@@ -481,10 +472,7 @@ class Zernike(object):
         j = len(self.coef)-1
         newCoef = np.hstack([
             [0],
-            np.dot(
-                _noll_coef_array_grady(j, self.R_inner/self.R_outer),
-                self.coef[1:]
-            )
+            _noll_coef_array_grady(j, self.R_inner/self.R_outer).dot(self.coef[1:])
         ])
         # Handle R_outer with
         # df/dy = df/d(y/R) * d(y/R)/dy = df/d(y/R) * 1/R
@@ -527,7 +515,7 @@ class Zernike(object):
         """
 
         M = zernikeRotMatrix(len(self.coef)-1, theta)
-        return Zernike(np.dot(M, self.coef), self.R_outer, self.R_inner)
+        return Zernike(M.dot(self.coef), self.R_outer, self.R_inner)
 
     def __eq__(self, other):
         return (isinstance(other, Zernike) and
@@ -556,7 +544,7 @@ def zernikeRotMatrix(jmax, theta):
 
         >>> Z = Zernike(coefs)
         >>> R = zernikeRotMatrix(jmax, theta)
-        >>> rotCoefs = np.dot(R, coefs)
+        >>> rotCoefs = R.dot(coefs)
         >>> Zrot = Zernike(rotCoefs)
         >>> Z.evalPolar(r, th) == Zrot.evalPolar(r, th + theta)
 
@@ -618,7 +606,7 @@ def zernikeBasis(jmax, x, y, R_outer=1.0, R_inner=0.0):
 
         or equivalently
 
-        >>> resids = np.dot(basis.T, coefs).T - z
+        >>> resids = basis.T.dot(coefs).T - z
 
     Note that since we follow the Noll indexing scheme for Zernike polynomials, which begins at 1,
     but python sequences are indexed from 0, the length of the leading dimension in the result is

--- a/galsim/zernike.py
+++ b/galsim/zernike.py
@@ -265,10 +265,7 @@ def __noll_coef_array_xy_gradx(jmax, obscuration):
     out = np.zeros(shape, dtype=np.float64)
     for j in range(1, jmax+1):
         out[:,:,j-1] = _xycoef_gradx(_rrsq_to_xy(nca[:,:,j-1], shape=shape[0:2]), shape=shape[0:2])
-    if jmax > 1:
-        return out[:-1, :-1, :]
-    else:
-        return out
+    return out[:-1, :-1, :]
 _noll_coef_array_xy_gradx = LRU_Cache(__noll_coef_array_xy_gradx)
 
 
@@ -289,10 +286,7 @@ def __noll_coef_array_xy_grady(jmax, obscuration):
     out = np.zeros(shape, dtype=np.float64)
     for j in range(1, jmax+1):
         out[:,:,j-1] = _xycoef_grady(_rrsq_to_xy(nca[:,:,j-1], shape=shape[0:2]), shape=shape[0:2])
-    if jmax > 1:
-        return out[:-1,:-1,:]
-    else:
-        return out
+    return out[:-1, :-1, :]
 _noll_coef_array_xy_grady = LRU_Cache(__noll_coef_array_xy_grady)
 
 

--- a/galsim/zernike.py
+++ b/galsim/zernike.py
@@ -490,6 +490,12 @@ class Zernike(object):
         return horner2d(x, y, self._coef_array_xy)
 
     def evalCartesianGrad(self, x, y):
+        """Evaluate the gradient of this Zernike polynomial series at Cartesian coordinates x and y.
+
+        @param x  x-coordinate of evaluation points.  Can be list-like.
+        @param y  y-coordinate of evaluation points.  Can be list-like.
+        @returns  d(Zernike)/dx, d(Zernike)/dy as numpy arrays.
+        """
         gradx = horner2d(x, y, self._coef_array_xy_gradx, dtype=np.float64)
         grady = horner2d(x, y, self._coef_array_xy_grady, dtype=np.float64)
         return gradx, grady

--- a/galsim/zernike.py
+++ b/galsim/zernike.py
@@ -510,7 +510,8 @@ class Zernike(object):
         """Evaluate this Zernike polynomial series at polar coordinates rho and theta.
 
         @param rho    radial coordinate of evaluation points.  Can be list-like.
-        @param theta  azimuthal coordinate in radians of evaluation points.  Can be list-like.
+        @param theta  azimuthal coordinate in radians (or as Angle object) of evaluation points.
+                      Can be list-like.
         @returns  Series evaluations as numpy array.
         """
         x = rho * np.cos(theta)

--- a/galsim/zernike.py
+++ b/galsim/zernike.py
@@ -186,7 +186,7 @@ def _rrsq_to_xy(coefs, shape=None):
     rho_order = coefs.shape[1] - 1
     if shape is None:
         out_order = rho_order + 2*rho2_order
-        out_shape = (out_order+1, out_order+1)
+        shape = (out_order+1, out_order+1)
     new_coefs = np.zeros(shape, dtype=np.float64)
 
     # Now we loop through the elements of coefs and compute their contribution to new_coefs
@@ -413,7 +413,7 @@ class Zernike(object):
     @param R_inner  Inner radius.  [default: 0.0]
     """
     def __init__(self, coef, R_outer=1.0, R_inner=0.0):
-        self.coef = np.array(coef)
+        self.coef = np.asarray(coef)
         self.R_outer = float(R_outer)
         self.R_inner = float(R_inner)
 
@@ -440,7 +440,8 @@ class Zernike(object):
 
         if self.R_outer != 1.0:
             shape = _coef_array_xygradx.shape
-            _coef_array_xygradx /= self.R_outer**(np.sum(np.mgrid[0:shape[0], 0:shape[1]], axis=0)+1)
+            _coef_array_xygradx /= (
+                self.R_outer**(np.sum(np.mgrid[0:shape[0], 0:shape[1]], axis=0)+1))
         return _coef_array_xygradx
 
     @lazy_property
@@ -452,7 +453,8 @@ class Zernike(object):
 
         if self.R_outer != 1.0:
             shape = _coef_array_xygrady.shape
-            _coef_array_xygrady /= self.R_outer**(np.sum(np.mgrid[0:shape[0], 0:shape[1]], axis=0)+1)
+            _coef_array_xygrady /= (
+                self.R_outer**(np.sum(np.mgrid[0:shape[0], 0:shape[1]], axis=0)+1))
         return _coef_array_xygrady
 
     @lazy_property

--- a/galsim/zernike.py
+++ b/galsim/zernike.py
@@ -133,7 +133,7 @@ def __noll_coef_array(jmax, obscuration):
 _noll_coef_array = LRU_Cache(__noll_coef_array)
 
 
-def _xy_contribution(rho2_power, rho_power, shape=None):
+def _xy_contribution(rho2_power, rho_power, shape):
     """Convert (rho, |rho|^2) bivariate polynomial coefficients to (x, y) bivariate polynomial
     coefficients.
     """
@@ -155,9 +155,6 @@ def _xy_contribution(rho2_power, rho_power, shape=None):
     #
     # and so on.  We can apply these operations repeatedly to effect arbitrary powers of rho or
     # |rho|^2.
-    if shape is None:
-        size = 2*rho2_power + rho_power + 1
-        shape = (size, size)
     out = np.zeros(shape, dtype=np.complex128)
     out[0,0] = 1
     while rho2_power >= 1:
@@ -179,14 +176,9 @@ def _xy_contribution(rho2_power, rho_power, shape=None):
     return out
 
 
-def _rrsq_to_xy(coefs, shape=None):
+def _rrsq_to_xy(coefs, shape):
     """Convert coefficient array from rho, |rho|^2 to x, y.
     """
-    rho2_order = coefs.shape[0] - 1
-    rho_order = coefs.shape[1] - 1
-    if shape is None:
-        out_order = rho_order + 2*rho2_order
-        shape = (out_order+1, out_order+1)
     new_coefs = np.zeros(shape, dtype=np.float64)
 
     # Now we loop through the elements of coefs and compute their contribution to new_coefs
@@ -195,7 +187,7 @@ def _rrsq_to_xy(coefs, shape=None):
     return new_coefs
 
 
-def _xycoef_gradx(coefs, shape=None):
+def _xycoef_gradx(coefs, shape):
     """Calculate x/y coefficient array of x-derivative of given x/y coefficient array.
     """
     # d/dx (x+y) = 1 looks like
@@ -215,8 +207,6 @@ def _xycoef_gradx(coefs, shape=None):
     # 0 1 0 -> 2 0 0
     # 1 0 0    0 0 0
 
-    if shape is None:
-        shape = coefs.shape
     gradx = np.zeros(shape, dtype=np.float64)
     for (i, j) in zip(*np.nonzero(coefs)):
         if i > 0:
@@ -225,12 +215,10 @@ def _xycoef_gradx(coefs, shape=None):
     return gradx
 
 
-def _xycoef_grady(coefs, shape=None):
+def _xycoef_grady(coefs, shape):
     """Calculate x/y coefficient array of y-derivative of given x/y coefficient array.
     """
     # see above
-    if shape is None:
-        shape = coefs.shape
     grady = np.zeros(shape, dtype=np.float64)
     for (i, j) in zip(*np.nonzero(coefs)):
         if j > 0:
@@ -429,7 +417,6 @@ class Zernike(object):
         if self.R_outer != 1.0:
             shape = _coef_array.shape
             _coef_array /= self.R_outer**np.sum(np.mgrid[0:2*shape[0]:2, 0:shape[1]], axis=0)
-
 
     @lazy_property
     def _coef_array_xy_gradx(self):

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -1433,6 +1433,8 @@ def test_dep_phase_psf():
 
     optical_screen = galsim.OpticalScreen(diam=1.0)
     assert check_dep(getattr, optical_screen, 'coef_array') == optical_screen._zernike._coef_array
+    optical_screen = galsim.OpticalScreen(diam=2.0)
+    assert check_dep(getattr, optical_screen, 'coef_array') == optical_screen._zernike._coef_array
 
 @timer
 def test_dep_wmult():

--- a/tests/test_zernike.py
+++ b/tests/test_zernike.py
@@ -364,7 +364,17 @@ def test_gradient():
         grady = 12*np.sqrt(5)*y*(2*r2-1)
         return gradx, grady
 
-    np.testing.assert_allclose(Z11.evalCartesianGrad(x, y), Z11_grad(x, y))
+    # import matplotlib.pyplot as plt
+    # fig, axes = plt.subplots(ncols=3, figsize=(12, 3))
+    # scat0 = axes[0].scatter(x, y, c=Z11.evalCartesianGrad(x, y)[0])
+    # fig.colorbar(scat0, ax=axes[0])
+    # scat1 = axes[1].scatter(x, y, c=Z11_grad(x, y)[0])
+    # fig.colorbar(scat1, ax=axes[1])
+    # scat2 = axes[2].scatter(x, y, c=Z11.evalCartesianGrad(x, y)[0] - Z11_grad(x, y)[0])
+    # fig.colorbar(scat2, ax=axes[2])
+    # plt.show()
+
+    np.testing.assert_allclose(Z11.evalCartesianGrad(x, y), Z11_grad(x, y), rtol=0, atol=1e-13)
 
     Z28 = galsim.zernike.Zernike([0]*28+[1])
 
@@ -373,7 +383,7 @@ def test_gradient():
         grady = -6*np.sqrt(14)*y*(5*x**4-10*x**2*y**2+y**4)
         return gradx, grady
 
-    np.testing.assert_allclose(Z28.evalCartesianGrad(x, y), Z28_grad(x, y))
+    np.testing.assert_allclose(Z28.evalCartesianGrad(x, y), Z28_grad(x, y), rtol=0, atol=1e-13)
 
     # Now try some finite differences on a broader set of input
 
@@ -385,39 +395,16 @@ def test_gradient():
 
     u = galsim.UniformDeviate(1234)
 
-    for j in range(100):
-        nj = int(u()*55)
-        Z = galsim.zernike.Zernike([0]+[u()]*nj)
+    for j in range(25):
+        nj = 1+int(u()*55)
+        R_inner = 0.2+0.6*u()
+        R_outer = R_inner + 0.2+0.6*u()
+        Z = galsim.zernike.Zernike([0]+[u() for _ in range(nj)], R_inner=R_inner, R_outer=R_outer)
 
         np.testing.assert_allclose(
                 finite_difference_gradient(Z, x, y),
                 Z.evalCartesianGrad(x, y),
-                rtol=2e-4)
-
-    # Try R_outer != 1
-
-    for j in range(100):
-        nj = int(u()*55)
-        Z = galsim.zernike.Zernike([0]+[u()]*nj, R_outer=1+u())
-
-        np.testing.assert_allclose(
-                finite_difference_gradient(Z, x, y),
-                Z.evalCartesianGrad(x, y),
-                rtol=2e-4)
-
-    # # Try annular Zernike
-    #
-    # for j in range(100):
-    #     print(j)
-    #     nj = int(u()*55)
-    #     R_inner = 0.2+0.6*u()
-    #     print(R_inner)
-    #     Z = galsim.zernike.Zernike([0]+[u()]*nj, R_inner=R_inner)
-    #
-    #     np.testing.assert_allclose(
-    #             finite_difference_gradient(Z, x, y),
-    #             Z.evalCartesianGrad(x, y),
-    #             rtol=2e-4)
+                rtol=1e-5, atol=1e-5)
 
 
 if __name__ == "__main__":

--- a/tests/test_zernike.py
+++ b/tests/test_zernike.py
@@ -40,7 +40,7 @@ def test_Zernike_orthonormality():
     jmax = 30  # Going up to 30 filled Zernikes takes about ~1 sec on my laptop
     diam = 4.0
     R_outer = diam/2
-    pad_factor = 3.0  # Increasing pad_factor eliminates test failures caused by pixelization.
+
     x = np.linspace(-R_outer, R_outer, 256)
     dx = x[1]-x[0]
     x, y = np.meshgrid(x, x)
@@ -239,7 +239,6 @@ def test_ne():
 @timer
 def test_Zernike_basis():
     """Test the zernikeBasis function"""
-    eps = 0.2
     diam = 2.4
     jmax = 30
     R_outer = diam/2
@@ -374,7 +373,7 @@ def test_gradient():
     # fig.colorbar(scat2, ax=axes[2])
     # plt.show()
 
-    np.testing.assert_allclose(Z11.evalCartesianGrad(x, y), Z11_grad(x, y), rtol=0, atol=1e-13)
+    np.testing.assert_allclose(Z11.evalCartesianGrad(x, y), Z11_grad(x, y), rtol=0, atol=1e-12)
 
     Z28 = galsim.zernike.Zernike([0]*28+[1])
 
@@ -383,7 +382,7 @@ def test_gradient():
         grady = -6*np.sqrt(14)*y*(5*x**4-10*x**2*y**2+y**4)
         return gradx, grady
 
-    np.testing.assert_allclose(Z28.evalCartesianGrad(x, y), Z28_grad(x, y), rtol=0, atol=1e-13)
+    np.testing.assert_allclose(Z28.evalCartesianGrad(x, y), Z28_grad(x, y), rtol=0, atol=1e-12)
 
     # Now try some finite differences on a broader set of input
 

--- a/tests/test_zernike.py
+++ b/tests/test_zernike.py
@@ -404,6 +404,9 @@ def test_gradient():
                 Z.evalCartesianGrad(x, y),
                 rtol=1e-5, atol=1e-5)
 
+    # Make sure the gradient of the zero-Zernike works
+    Z = galsim.zernike.Zernike([0,0])
+    assert Z == Z.gradX == Z.gradX.gradX == Z.gradY == Z.gradY.gradY
 
 if __name__ == "__main__":
     test_Zernike_orthonormality()

--- a/tests/test_zernike.py
+++ b/tests/test_zernike.py
@@ -149,10 +149,10 @@ def test_noll():
         m = (-1)**j * ((n % 2) + 2 * int((j1+((n+1) % 2)) / 2.0))
         return (n, m)
 
-    # Test that the version of _noll_to_zern in phase_screens.py is accurate.
+    # Test that the version of noll_to_zern in phase_screens.py is accurate.
     for j in range(1,30):
         true_n,true_m = noll_to_zern(j)
-        n,m = galsim.zernike._noll_to_zern(j)
+        n,m = galsim.zernike.noll_to_zern(j)
         #print('j=%d, noll = %d,%d, true_noll = %d,%d'%(j,n,m,true_n,true_m))
         assert n == true_n
         assert m == true_m
@@ -173,7 +173,7 @@ def test_noll():
         return A
 
     for j in range(1,30):
-        n,m = galsim.zernike._noll_to_zern(j)
+        n,m = galsim.zernike.noll_to_zern(j)
         true_coefs = zern_rho_coefs(n,m)
         coefs = galsim.zernike._zern_rho_coefs(n,m)
         #print('j=%d, coefs = %s'%(j,coefs))

--- a/tests/test_zernike.py
+++ b/tests/test_zernike.py
@@ -136,7 +136,7 @@ def test_annular_Zernike_limit():
 @timer
 def test_noll():
     # This function stolen from https://github.com/tvwerkhoven/libtim-py/blob/master/libtim/zern.py
-    # It used to be in phase_screen.py, but now we use a faster lookup-table implementation.
+    # It used to be in zernike.py, but now we use a faster lookup-table implementation.
     # This reference version is still useful as a test.
     def noll_to_zern(j):
         if (j == 0):
@@ -149,7 +149,7 @@ def test_noll():
         m = (-1)**j * ((n % 2) + 2 * int((j1+((n+1) % 2)) / 2.0))
         return (n, m)
 
-    # Test that the version of noll_to_zern in phase_screens.py is accurate.
+    # Test that the version of noll_to_zern in zernike.py is accurate.
     for j in range(1,30):
         true_n,true_m = noll_to_zern(j)
         n,m = galsim.zernike.noll_to_zern(j)
@@ -161,7 +161,7 @@ def test_noll():
         mm = -m if (n//2)%2 == 0 else m
         assert j == n*(n+1)/2 + (abs(2*mm+1)+1)//2
 
-    # Again, the reference version of this function used to be in phase_screens.py
+    # Again, the reference version of this function used to be in zernike.py
     def zern_rho_coefs(n, m):
         """Compute coefficients of radial part of Zernike (n, m).
         """
@@ -358,6 +358,7 @@ def test_gradient():
     x, y = np.meshgrid(x, x)
 
     def Z11_grad(x, y):
+        # Z11 = sqrt(5) (6(x^2+y^2)^2 - 6(x^2+y^2)+1)
         r2 = x**2 + y**2
         gradx = 12*np.sqrt(5)*x*(2*r2-1)
         grady = 12*np.sqrt(5)*y*(2*r2-1)
@@ -378,8 +379,9 @@ def test_gradient():
     Z28 = galsim.zernike.Zernike([0]*28+[1])
 
     def Z28_grad(x, y):
-        gradx = 6*np.sqrt(14)*x*(x**4-10*x**2*y**2+5*y**4)
-        grady = -6*np.sqrt(14)*y*(5*x**4-10*x**2*y**2+y**4)
+        # Z28 = sqrt(14) (x^6 - 15 x^4 y^2 + 15 x^2 y^4 - y^6)
+        gradx = 6*np.sqrt(14)*x*(x**4 - 10*x**2*y**2 + 5*y**4)
+        grady = -6*np.sqrt(14)*y*(5*x**4 - 10*x**2*y**2 + y**4)
         return gradx, grady
 
     np.testing.assert_allclose(Z28.evalCartesianGrad(x, y), Z28_grad(x, y), rtol=0, atol=1e-12)
@@ -393,6 +395,8 @@ def test_gradient():
 
     u = galsim.UniformDeviate(1234)
 
+    # Test finite difference against analytic result for 25 different Zernikes with random number of
+    # random coefficients and random inner/outer radii.
     for j in range(25):
         nj = 1+int(u()*55)
         R_inner = 0.2+0.6*u()

--- a/tests/test_zernike.py
+++ b/tests/test_zernike.py
@@ -392,7 +392,6 @@ def test_gradient():
         return ((Z.evalCartesian(x+dh, y)-Z.evalCartesian(x-dh, y))/(2*dh),
                 (Z.evalCartesian(x, y+dh)-Z.evalCartesian(x, y-dh))/(2*dh))
 
-
     u = galsim.UniformDeviate(1234)
 
     for j in range(25):


### PR DESCRIPTION
This PR 
1) Adds analytic Zernike gradients (replacing the finite difference gradients I had been using for optical screen geometric photon-shooting)
2) Changes the Zernike implementation to use coefficients in x and y coordinates instead of coefficients in (x + iy) and (x^2 + y^2) coordinates.

The first change increases speed by only requiring two calls to `horner2d` instead of three, and also eliminating subsequent array operations to create finite differences.

The second change increases speed since all of the work performed becomes part of the final result, compared to before where we would perform work using complex numbers and at the last step only keep the real parts.

Overall, I find a speed increase for evaluating Zernikes of about a factor of 2, and for evaluating Zernike gradients of about a factor of 4.