### PR TITLE
Phase gradient photon shooting with 0 or 1 photons

### DIFF
--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -1382,6 +1382,9 @@ class PhaseScreenPSF(GSObject):
             self._prepareDraw()
             return self.ii.shoot(n_photons, rng)
 
+        if n_photons == 0:
+            return galsim._galsim.PhotonArray(0)
+
         ud = galsim.UniformDeviate(rng)
 
         t = np.empty((n_photons,), dtype=float)

--- a/galsim/table.py
+++ b/galsim/table.py
@@ -22,6 +22,7 @@ addition of the docstring and few extra features.
 Also, a simple 2D table for gridded input data: LookupTable2D.
 """
 import numpy as np
+import numbers
 
 from . import _galsim
 
@@ -494,8 +495,7 @@ class LookupTable2D(object):
         if not self._inbounds(x, y):
             raise ValueError("Extrapolating beyond input range.")
 
-        from numbers import Real
-        if isinstance(x, Real):
+        if isinstance(x, numbers.Real):
             return self.table(x, y)
         else:
             x = np.array(x, dtype=float)
@@ -513,8 +513,7 @@ class LookupTable2D(object):
         return self._call_raise(x, y)
 
     def _call_constant(self, x, y):
-        from numbers import Real
-        if isinstance(x, Real):
+        if isinstance(x, numbers.Real):
             if self._inbounds(x, y):
                 return self.table(x, y)
             else:
@@ -547,11 +546,9 @@ class LookupTable2D(object):
         if not self._inbounds(x, y):
             raise ValueError("Extrapolating beyond input range.")
 
-        try:
-            xx = float(x)
-            yy = float(y)
-            return self.table.gradient(xx, yy)
-        except TypeError:
+        if isinstance(x, numbers.Real):
+            return self.table.gradient(x, y)
+        else:
             dfdx = np.empty_like(x)
             dfdy = np.empty_like(x)
             self.table.gradientMany(x.ravel(), y.ravel(), dfdx.ravel(), dfdy.ravel())
@@ -562,8 +559,7 @@ class LookupTable2D(object):
         return self._gradient_raise(x, y)
 
     def _gradient_constant(self, x, y):
-        from numbers import Real
-        if isinstance(x, Real):
+        if isinstance(x, numbers.Real):
             if self._inbounds(x, y):
                 return self.table.gradient(x, y)
             else:

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -721,6 +721,10 @@ def test_phase_gradient_shoot():
         assert psf.second_kick == second_kick
         img = psf.drawImage(nx=64, ny=64, scale=0.1, method='phot', n_photons=100)
 
+    # Verify that we can phase_gradient_shoot with 0 or 1 photons.
+    psf.shoot(0)
+    psf.shoot(1)
+
 
 @timer
 def test_input():


### PR DESCRIPTION
@jchiang87 found [here](https://github.com/LSSTDESC/imSim/pull/101#issuecomment-386907091) a bug that boiled down to a failure in the phase gradient shooting code to shoot just a single photon.  This PR adds a test and fix for this, plus a test and fix for shooting 0 photons.
