### PR TITLE
#968 Add `withGSParams` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,14 +63,12 @@ API Changes
   aliases for galsim -f yaml and galsim -f json respectively. (#809f)
 - Removed lsst module, which depended on the LSST stack and had gotten quite
   out of sync and broken. (#964)
-
-
-Bug Fixes
----------
-=======
-- Removed the lsst module, which depended on the LSST stack and had gotten
-  quite out of sync and broken. (#964)
->>>>>>> Change default maximum_fft_size to 8192
+- Changed how gsparams work for objects that wrap other objects (e.g. Sum,
+  Convolution, etc.). Now if you specify a gsparams at that level, it is
+  propagated to all of the component objects.  If you do not specify one,
+  then the most restrictive combination of parameters from the components are
+  applied to all of them. This is how gsparams should have worked originally,
+  but it was not really possible in 1.x. (#968)
 
 
 Deprecated Features
@@ -92,3 +90,4 @@ New Features
   sure that the errors you wanted to catch are still being caught. (#755)
 - Changed the type of warnings raised by GalSim to GalSimWarning, which is
   a subclass of UserWarning. (#755)
+- Added the withGSParams() method for all GSObjects. (#968)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,10 +65,11 @@ API Changes
   out of sync and broken. (#964)
 - Changed how gsparams work for objects that wrap other objects (e.g. Sum,
   Convolution, etc.). Now if you specify a gsparams at that level, it is
-  propagated to all of the component objects.  If you do not specify one,
-  then the most restrictive combination of parameters from the components are
-  applied to all of them. This is how gsparams should have worked originally,
-  but it was not really possible in 1.x. (#968)
+  propagated to all of the component objects.  (This behavior can be turned
+  off with `propagate_gsparams=False`.) If you do not specify one, then the
+  most restrictive combination of parameters from the components are applied
+  to all of them. This is how gsparams should have worked originally, but it
+  was not really possible in 1.x. (#968)
 
 
 Deprecated Features

--- a/galsim/convolve.py
+++ b/galsim/convolve.py
@@ -237,6 +237,7 @@ class Convolution(GSObject):
 
     @doc_inherit
     def withGSParams(self, gsparams):
+        if gsparams is self.gsparams: return self
         from copy import copy
         ret = copy(self)
         ret._gsparams = GSParams.check(gsparams)
@@ -475,8 +476,8 @@ class Deconvolution(GSObject):
             raise TypeError("Argument to Deconvolution must be a GSObject.")
 
         # Save the original object as an attribute, so it can be inspected later if necessary.
-        self._orig_obj = obj
-        self._gsparams = GSParams.check(gsparams, self._orig_obj.gsparams)
+        self._gsparams = GSParams.check(gsparams, obj.gsparams)
+        self._orig_obj = obj.withGSParams(self._gsparams)
         self._min_acc_kvalue = obj.flux * self.gsparams.kvalue_accuracy
         self._inv_min_acc_kvalue = 1./self._min_acc_kvalue
 
@@ -496,6 +497,7 @@ class Deconvolution(GSObject):
 
     @doc_inherit
     def withGSParams(self, gsparams):
+        if gsparams is self.gsparams: return self
         from copy import copy
         ret = copy(self)
         ret._gsparams = GSParams.check(gsparams)
@@ -672,11 +674,11 @@ class AutoConvolution(Convolution):
         # Save the construction parameters (as they are at this point) as attributes so they
         # can be inspected later if necessary.
         self._real_space = bool(real_space)
-        self._orig_obj = obj
-        self._gsparams = GSParams.check(gsparams, self._orig_obj.gsparams)
+        self._gsparams = GSParams.check(gsparams, obj.gsparams)
+        self._orig_obj = obj.withGSParams(self._gsparams)
 
         # So we can use Convolve methods when there is no advantage to overloading.
-        self._obj_list = [obj, obj]
+        self._obj_list = [self._orig_obj, self._orig_obj]
 
     @lazy_property
     def _sbp(self):
@@ -696,10 +698,12 @@ class AutoConvolution(Convolution):
 
     @doc_inherit
     def withGSParams(self, gsparams):
+        if gsparams is self.gsparams: return self
         from copy import copy
         ret = copy(self)
         ret._gsparams = GSParams.check(gsparams)
         ret._orig_obj = self._orig_obj.withGSParams(gsparams)
+        ret._obj_list = [ret._orig_obj, ret._orig_obj]
         return ret
 
     def __eq__(self, other):
@@ -816,11 +820,11 @@ class AutoCorrelation(Convolution):
         # Save the construction parameters (as they are at this point) as attributes so they
         # can be inspected later if necessary.
         self._real_space = bool(real_space)
-        self._orig_obj = obj
-        self._gsparams = GSParams.check(gsparams, self._orig_obj.gsparams)
+        self._gsparams = GSParams.check(gsparams, obj.gsparams)
+        self._orig_obj = obj.withGSParams(self._gsparams)
 
         # So we can use Convolve methods when there is no advantage to overloading.
-        self._obj_list = [obj, obj.transform(-1,0,0,-1)]
+        self._obj_list = [self._orig_obj, self._orig_obj.transform(-1,0,0,-1)]
 
     @lazy_property
     def _sbp(self):
@@ -840,10 +844,12 @@ class AutoCorrelation(Convolution):
 
     @doc_inherit
     def withGSParams(self, gsparams):
+        if gsparams is self.gsparams: return self
         from copy import copy
         ret = copy(self)
         ret._gsparams = GSParams.check(gsparams)
         ret._orig_obj = self._orig_obj.withGSParams(gsparams)
+        ret._obj_list = [ret._orig_obj, ret._orig_obj.transform(-1,0,0,-1)]
         return ret
 
     def __eq__(self, other):

--- a/galsim/correlatednoise.py
+++ b/galsim/correlatednoise.py
@@ -1536,7 +1536,7 @@ class CovarianceSpectrum(object):
         PSF_eff_kimgs = np.empty((NSED, nk, nk), dtype=np.complex128)
         for i, sed in enumerate(self.SEDs):
             # Assume that PSF does not yet include pixel contribution, so add it in.
-            conv = Convolve(PSF, Pixel(wcs.scale)) * sed
+            conv = Convolve(PSF, Pixel(wcs.scale, gsparams=PSF.gsparams)) * sed
             PSF_eff_kimgs[i] = conv.drawKImage(bandpass, nx=nk, ny=nk, scale=stepk).array
         pkout = np.zeros((nk, nk), dtype=np.float64)
         for i in range(NSED):

--- a/galsim/fouriersqrt.py
+++ b/galsim/fouriersqrt.py
@@ -93,8 +93,8 @@ class FourierSqrtProfile(GSObject):
             raise TypeError("Argument to FourierSqrtProfile must be a GSObject.")
 
         # Save the original object as an attribute, so it can be inspected later if necessary.
-        self._orig_obj = obj
-        self._gsparams = GSParams.check(gsparams, self._orig_obj.gsparams)
+        self._gsparams = GSParams.check(gsparams, obj.gsparams)
+        self._orig_obj = obj.withGSParams(self._gsparams)
 
     @property
     def orig_obj(self): return self._orig_obj
@@ -109,6 +109,15 @@ class FourierSqrtProfile(GSObject):
         if self.orig_obj.noise is not None:
             galsim_warn("Unable to propagate noise in galsim.FourierSqrtProfile")
         return None
+
+    @doc_inherit
+    def withGSParams(self, gsparams):
+        if gsparams is self.gsparams: return self
+        from copy import copy
+        ret = copy(self)
+        ret._gsparams = GSParams.check(gsparams)
+        ret._orig_obj = self._orig_obj.withGSParams(gsparams)
+        return ret
 
     def __eq__(self, other):
         return (isinstance(other, FourierSqrtProfile) and

--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -743,6 +743,10 @@ class GSObject(object):
         """
         # Note to developers: objects that wrap other objects should override this in order
         # to apply the new gsparams to the components.
+        # This implementation relies on getstate/setstate clearing out any `_sbp` or similar
+        # attribute that depends on the details of gsparams.  If there are stored calculations
+        # aside from these, you should also clear them as well, or update them.
+        if gsparams is self.gsparams: return self
         from copy import copy
         ret = copy(self)
         ret._gsparams = GSParams.check(gsparams)

--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -56,6 +56,7 @@ import numpy as np
 import math
 
 from . import _galsim
+from .gsparams import GSParams
 from .position import PositionD, PositionI
 from .utilities import lazy_property, parse_pos_args
 from .errors import GalSimError, GalSimRangeError, GalSimValueError, GalSimIncompatibleValuesError
@@ -286,6 +287,7 @@ class GSObject(object):
     def flux(self):
         "The flux of the profile"
         return self._flux
+
     @property
     def gsparams(self):
         "A GSParams object that sets various parameters relevant for speed/accuracy trade-offs"
@@ -732,6 +734,19 @@ class GSObject(object):
         """Equivalent to kValue(kpos), but kpos must be a galsim.PositionD instance.
         """
         raise NotImplementedError("%s does not implement kValue"%self.__class__.__name__)
+
+    def withGSParams(self, gsparams):
+        """Create a version of the current object with the given gsparams
+
+        Note: if this object wraps other objects (e.g. Convolution, Sum, Transformation, etc.)
+              those component objects will also have their gsparams updated to the new value.
+        """
+        # Note to developers: objects that wrap other objects should override this in order
+        # to apply the new gsparams to the components.
+        from copy import copy
+        ret = copy(self)
+        ret._gsparams = GSParams.check(gsparams)
+        return ret
 
     def withFlux(self, flux):
         """Create a version of the current object with a different flux.

--- a/galsim/gsparams.py
+++ b/galsim/gsparams.py
@@ -200,6 +200,35 @@ class GSParams(object):
         else:
             return gsparams
 
+    @staticmethod
+    def combine(gsp_list):
+        """Combine a list of GSParams instances using the most restrictive parameter from each.
+
+        Uses the minimum value for most parameters. For the following parameters, it uses the
+        maximum numerical value: minimum_fft_size, maximum_fft_size, stepk_minimum_hlr,
+        allowed_flux_variation, range_division_for_extrema.
+        """
+        if len(gsp_list) == 1:
+            return gsp_list[0]
+        else:
+            return GSParams(
+                max([g.minimum_fft_size for g in gsp_list]),
+                max([g.maximum_fft_size for g in gsp_list]),
+                min([g.folding_threshold for g in gsp_list]),
+                max([g.stepk_minimum_hlr for g in gsp_list]),
+                min([g.maxk_threshold for g in gsp_list]),
+                min([g.kvalue_accuracy for g in gsp_list]),
+                min([g.xvalue_accuracy for g in gsp_list]),
+                min([g.table_spacing for g in gsp_list]),
+                min([g.realspace_relerr for g in gsp_list]),
+                min([g.realspace_abserr for g in gsp_list]),
+                min([g.integration_relerr for g in gsp_list]),
+                min([g.integration_abserr for g in gsp_list]),
+                min([g.shoot_accuracy for g in gsp_list]),
+                max([g.allowed_flux_variation for g in gsp_list]),
+                max([g.range_division_for_extrema for g in gsp_list]),
+                min([g.small_fraction_of_flux for g in gsp_list]))
+
     # Define once the order of args in __init__, since we use it a few times.
     def _getinitargs(self):
         return (self.minimum_fft_size, self.maximum_fft_size,

--- a/galsim/gsparams.py
+++ b/galsim/gsparams.py
@@ -131,22 +131,22 @@ class GSParams(object):
                  integration_relerr=1.e-6, integration_abserr=1.e-8,
                  shoot_accuracy=1.e-5, allowed_flux_variation=0.81,
                  range_division_for_extrema=32, small_fraction_of_flux=1.e-4):
-        self._minimum_fft_size = minimum_fft_size
-        self._maximum_fft_size = maximum_fft_size
-        self._folding_threshold = folding_threshold
-        self._stepk_minimum_hlr = stepk_minimum_hlr
-        self._maxk_threshold = maxk_threshold
-        self._kvalue_accuracy = kvalue_accuracy
-        self._xvalue_accuracy = xvalue_accuracy
-        self._table_spacing = table_spacing
-        self._realspace_relerr = realspace_relerr
-        self._realspace_abserr = realspace_abserr
-        self._integration_relerr = integration_relerr
-        self._integration_abserr = integration_abserr
-        self._shoot_accuracy = shoot_accuracy
-        self._allowed_flux_variation = allowed_flux_variation
-        self._range_division_for_extrema = range_division_for_extrema
-        self._small_fraction_of_flux = small_fraction_of_flux
+        self._minimum_fft_size = int(minimum_fft_size)
+        self._maximum_fft_size = int(maximum_fft_size)
+        self._folding_threshold = float(folding_threshold)
+        self._stepk_minimum_hlr = float(stepk_minimum_hlr)
+        self._maxk_threshold = float(maxk_threshold)
+        self._kvalue_accuracy = float(kvalue_accuracy)
+        self._xvalue_accuracy = float(xvalue_accuracy)
+        self._table_spacing = int(table_spacing)
+        self._realspace_relerr = float(realspace_relerr)
+        self._realspace_abserr = float(realspace_abserr)
+        self._integration_relerr = float(integration_relerr)
+        self._integration_abserr = float(integration_abserr)
+        self._shoot_accuracy = float(shoot_accuracy)
+        self._allowed_flux_variation = float(allowed_flux_variation)
+        self._range_division_for_extrema = int(range_division_for_extrema)
+        self._small_fraction_of_flux = float(small_fraction_of_flux)
 
         # This is the thing that is needed for any c++ calls.
         with convert_cpp_errors():

--- a/galsim/interpolant.py
+++ b/galsim/interpolant.py
@@ -96,6 +96,10 @@ class Interpolant(object):
                                    ('linear', 'cubic', 'quintic', 'lanczosN', 'nearest', 'delta',
                                     'sinc'))
 
+    @property
+    def gsparams(self):
+        return self._gsparams
+
     def withGSParams(self, gsparams):
         """Create a version of the current interpolant with the given gsparams
         """

--- a/galsim/interpolant.py
+++ b/galsim/interpolant.py
@@ -96,6 +96,15 @@ class Interpolant(object):
                                    ('linear', 'cubic', 'quintic', 'lanczosN', 'nearest', 'delta',
                                     'sinc'))
 
+    def withGSParams(self, gsparams):
+        """Create a version of the current interpolant with the given gsparams
+        """
+        if gsparams is self.gsparams: return self
+        from copy import copy
+        ret = copy(self)
+        ret._gsparams = GSParams.check(gsparams)
+        return ret
+
     def __getstate__(self):
         d = self.__dict__.copy()
         d.pop('_i', None)

--- a/galsim/interpolatedimage.py
+++ b/galsim/interpolatedimage.py
@@ -297,22 +297,22 @@ class InterpolatedImage(GSObject):
             raise GalSimValueError("Invalid normalization requested.", normalization,
                                    ('flux', 'f', 'surface brightness', 'sb'))
 
-        # set up the interpolants if none was provided by user, or check that the user-provided ones
-        # are of a valid type
-        if x_interpolant is None:
-            self._x_interpolant = Quintic(tol=1e-4)
-        else:
-            self._x_interpolant = convert_interpolant(x_interpolant)
-        if k_interpolant is None:
-            self._k_interpolant = Quintic(tol=1e-4)
-        else:
-            self._k_interpolant = convert_interpolant(k_interpolant)
-
         # Store the image as an attribute and make sure we don't change the original image
         # in anything we do here.  (e.g. set scale, etc.)
         self._image = image._view()
         self._image.setCenter(0,0)
         self._gsparams = GSParams.check(gsparams)
+
+        # Set up the interpolants if none was provided by user, or check that the user-provided ones
+        # are of a valid type
+        if x_interpolant is None:
+            self._x_interpolant = Quintic(tol=1e-4, gsparams=self._gsparams)
+        else:
+            self._x_interpolant = convert_interpolant(x_interpolant).withGSParams(self._gsparams)
+        if k_interpolant is None:
+            self._k_interpolant = Quintic(tol=1e-4, gsparams=self._gsparams)
+        else:
+            self._k_interpolant = convert_interpolant(k_interpolant).withGSParams(self._gsparams)
 
         # Set the wcs if necessary
         if scale is not None:

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -593,8 +593,7 @@ class Aperture(object):
         """ Unit-disk normalized pupil plane coordinate as a complex number:
         (x, y) => x + 1j * y.
         """
-        if not hasattr(self, '_npix'):
-            self._illuminated
+        self._illuminated
         u = np.fft.fftshift(np.fft.fftfreq(self._npix, self.diam/self._pupil_plane_size/2.0))
         u, v = np.meshgrid(u, u)
         return u + 1j * v
@@ -602,6 +601,8 @@ class Aperture(object):
     @lazy_property
     def _uv(self):
         if not hasattr(self, '_npix'):
+            # Need this check, since `_uv` is used by `_illuminated`, so need to make sure we
+            # don't have an infinite loop.
             self._illuminated
         u = np.fft.fftshift(np.fft.fftfreq(self._npix, 1./self._pupil_plane_size))
         u, v =  np.meshgrid(u, u)

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -565,7 +565,8 @@ class Aperture(object):
             return (self.pupil_plane_scale == other.pupil_plane_scale and
                     np.array_equal(self.illuminated, other.illuminated))
         else:
-            return (self._circular_pupil == other._circular_pupil and
+            return (other._pupil_plane_im is None and
+                    self._circular_pupil == other._circular_pupil and
                     self._obscuration == other._obscuration and
                     self._nstruts == other._nstruts and
                     self._strut_thick == other._strut_thick and

--- a/galsim/randwalk.py
+++ b/galsim/randwalk.py
@@ -74,8 +74,6 @@ class RandomWalk(GSObject):
         .npoints
         .input_half_light_radius
         .flux
-        .deltas
-            The list of galsim.DeltaFunction objects representing the points
         .points
             The array of x,y offsets used to create the point sources
 
@@ -119,26 +117,17 @@ class RandomWalk(GSObject):
         self._set_gaussian_rng()
         self._points = self._get_points()
 
-    @property
-    def deltas(self):
-        deltas = []
+    @lazy_property
+    def _sbp(self):
         fluxper=self._flux/self._npoints
-
-        for p in self._points:
-            with convert_cpp_errors():
+        deltas = []
+        with convert_cpp_errors():
+            for p in self._points:
                 d = _galsim.SBDeltaFunction(fluxper, self.gsparams._gsp)
                 d = _galsim.SBTransform(d, 1.0, 0.0, 0.0, 1.0, _galsim.PositionD(p[0],p[1]), 1.0,
                                         self.gsparams._gsp)
-            deltas.append(d)
-        return deltas
-
-    # For backwards compatibility in case anyone referenced this attribute.
-    gaussians = deltas
-
-    @lazy_property
-    def _sbp(self):
-        with convert_cpp_errors():
-            return _galsim.SBAdd(self.deltas, self.gsparams._gsp)
+                deltas.append(d)
+            return _galsim.SBAdd(deltas, self.gsparams._gsp)
 
     @property
     def input_half_light_radius(self):

--- a/galsim/real.py
+++ b/galsim/real.py
@@ -278,7 +278,7 @@ class RealGalaxy(GSObject):
 
         if noise_image is None:
             self._gal_noise = UncorrelatedNoise(var, rng=self.rng, scale=pixel_scale,
-                                            gsparams=self._gsparams)
+                                                gsparams=self._gsparams)
         else:
             ii = InterpolatedImage(noise_image, normalization="sb",
                                    calculate_stepk=False, calculate_maxk=False,

--- a/galsim/spergel.py
+++ b/galsim/spergel.py
@@ -197,7 +197,7 @@ class Spergel(GSObject):
     @property
     def _maxk(self):
         # (1+k^2)^(-1-nu) = maxk_threshold
-        return math.sqrt(self._gsparams.maxk_threshold ** (-1./(1.+self._nu)) - 1.0) / self._r0
+        return math.sqrt(self.gsparams.maxk_threshold ** (-1./(1.+self._nu)) - 1.0) / self._r0
 
     @property
     def _stepk(self):

--- a/galsim/sum.py
+++ b/galsim/sum.py
@@ -191,6 +191,7 @@ class Sum(GSObject):
 
     @doc_inherit
     def withGSParams(self, gsparams):
+        if gsparams is self.gsparams: return self
         from copy import copy
         ret = copy(self)
         ret._gsparams = GSParams.check(gsparams)

--- a/galsim/transform.py
+++ b/galsim/transform.py
@@ -181,6 +181,14 @@ class Transformation(GSObject):
                                flux_ratio=self.flux_ratio**2),
                     self.original.noise.wcs)
 
+    @doc_inherit
+    def withGSParams(self, gsparams):
+        from copy import copy
+        ret = copy(self)
+        ret._gsparams = GSParams.check(gsparams)
+        ret._original = self.original.withGSParams(gsparams)
+        return ret
+
     def __eq__(self, other):
         return (isinstance(other, Transformation) and
                 self.original == other.original and

--- a/galsim/transform.py
+++ b/galsim/transform.py
@@ -132,11 +132,11 @@ class Transformation(GSObject):
     """
     def __init__(self, obj, jac=(1.,0.,0.,1.), offset=PositionD(0.,0.), flux_ratio=1.,
                  gsparams=None):
-        self._original = obj
         self._jac = np.asarray(jac, dtype=float).reshape(2,2)
         self._offset = PositionD(offset)
         self._flux_ratio = float(flux_ratio)
-        self._gsparams = GSParams.check(gsparams, self._original.gsparams)
+        self._gsparams = GSParams.check(gsparams, obj.gsparams)
+        obj = obj.withGSParams(self._gsparams)
 
         if isinstance(obj, Transformation):
             # Combine the two affine transformations into one.
@@ -146,6 +146,8 @@ class Transformation(GSObject):
             self._jac = self._jac.dot(obj.jac)
             self._flux_ratio *= obj._flux_ratio
             self._original = obj.original
+        else:
+            self._original = obj
 
     @property
     def original(self): return self._original
@@ -183,6 +185,7 @@ class Transformation(GSObject):
 
     @doc_inherit
     def withGSParams(self, gsparams):
+        if gsparams is self.gsparams: return self
         from copy import copy
         ret = copy(self)
         ret._gsparams = GSParams.check(gsparams)

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -186,7 +186,8 @@ class SimpleGenerator:
     Then generator() will return that object.
     """
     def __init__(self, obj): self._obj = obj
-    def __call__(self): return self._obj
+    def __call__(self):  # pragma: no cover  (It is covered, but coveralls doesn't get it right.)
+        return self._obj
 
 class AttributeDict(object): # pragma: no cover
     """Dictionary class that allows for easy initialization and refs to key values via attributes.

--- a/tests/galsim_test_helpers.py
+++ b/tests/galsim_test_helpers.py
@@ -230,12 +230,16 @@ def check_basic(prof, name, approx_maxsb=False, scale=None, do_x=True, do_k=True
     assert isinstance(prof.is_analytic_x, bool)
     assert isinstance(prof.is_analytic_k, bool)
 
-    assert prof.withGSParams(prof.gsparams) == prof
+    # When made with the same gsparams, it returns itself
+    assert prof.withGSParams(prof.gsparams) is prof
     alt_gsp = galsim.GSParams(xvalue_accuracy=0.2, folding_threshold=1.e-10)
     prof_alt = prof.withGSParams(alt_gsp)
     assert isinstance(prof_alt, prof.__class__)
     assert prof_alt.gsparams == alt_gsp
     assert prof_alt != prof  # Assuming none of our tests use this exact gsparams choice.
+    # Back to the original, ==, but not is
+    assert prof_alt.withGSParams(prof.gsparams) is not prof
+    assert prof_alt.withGSParams(prof.gsparams) == prof
 
     # Repeat for a rotated version of the profile.
     # The rotated version is mathematically the same for most profiles (all axisymmetric ones),

--- a/tests/galsim_test_helpers.py
+++ b/tests/galsim_test_helpers.py
@@ -54,8 +54,8 @@ def gsobject_compare(obj1, obj2, conv=None, decimal=10):
     """Helper function to check that two GSObjects are equivalent
     """
     if conv:
-        obj1 = galsim.Convolve([obj1,conv])
-        obj2 = galsim.Convolve([obj2,conv])
+        obj1 = galsim.Convolve([obj1,conv.withGSParams(obj1.gsparams)])
+        obj2 = galsim.Convolve([obj2,conv.withGSParams(obj2.gsparams)])
 
     im1 = galsim.ImageD(16,16)
     im2 = galsim.ImageD(16,16)
@@ -229,6 +229,13 @@ def check_basic(prof, name, approx_maxsb=False, scale=None, do_x=True, do_k=True
     assert isinstance(prof.is_axisymmetric, bool)
     assert isinstance(prof.is_analytic_x, bool)
     assert isinstance(prof.is_analytic_k, bool)
+
+    assert prof.withGSParams(prof.gsparams) == prof
+    alt_gsp = galsim.GSParams(xvalue_accuracy=0.2, folding_threshold=1.e-10)
+    prof_alt = prof.withGSParams(alt_gsp)
+    assert isinstance(prof_alt, prof.__class__)
+    assert prof_alt.gsparams == alt_gsp
+    assert prof_alt != prof  # Assuming none of our tests use this exact gsparams choice.
 
     # Repeat for a rotated version of the profile.
     # The rotated version is mathematically the same for most profiles (all axisymmetric ones),

--- a/tests/galsim_test_helpers.py
+++ b/tests/galsim_test_helpers.py
@@ -232,7 +232,7 @@ def check_basic(prof, name, approx_maxsb=False, scale=None, do_x=True, do_k=True
 
     # When made with the same gsparams, it returns itself
     assert prof.withGSParams(prof.gsparams) is prof
-    alt_gsp = galsim.GSParams(xvalue_accuracy=0.2, folding_threshold=1.e-10)
+    alt_gsp = galsim.GSParams(xvalue_accuracy=0.2, folding_threshold=0.03)
     prof_alt = prof.withGSParams(alt_gsp)
     assert isinstance(prof_alt, prof.__class__)
     assert prof_alt.gsparams == alt_gsp

--- a/tests/test_airy.py
+++ b/tests/test_airy.py
@@ -63,6 +63,11 @@ def test_airy():
             myImg.array, savedImg.array, 5,
             err_msg="Using GSObject Airy with GSParams() disagrees with expected result")
 
+    gsp = galsim.GSParams(xvalue_accuracy=1.e-8, kvalue_accuracy=1.e-8)
+    airy2 = galsim.Airy(lam_over_diam=1./0.8, obscuration=0.1, flux=1, gsparams=gsp)
+    assert airy2 != airy
+    assert airy2 == airy.withGSParams(gsp)
+
     # Check some properties
     airy = galsim.Airy(lam_over_diam=1./0.8, obscuration=0.1, flux=test_flux)
     cen = galsim.PositionD(0, 0)

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -60,6 +60,10 @@ def test_box():
 
     # Use non-unity values.
     pixel = galsim.Pixel(flux=1.7, scale=2.3)
+    gsp = galsim.GSParams(xvalue_accuracy=1.e-8, kvalue_accuracy=1.e-8)
+    pixel2 = galsim.Pixel(flux=1.7, scale=2.3, gsparams=gsp)
+    assert pixel2 != pixel
+    assert pixel2 == pixel.withGSParams(gsp)
 
     # Test photon shooting.
     do_shoot(pixel,myImg,"Pixel")
@@ -98,6 +102,11 @@ def test_box():
         np.testing.assert_array_equal(
                 box.height, height,
                 err_msg="Box height returned wrong value")
+
+        gsp2 = galsim.GSParams(xvalue_accuracy=1.e-8, kvalue_accuracy=1.e-8)
+        box2 = galsim.Box(width=width, height=height, flux=test_flux, gsparams=gsp2)
+        assert box2 != box
+        assert box2 == box.withGSParams(gsp2)
 
     # Check picklability
     do_pickle(box, lambda x: x.drawImage(method='no_pixel'))
@@ -166,6 +175,10 @@ def test_tophat():
 
     # Use non-unity values.
     tophat = galsim.TopHat(flux=1.7, radius=2.3)
+    gsp = galsim.GSParams(xvalue_accuracy=1.e-8, kvalue_accuracy=1.e-8)
+    tophat2 = galsim.TopHat(flux=1.7, radius=2.3, gsparams=gsp)
+    assert tophat2 != tophat
+    assert tophat2 == tophat.withGSParams(gsp)
 
     # Test photon shooting.
     do_shoot(tophat,myImg,"TopHat")

--- a/tests/test_chromatic.py
+++ b/tests/test_chromatic.py
@@ -1285,7 +1285,6 @@ def test_gsparams():
     gsparams = galsim.GSParams(folding_threshold=1.e-4, maxk_threshold=1.e-4, maximum_fft_size=1.e4)
     final = galsim.Convolve([gal, psf], gsparams=gsparams)
     assert galsim.Convolve([gal, psf]) != final
-    final2 = galsim.Convolve([gal, psf]).withGSParams(gsparams)
     assert galsim.Convolve([gal, psf]).withGSParams(gsparams) == final
     assert galsim.Convolve([gal.withGSParams(gsparams), psf]) == final
     assert galsim.Convolve([gal, psf.withGSParams(gsparams)]) == final

--- a/tests/test_convolve.py
+++ b/tests/test_convolve.py
@@ -812,6 +812,72 @@ def test_convolve_noise():
     assert autocorr.noise is None
     assert four.noise is None
 
+@timer
+def test_gsparams():
+    """Test withGSParams with some non-default gsparams
+    """
+    obj1 = galsim.Exponential(half_light_radius=1.7)
+    obj2 = galsim.Pixel(scale=0.2)
+    gsp = galsim.GSParams(folding_threshold=1.e-4, maxk_threshold=1.e-4, maximum_fft_size=1.e4)
+
+    conv = galsim.Convolve(obj1, obj2)
+    conv1 = conv.withGSParams(gsp)
+    conv2 = galsim.Convolve(obj1.withGSParams(gsp), obj2.withGSParams(gsp))
+    conv3 = galsim.Convolve(galsim.Exponential(half_light_radius=1.7, gsparams=gsp),
+                            galsim.Pixel(scale=0.2))
+    assert conv != conv1
+    assert conv1 == conv2
+    assert conv1 == conv3
+    print('stepk = ',conv.stepk, conv1.stepk)
+    assert conv1.stepk < conv.stepk
+    print('maxk = ',conv.maxk, conv1.maxk)
+    assert conv1.maxk > conv.maxk
+
+    conv = galsim.AutoConvolve(obj1)
+    conv1 = conv.withGSParams(gsp)
+    conv2 = galsim.AutoConvolve(obj1.withGSParams(gsp))
+    assert conv != conv1
+    assert conv1 == conv2
+    print('stepk = ',conv.stepk, conv1.stepk)
+    assert conv1.stepk < conv.stepk
+    print('maxk = ',conv.maxk, conv1.maxk)
+    assert conv1.maxk > conv.maxk
+
+    conv = galsim.AutoCorrelate(obj1)
+    conv1 = conv.withGSParams(gsp)
+    conv2 = galsim.AutoCorrelate(obj1.withGSParams(gsp))
+    assert conv != conv1
+    assert conv1 == conv2
+    print('stepk = ',conv.stepk, conv1.stepk)
+    assert conv1.stepk < conv.stepk
+    print('maxk = ',conv.maxk, conv1.maxk)
+    assert conv1.maxk > conv.maxk
+
+    conv = galsim.Convolve(obj1, galsim.Deconvolve(obj2))
+    conv1 = conv.withGSParams(gsp)
+    conv2 = galsim.Convolve(obj1, galsim.Deconvolve(obj2.withGSParams(gsp)))
+    conv3 = galsim.Convolve(obj1.withGSParams(gsp), galsim.Deconvolve(obj2))
+    assert conv != conv1
+    assert conv1 == conv2
+    assert conv1 == conv3
+    print('stepk = ',conv.stepk, conv1.stepk)
+    assert conv1.stepk < conv.stepk
+    print('maxk = ',conv.maxk, conv1.maxk)
+    assert conv1.maxk > conv.maxk
+
+    conv = galsim.Convolve(obj1, galsim.FourierSqrt(obj2))
+    conv1 = conv.withGSParams(gsp)
+    conv2 = galsim.Convolve(obj1, galsim.FourierSqrt(obj2.withGSParams(gsp)))
+    conv3 = galsim.Convolve(obj1.withGSParams(gsp), galsim.FourierSqrt(obj2))
+    assert conv != conv1
+    assert conv1 == conv2
+    assert conv1 == conv3
+    print('stepk = ',conv.stepk, conv1.stepk)
+    assert conv1.stepk < conv.stepk
+    print('maxk = ',conv.maxk, conv1.maxk)
+    assert conv1.maxk > conv.maxk
+
+
 if __name__ == "__main__":
     test_convolve()
     test_convolve_flux_scaling()
@@ -824,3 +890,4 @@ if __name__ == "__main__":
     test_autocorrelate()
     test_ne()
     test_convolve_noise()
+    test_gsparams()

--- a/tests/test_correlatednoise.py
+++ b/tests/test_correlatednoise.py
@@ -1309,6 +1309,9 @@ def test_gsparams():
     print('ucn2 = ',repr(ucn2))
     assert ucn != ucn1
     assert ucn1 == ucn2
+    assert ucn.withGSParams(ucn.gsparams) is ucn
+    assert ucn1.withGSParams(ucn.gsparams) is not ucn
+    assert ucn1.withGSParams(ucn.gsparams) == ucn
 
     ccn = galsim.getCOSMOSNoise(rng=rng)
 
@@ -1316,6 +1319,9 @@ def test_gsparams():
     ccn2 = galsim.getCOSMOSNoise(rng=rng, gsparams=gsp)
     assert ccn != ccn1
     assert ccn1 == ccn2
+    assert ccn.withGSParams(ccn.gsparams) is ccn
+    assert ccn1.withGSParams(ccn.gsparams) is not ccn
+    assert ccn1.withGSParams(ccn.gsparams) == ccn
 
 
 if __name__ == "__main__":

--- a/tests/test_correlatednoise.py
+++ b/tests/test_correlatednoise.py
@@ -1295,6 +1295,28 @@ def test_covariance_spectrum():
     do_pickle(covspec)
     do_pickle(covspec, lambda x: x.toNoise(bp, psf, wcs, rng=bd))
 
+@timer
+def test_gsparams():
+    """Test withGSParams
+    """
+    rng = galsim.BaseDeviate(1234)
+    ucn = galsim.UncorrelatedNoise(rng=rng, variance=1.e3)
+    gsp = galsim.GSParams(folding_threshold=1.e-4, maxk_threshold=1.e-4, maximum_fft_size=1.e4)
+
+    ucn1 = ucn.withGSParams(gsp)
+    ucn2 = galsim.UncorrelatedNoise(rng=rng, variance=1.e3, gsparams=gsp)
+    print('ucn1 = ',repr(ucn1))
+    print('ucn2 = ',repr(ucn2))
+    assert ucn != ucn1
+    assert ucn1 == ucn2
+
+    ccn = galsim.getCOSMOSNoise(rng=rng)
+
+    ccn1 = ccn.withGSParams(gsp)
+    ccn2 = galsim.getCOSMOSNoise(rng=rng, gsparams=gsp)
+    assert ccn != ccn1
+    assert ccn1 == ccn2
+
 
 if __name__ == "__main__":
     test_uncorrelated_noise_zero_lag()
@@ -1319,3 +1341,4 @@ if __name__ == "__main__":
     test_variance_changes()
     test_cosmos_wcs()
     test_covariance_spectrum()
+    test_gsparams()

--- a/tests/test_deltafunction.py
+++ b/tests/test_deltafunction.py
@@ -45,6 +45,11 @@ def test_deltaFunction():
     check_basic(delta, "DeltaFunction")
     do_pickle(delta)
 
+    gsp = galsim.GSParams(xvalue_accuracy=1.e-8, kvalue_accuracy=1.e-8)
+    delta2 = galsim.DeltaFunction(flux=test_flux, gsparams=gsp)
+    assert delta2 != delta
+    assert delta2 == delta.withGSParams(gsp)
+
     # Test operations with no-ops on DeltaFunction
     delta_shr = delta.shear(g1=0.3, g2=0.1)
     np.testing.assert_almost_equal(delta_shr.flux, test_flux)

--- a/tests/test_exponential.py
+++ b/tests/test_exponential.py
@@ -64,6 +64,11 @@ def test_exponential():
 
     # Use non-unity values.
     expon = galsim.Exponential(flux=1.7, scale_radius=0.91)
+    gsp = galsim.GSParams(xvalue_accuracy=1.e-8, kvalue_accuracy=1.e-8)
+    expon2 = galsim.Exponential(flux=1.7, scale_radius=0.91, gsparams=gsp)
+    assert expon2 != expon
+    assert expon2 == expon.withGSParams(gsp)
+
     check_basic(expon, "Exponential")
 
     # Test photon shooting.

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -75,6 +75,10 @@ def test_gaussian():
 
     # Use non-unity values.
     gauss = galsim.Gaussian(flux=1.7, sigma=2.3)
+    gsp = galsim.GSParams(xvalue_accuracy=1.e-8, kvalue_accuracy=1.e-8)
+    gauss2 = galsim.Gaussian(flux=1.7, sigma=2.3, gsparams=gsp)
+    assert gauss2 != gauss
+    assert gauss2 == gauss.withGSParams(gsp)
     check_basic(gauss, "Gaussian")
 
     # Test photon shooting.

--- a/tests/test_inclined.py
+++ b/tests/test_inclined.py
@@ -131,6 +131,13 @@ def test_regression():
             # Now make a test image
             test_profile = get_prof(mode, inc_angle * galsim.radians, scale_radius,
                                     scale_height, flux=flux)
+
+            gsp = galsim.GSParams(xvalue_accuracy=1.e-8, kvalue_accuracy=1.e-8)
+            test2 = get_prof(mode, inc_angle * galsim.radians, scale_radius, scale_height,
+                             flux=flux, gsparams=gsp)
+            assert test2 != test_profile
+            assert test2 == test_profile.withGSParams(gsp)
+
             check_basic(test_profile, mode)
 
             # Rotate it by the position angle

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -98,6 +98,10 @@ def test_roundtrip():
         interp2 = galsim.InterpolatedImage(image_in, scale=test_scale, gsparams=gsp)
         assert interp2 != interp
         assert interp2 == interp.withGSParams(gsp)
+        assert interp2.x_interpolant.gsparams == gsp
+        assert interp2.k_interpolant.gsparams == gsp
+        assert interp.x_interpolant.gsparams != gsp
+        assert interp.k_interpolant.gsparams != gsp
 
         # Lanczos doesn't quite get the flux right.  Wrong at the 5th decimal place.
         # Gary says that's expected -- Lanczos isn't technically flux conserving.
@@ -1122,6 +1126,13 @@ def test_kroundtrip():
     # Check picklability
     do_pickle(b)
     do_pickle(b, lambda x: x.drawImage())
+
+    gsp = galsim.GSParams(xvalue_accuracy=1.e-8, kvalue_accuracy=1.e-8)
+    b2 = galsim.InterpolatedKImage(kim_a, gsparams=gsp)
+    assert b2 != b
+    assert b2 == b.withGSParams(gsp)
+    assert b2.k_interpolant.gsparams == gsp
+    assert b.k_interpolant.gsparams != gsp
 
     check_basic(b, "InterpolatedKImage", approx_maxsb=True)
 

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -94,6 +94,11 @@ def test_roundtrip():
                 err_msg="Output Image differs from reference for type %s, scale %s"%
                         (array_type,test_scale))
 
+        gsp = galsim.GSParams(xvalue_accuracy=1.e-8, kvalue_accuracy=1.e-8)
+        interp2 = galsim.InterpolatedImage(image_in, scale=test_scale, gsparams=gsp)
+        assert interp2 != interp
+        assert interp2 == interp.withGSParams(gsp)
+
         # Lanczos doesn't quite get the flux right.  Wrong at the 5th decimal place.
         # Gary says that's expected -- Lanczos isn't technically flux conserving.
         # He applied the 1st order correction to the flux, but expect to be wrong at around

--- a/tests/test_kolmogorov.py
+++ b/tests/test_kolmogorov.py
@@ -64,6 +64,11 @@ def test_kolmogorov():
             myImg.array, savedImg.array, 5,
             err_msg="Using GSObject Kolmogorov with GSParams() disagrees with expected result")
 
+    gsp = galsim.GSParams(xvalue_accuracy=1.e-8, kvalue_accuracy=1.e-8)
+    kolm2 = galsim.Kolmogorov(lam_over_r0=1.5, flux=test_flux, gsparams=gsp)
+    assert kolm2 != kolm
+    assert kolm2 == kolm.withGSParams(gsp)
+
     check_basic(kolm, "Kolmogorov")
 
     # Test photon shooting.

--- a/tests/test_moffat.py
+++ b/tests/test_moffat.py
@@ -67,6 +67,11 @@ def test_moffat():
 
     # Use non-unity values.
     moffat = galsim.Moffat(beta=3.7, flux=1.7, half_light_radius=2.3, trunc=8.2)
+    gsp = galsim.GSParams(xvalue_accuracy=1.e-8, kvalue_accuracy=1.e-8)
+    moffat2 = galsim.Moffat(beta=3.7, flux=1.7, half_light_radius=2.3, trunc=8.2, gsparams=gsp)
+    assert moffat2 != moffat
+    assert moffat2 == moffat.withGSParams(gsp)
+
     check_basic(moffat, "Moffat")
 
     # Test photon shooting.

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -453,10 +453,15 @@ def test_OpticalPSF_pupil_plane():
                   pupil_plane_scale=pp_scale)
     assert_raises(ValueError, galsim.OpticalPSF, lam_over_diam,
                   pupil_plane_im=im.view(scale=pp_scale))
-    assert_raises(ValueError, galsim.OpticalPSF, lam_over_diam,
-                  pupil_plane_im=galsim.Image(im.array[:-2,:]))
-    assert_raises(ValueError, galsim.OpticalPSF, lam_over_diam,
-                  pupil_plane_im=galsim.Image(im.array[:-1,:-1]))
+    # These aren't raised until the image is actually used
+    with assert_raises(ValueError):
+        # not square
+        op = galsim.OpticalPSF(lam_over_diam, pupil_plane_im=galsim.Image(im.array[:-2,:]))
+        op.drawImage()
+    with assert_raises(ValueError):
+        # not even sides
+        op = galsim.OpticalPSF(lam_over_diam, pupil_plane_im=galsim.Image(im.array[:-1,:-1]))
+        op.drawImage()
 
     # It is supposed to be able to figure this out even if we *don't* tell it the pad factor. So
     # make sure that it still works even if we don't tell it that value.

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -507,9 +507,8 @@ def test_stepk_maxk():
 
     # Check that stepk changes when gsparams.folding_threshold become more extreme.
     # (Note: maxk is independent of maxk_threshold because of the hard edge of the aperture.)
-    psf1 = galsim.PhaseScreenPSF(atm, 500.0, diam=1.0, scale_unit=galsim.arcsec,
-                                 gsparams=galsim.GSParams(folding_threshold=1.e-3,
-                                                          maxk_threshold=1.e-4))
+    gsp = galsim.GSParams(folding_threshold=1.e-3, maxk_threshold=1.e-4)
+    psf1 = galsim.PhaseScreenPSF(atm, 500.0, diam=1.0, scale_unit=galsim.arcsec, gsparams=gsp)
     stepk3 = psf1.stepk
     maxk3 = psf1.maxk
     print('stepk3 = ',stepk3)
@@ -517,6 +516,19 @@ def test_stepk_maxk():
     print('goodImageSize = ',psf1.getGoodImageSize(0.2))
     assert stepk3 < stepk1
     assert maxk3 == maxk1
+
+    psf2 = psf.withGSParams(gsp)
+    assert psf2.gsparams == gsp
+    assert psf2 != psf
+    assert psf2 == psf1
+    assert psf2.aper.gsparams == gsp
+    assert psf.aper.gsparams != gsp
+
+    aper3 = galsim.Aperture(diam=1.0, gsparams=gsp)
+    psf3 = galsim.PhaseScreenPSF(atm, 500.0, aper=aper3, scale_unit=galsim.arcsec)
+    assert psf3.gsparams == gsp
+    assert psf3 != psf
+    assert psf3 == psf1
 
     # Check that it respects the force_stepk and force_maxk parameters
     psf2 = galsim.PhaseScreenPSF(atm, 500.0, aper=aper, scale_unit=galsim.arcsec,

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -461,12 +461,18 @@ def test_scale_unit():
 def test_stepk_maxk():
     """Test options to specify (or not) stepk and maxk.
     """
+    # Make a dummy Kolmogorov just in case this test is the first to do so.  Don't want the
+    # building of the KolmogorovInfo lookup table to mess up the timing test.
+    kolm = galsim.Kolmogorov(fwhm=2)
+    kolm._sbp
+
     import time
     aper = galsim.Aperture(diam=1.0)
     rng = galsim.BaseDeviate(123456)
     # Test frozen AtmosphericScreen first
     atm = galsim.Atmosphere(screen_size=30.0, altitude=10.0, speed=0.1, alpha=1.0, rng=rng)
     psf = galsim.PhaseScreenPSF(atm, 500.0, aper=aper, scale_unit=galsim.arcsec)
+
     t0 = time.time()
     stepk1 = psf.stepk
     maxk1 = psf.maxk
@@ -529,6 +535,7 @@ def test_stepk_maxk():
                                  _force_stepk=stepk2/3.5)
     with assert_warns(galsim.GalSimWarning):
         psf4._prepareDraw()
+        psf4._ii  # Don't need to actually draw it.  Just access this attribute.
 
     # Can suppress this warning if desired.
     psf5 = galsim.PhaseScreenPSF(atm, 500.0, aper=aper, scale_unit=galsim.arcsec,

--- a/tests/test_randwalk.py
+++ b/tests/test_randwalk.py
@@ -42,7 +42,7 @@ def test_randwalk_defaults():
     assert rw.input_half_light_radius==hlr,\
         "expected hlr==%g, got %g" % (hlr, rw.input_half_light_radius)
 
-    nobj=len(rw.deltas)
+    nobj=len(rw.points)
     assert nobj == npoints,"expected %d objects, got %d" % (npoints, nobj)
 
     pts=rw.points
@@ -84,11 +84,9 @@ def test_randwalk_valid_inputs():
     assert rw.flux==flux,\
         "expected flux==%g, got %g" % (flux, rw.flux)
 
-    d=rw.deltas
-    nobj=len(d)
-    assert nobj == npoints==npoints,"expected %d objects, got %d" % (npoints, nobj)
-
     pts=rw.points
+    nobj=len(pts)
+    assert nobj == npoints==npoints,"expected %d objects, got %d" % (npoints, nobj)
     assert pts.shape == (npoints,2),"expected (%d,2) shape for points, got %s" % (npoints, pts.shape)
 
 @timer
@@ -218,14 +216,13 @@ def test_randwalk_config():
     assert rw.input_half_light_radius==rwc.input_half_light_radius,\
         "expected hlr==%g, got %g" % (rw.input_half_light_radius, rw.input_half_light_radius)
 
-    nobj=len(rw.deltas)
-    nobjc=len(rwc.deltas)
+    nobj=len(rw.points)
+    nobjc=len(rwc.points)
     assert nobj==nobjc,"expected %d objects, got %d" % (nobj,nobjc)
 
     pts=rw.points
     ptsc=rwc.points
-    assert (pts.shape == ptsc.shape),\
-            "expected %s shape for points, got %s" % (pts.shape,ptsc.shape)
+    assert pts.shape == ptsc.shape, "expected %s shape for points, got %s" % (pts.shape,ptsc.shape)
 
 
 @timer

--- a/tests/test_randwalk.py
+++ b/tests/test_randwalk.py
@@ -50,6 +50,11 @@ def test_randwalk_defaults():
     np.testing.assert_almost_equal(rw.centroid.x, np.mean(pts[:,0]))
     np.testing.assert_almost_equal(rw.centroid.y, np.mean(pts[:,1]))
 
+    gsp = galsim.GSParams(xvalue_accuracy=1.e-8, kvalue_accuracy=1.e-8)
+    rw2 = galsim.RandomWalk(npoints, hlr, rng=rng, gsparams=gsp)
+    assert rw2 != rw
+    assert rw2 == rw.withGSParams(gsp)
+
     # Run some basic tests of correctness
     psf = galsim.Gaussian(sigma=0.8)
     conv = galsim.Convolve(rw, psf)

--- a/tests/test_real.py
+++ b/tests/test_real.py
@@ -184,6 +184,11 @@ def test_real_galaxy_ideal():
     rg_4 = galsim.RealGalaxy(rgc, random=True, rng=galsim.BaseDeviate(67890))
     assert rg_3.index != rg_4.index, 'Different seeds did not give different random objects!'
 
+    gsp = galsim.GSParams(xvalue_accuracy=1.e-8, kvalue_accuracy=1.e-8)
+    rg_5 = galsim.RealGalaxy(rgc, random=True, rng=galsim.BaseDeviate(67890), gsparams=gsp)
+    assert rg_5 != rg_4
+    assert rg_5 == rg_4.withGSParams(gsp)
+
     check_basic(rg, "RealGalaxy", approx_maxsb=True)
     check_basic(rg_1, "RealGalaxy", approx_maxsb=True)
     check_basic(rg_2, "RealGalaxy", approx_maxsb=True)

--- a/tests/test_second_kick.py
+++ b/tests/test_second_kick.py
@@ -53,6 +53,11 @@ def test_init():
                 do_pickle(sk)
                 t2 = time.time()
 
+                gsp = galsim.GSParams(xvalue_accuracy=1.e-8, kvalue_accuracy=1.e-8)
+                sk2 = galsim.SecondKick(flux=2.2, gsparams=gsp, **kwargs)
+                assert sk2 != sk
+                assert sk2 == sk.withGSParams(gsp)
+
                 # Raw sk objects are hard to draw due to a large maxk/stepk ratio.
                 # Decrease maxk by convolving in a smallish Gaussian.
                 obj = galsim.Convolve(sk, galsim.Gaussian(fwhm=0.2))

--- a/tests/test_sersic.py
+++ b/tests/test_sersic.py
@@ -58,6 +58,10 @@ def test_sersic():
 
     # Use non-unity values.
     sersic = galsim.Sersic(n=3, flux=1.7, half_light_radius=2.3)
+    gsp = galsim.GSParams(xvalue_accuracy=1.e-8, kvalue_accuracy=1.e-8)
+    sersic2 = galsim.Sersic(n=3, flux=1.7, half_light_radius=2.3, gsparams=gsp)
+    assert sersic2 != sersic
+    assert sersic2 == sersic.withGSParams(gsp)
     check_basic(sersic, "Sersic")
 
     # Test photon shooting.

--- a/tests/test_shapelet.py
+++ b/tests/test_shapelet.py
@@ -91,6 +91,11 @@ def test_shapelet_drawImage():
             print('shapelet vector = ',bvec)
             shapelet = galsim.Shapelet(sigma=sigma, order=order, bvec=bvec)
 
+            gsp = galsim.GSParams(xvalue_accuracy=1.e-8, kvalue_accuracy=1.e-8)
+            shapelet2 = galsim.Shapelet(sigma=sigma, order=order, bvec=bvec, gsparams=gsp)
+            assert shapelet2 != shapelet
+            assert shapelet2 == shapelet.withGSParams(gsp)
+
             check_basic(shapelet, "Shapelet", approx_maxsb=True)
 
             # Test normalization  (This is normally part of do_shoot.  When we eventually

--- a/tests/test_spergel.py
+++ b/tests/test_spergel.py
@@ -55,6 +55,11 @@ def test_spergel():
             myImg.array, savedImg.array, 5,
             err_msg="Using GSObject Spergel disagrees with expected result")
 
+        gsp = galsim.GSParams(xvalue_accuracy=1.e-8, kvalue_accuracy=1.e-8)
+        spergel2 = galsim.Spergel(nu=nu, half_light_radius=1.0, gsparams=gsp)
+        assert spergel2 != spergel
+        assert spergel2 == spergel.withGSParams(gsp)
+
         # nu < 0 has inf for xValue(0,0), so the x tests fail for them.
         check_basic(spergel, "Spergel with nu=%f"%nu, do_x=(nu > 0))
 

--- a/tests/test_sum.py
+++ b/tests/test_sum.py
@@ -225,7 +225,8 @@ def test_ne():
             galsim.Sum(gal1, gal2),
             galsim.Sum(gal2, gal1),  # Not! commutative.  (but is associative)
             galsim.Sum(galsim.Sum(gal1, gal2), gal2),
-            galsim.Sum(gal1, gsparams=gsp)]
+            galsim.Sum(gal1, gsparams=gsp),
+            galsim.Sum(gal1, gsparams=gsp, propagate_gsparams=False)]
     all_obj_diff(gals)
 
 
@@ -313,19 +314,40 @@ def test_gsparams():
     obj1 = galsim.Exponential(half_light_radius=1.7)
     obj2 = galsim.Pixel(scale=0.2)
     gsp = galsim.GSParams(folding_threshold=1.e-4, maxk_threshold=1.e-4, maximum_fft_size=1.e4)
+    gsp2 = galsim.GSParams(folding_threshold=1.e-2, maxk_threshold=1.e-2)
 
     sum = galsim.Sum(obj1, obj2)
     sum1 = sum.withGSParams(gsp)
+    assert sum.gsparams == galsim.GSParams()
+    assert sum1.gsparams == gsp
+    assert sum1.obj_list[0].gsparams == gsp
+    assert sum1.obj_list[1].gsparams == gsp
+
     sum2 = galsim.Sum(obj1.withGSParams(gsp), obj2.withGSParams(gsp))
     sum3 = galsim.Sum(galsim.Exponential(half_light_radius=1.7, gsparams=gsp),
                        galsim.Pixel(scale=0.2))
+    sum4 = galsim.Add(obj1, obj2, gsparams=gsp)
     assert sum != sum1
     assert sum1 == sum2
     assert sum1 == sum3
+    assert sum1 == sum4
     print('stepk = ',sum.stepk, sum1.stepk)
     assert sum1.stepk < sum.stepk
     print('maxk = ',sum.maxk, sum1.maxk)
     assert sum1.maxk > sum.maxk
+
+    sum5 = galsim.Add(obj1, obj2, gsparams=gsp, propagate_gsparams=False)
+    assert sum5 != sum4
+    assert sum5.gsparams == gsp
+    assert sum5.obj_list[0].gsparams == galsim.GSParams()
+    assert sum5.obj_list[1].gsparams == galsim.GSParams()
+
+    sum6 = sum5.withGSParams(gsp2)
+    assert sum6 != sum5
+    assert sum6.gsparams == gsp2
+    assert sum6.obj_list[0].gsparams == galsim.GSParams()
+    assert sum6.obj_list[1].gsparams == galsim.GSParams()
+
 
 
 if __name__ == "__main__":

--- a/tests/test_sum.py
+++ b/tests/test_sum.py
@@ -306,6 +306,28 @@ def test_sum_noise():
     except:
         pass
 
+@timer
+def test_gsparams():
+    """Test withGSParams with some non-default gsparams
+    """
+    obj1 = galsim.Exponential(half_light_radius=1.7)
+    obj2 = galsim.Pixel(scale=0.2)
+    gsp = galsim.GSParams(folding_threshold=1.e-4, maxk_threshold=1.e-4, maximum_fft_size=1.e4)
+
+    sum = galsim.Sum(obj1, obj2)
+    sum1 = sum.withGSParams(gsp)
+    sum2 = galsim.Sum(obj1.withGSParams(gsp), obj2.withGSParams(gsp))
+    sum3 = galsim.Sum(galsim.Exponential(half_light_radius=1.7, gsparams=gsp),
+                       galsim.Pixel(scale=0.2))
+    assert sum != sum1
+    assert sum1 == sum2
+    assert sum1 == sum3
+    print('stepk = ',sum.stepk, sum1.stepk)
+    assert sum1.stepk < sum.stepk
+    print('maxk = ',sum.maxk, sum1.maxk)
+    assert sum1.maxk > sum.maxk
+
+
 if __name__ == "__main__":
     test_add()
     test_sub_neg()
@@ -313,3 +335,4 @@ if __name__ == "__main__":
     test_ne()
     test_sum_transform()
     test_sum_noise()
+    test_gsparams()

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -960,6 +960,27 @@ def test_compound():
     np.testing.assert_array_almost_equal(im3_cf.array, im3_cd.array, decimal=3)
     np.testing.assert_array_almost_equal(im5_cf.array, im5_cd.array, decimal=3)
 
+@timer
+def test_gsparams():
+    """Test withGSParams with some non-default gsparams
+    """
+    obj = galsim.Exponential(half_light_radius=1.7)
+    gsp = galsim.GSParams(folding_threshold=1.e-4, maxk_threshold=1.e-4, maximum_fft_size=1.e4)
+
+    tr = obj.shear(g1=0.2, g2=0.3)
+    jac = galsim.Shear(g1=0.2, g2=0.3).getMatrix()
+    tr1 = tr.withGSParams(gsp)
+    tr2 = galsim.Transformation(obj.withGSParams(gsp), jac=jac)
+    tr3 = galsim.Transformation(obj, jac=jac, gsparams=gsp)
+    assert tr != tr1
+    assert tr1 == tr2
+    assert tr1 == tr3
+    print('stepk = ',tr.stepk, tr1.stepk)
+    assert tr1.stepk < tr.stepk
+    print('maxk = ',tr.maxk, tr1.maxk)
+    assert tr1.maxk > tr.maxk
+
+
 if __name__ == "__main__":
     test_smallshear()
     test_largeshear()
@@ -973,3 +994,4 @@ if __name__ == "__main__":
     test_flip()
     test_ne()
     test_compound()
+    test_gsparams()

--- a/tests/test_vonkarman.py
+++ b/tests/test_vonkarman.py
@@ -54,6 +54,11 @@ def test_vk(slow=False):
                     vk = galsim.VonKarman(flux=2.2, **kwargs)
                     np.testing.assert_almost_equal(vk.flux, 2.2)
 
+                    gsp = galsim.GSParams(xvalue_accuracy=1.e-8, kvalue_accuracy=1.e-8)
+                    vk2 = galsim.VonKarman(flux=2.2, gsparams=gsp, **kwargs)
+                    assert vk2 != vk
+                    assert vk2 == vk.withGSParams(gsp)
+
                     check_basic(vk, "VonKarman")
                     do_pickle(vk)
 


### PR DESCRIPTION
This is mostly a new feature to add a method of GSObjects, `withGSParams`, that lets the user change the GSParams attribute of a given object after being constructed.

This feature enables an API change in how `gsparams` works for Convolve (and similar) objects, which i think will make it a lot easier for users to set gsparams the way they want.  They will no longer need to go back to the start and recreate everything if they want to change the `folding_threshold` or something (as @jchiang87 and @sweverett have desired at various points, among others).  Instead, if they set a `gsparams` value in Convolve (or anything else that wraps another object), it will apply to all the components as well as the wrapper.  And if they don't then it will find the most restrictive combination of parameters used by the components and apply that to all of the components.

Most of this should be an easy review I think.  The exception is the Aperture class (and to some extent the related aspects of PhaseScreenPSF), which required a lot of refactoring.  So @jmeyers314 I'd appreciate if you can look at that and make sure I didn't break anything there.  The unit tests all still pass of course, but you might think of a use case that is made more complicated or slower or something because of the changes here.