### PR TITLE
Update stepk and maxk in dummy ii variable to be more accurate.

### DIFF
--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -433,6 +433,19 @@ def test_stepk_maxk():
     # Should be very quick to do the first stepk, maxk, but slow to do the second.
     assert t1-t0 < t2-t1
 
+    # Check that stepk changes when gsparams.folding_threshold become more extreme.
+    # (Note: maxk is independent of maxk_threshold because of the hard edge of the aperture.)
+    psf1 = galsim.PhaseScreenPSF(atm, 500.0, diam=1.0, scale_unit=galsim.arcsec,
+                                 gsparams=galsim.GSParams(folding_threshold=1.e-3,
+                                                          maxk_threshold=1.e-4))
+    stepk3 = psf1.stepk
+    maxk3 = psf1.maxk
+    print('stepk3 = ',stepk3)
+    print('maxk3 = ',maxk3)
+    assert stepk3 < stepk1
+    assert maxk3 == maxk1
+
+    # Check that it respects the force_stepk and force_maxk parameters
     psf2 = galsim.PhaseScreenPSF(atm, 500.0, aper=aper, scale_unit=galsim.arcsec,
                                  _force_stepk=stepk2/1.5, _force_maxk=maxk2*2.0)
     np.testing.assert_almost_equal(


### PR DESCRIPTION
@jchiang87 uses stepk to determine a good stamp size for stars in the imsim code.  But for PhaseScreenPSF, that requires a call to `_prepareDraw`, which is slow.

This PR sets the stepk and maxk in the dummy `_ii` variable to something close to correct and removes the `self._prepareDraw()` call in the stepk and maxk properties.  So now those properties are fast for photon shooting applications.

However, note that this is probably not the main problem that Jim was seeing [here](https://github.com/LSSTDESC/imSim/pull/101#issuecomment-386953767).  I'd thought the problem was that `_prepareDraw` needed to be called.  But apparently not.  (My [example](https://github.com/LSSTDESC/imSim/pull/101#issuecomment-386961195) was running on noboost, not master, where I had apparently removed the prepareDraw calls.)  So there might be some other bug as well.  Probably in the imsim integration that uses the PhaseScreenPSFs.