### PR TITLE
#990 fix PhaseScreenPSF.withGSParams

### DIFF
--- a/galsim/__init__.py
+++ b/galsim/__init__.py
@@ -137,7 +137,7 @@ from .spergel import Spergel
 from .deltafunction import DeltaFunction
 from .real import RealGalaxy, RealGalaxyCatalog, ChromaticRealGalaxy
 from .phase_psf import Aperture, PhaseScreenList, PhaseScreenPSF, OpticalPSF
-from .phase_screens import AtmosphericScreen, Atmosphere, OpticalScreen, _DummyScreen
+from .phase_screens import AtmosphericScreen, Atmosphere, OpticalScreen
 from .shapelet import Shapelet
 from .inclined import InclinedExponential, InclinedSersic
 from .interpolant import Interpolant

--- a/galsim/__init__.py
+++ b/galsim/__init__.py
@@ -137,7 +137,7 @@ from .spergel import Spergel
 from .deltafunction import DeltaFunction
 from .real import RealGalaxy, RealGalaxyCatalog, ChromaticRealGalaxy
 from .phase_psf import Aperture, PhaseScreenList, PhaseScreenPSF, OpticalPSF
-from .phase_screens import AtmosphericScreen, Atmosphere, OpticalScreen
+from .phase_screens import AtmosphericScreen, Atmosphere, OpticalScreen, _DummyScreen
 from .shapelet import Shapelet
 from .inclined import InclinedExponential, InclinedSersic
 from .interpolant import Interpolant

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -1816,12 +1816,12 @@ class OpticalPSF(GSObject):
     @lazy_property
     def _psf(self):
         psf = PhaseScreenPSF(self._screens, lam=self._lam, flux=self._flux,
-                                   aper=self._aper, interpolant=self._interpolant,
-                                   scale_unit=self._scale_unit, gsparams=self._gsparams,
-                                   suppress_warning=self._suppress_warning,
-                                   geometric_shooting=self._geometric_shooting,
-                                   _force_stepk=self._force_stepk, _force_maxk=self._force_maxk,
-                                   ii_pad_factor=self._ii_pad_factor)
+                             aper=self._aper, interpolant=self._interpolant,
+                             scale_unit=self._scale_unit, gsparams=self._gsparams,
+                             suppress_warning=self._suppress_warning,
+                             geometric_shooting=self._geometric_shooting,
+                             _force_stepk=self._force_stepk, _force_maxk=self._force_maxk,
+                             ii_pad_factor=self._ii_pad_factor)
         psf._prepareDraw()  # No need to delay an OpticalPSF.
         return psf
 

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -1185,7 +1185,7 @@ class PhaseScreenPSF(GSObject):
                  theta=(0.0*arcsec, 0.0*arcsec), interpolant=None,
                  scale_unit=arcsec, ii_pad_factor=4., suppress_warning=False,
                  geometric_shooting=True, aper=None, second_kick=None, kcrit=0.2,
-                 gsparams=None, _bar=None, _force_stepk=0., _force_maxk=0., **kwargs):
+                 gsparams=None, _force_stepk=0., _force_maxk=0., _bar=None, **kwargs):
         # Hidden `_bar` kwarg can be used with astropy.console.utils.ProgressBar to print out a
         # progress bar during long calculations.
 
@@ -1324,11 +1324,14 @@ class PhaseScreenPSF(GSObject):
     @doc_inherit
     def withGSParams(self, gsparams):
         if gsparams is self.gsparams: return self
-        from copy import copy
-        ret = copy(self)
-        ret._gsparams = GSParams.check(gsparams)
-        ret.aper = self.aper.withGSParams(gsparams)
-        return ret
+        gsparams = GSParams.check(gsparams)
+        aper = self.aper.withGSParams(gsparams)
+        return PhaseScreenPSF(
+            self.screen_list, self.lam, self.t0, self.exptime, self.time_step, self.flux,
+            self.theta, self.interpolant, self.scale_unit, self._ii_pad_factor,
+            self._suppress_warning, self._geometric_shooting, aper, self._second_kick, self._kcrit,
+            gsparams, self._force_stepk, self._force_maxk
+        )
 
     def __str__(self):
         return ("galsim.PhaseScreenPSF(%s, lam=%s, exptime=%s)" %

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -1224,7 +1224,7 @@ class PhaseScreenPSF(GSObject):
         self._force_stepk = _force_stepk
         self._force_maxk = _force_maxk
 
-        self._img = np.zeros(self.aper.illuminated.shape, dtype=np.float64)
+        self._img = None
 
         if self.exptime < 0:
             raise GalSimRangeError("Cannot integrate PSF for negative time.", self.exptime, 0.)
@@ -1345,6 +1345,7 @@ class PhaseScreenPSF(GSObject):
         # Make sure we mark that we need to recalculate any previously finalized InterpolatedImage
         ret._finalized = False
         ret._screen_list._delayCalculation(ret)
+        ret._img = None
         return ret
 
     def __str__(self):
@@ -1395,6 +1396,8 @@ class PhaseScreenPSF(GSObject):
         expwf_grid = np.zeros_like(self.aper.illuminated, dtype=np.complex128)
         expwf_grid[self.aper.illuminated] = expwf
         ftexpwf = fft.fft2(expwf_grid, shift_in=True, shift_out=True)
+        if self._img is None:
+            self._img = np.zeros(self.aper.illuminated.shape, dtype=np.float64)
         self._img += np.abs(ftexpwf)**2
         if self._bar:  # pragma: no cover
             self._bar.update()

--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -778,3 +778,9 @@ class OpticalScreen(object):
         # Note, this phase screen is actually independent of time and theta.
         gradx, grady = self._zernike.evalCartesianGrad(u, v)
         return gradx * self.lam_0, grady * self.lam_0
+
+
+# Used only for testing
+class _DummyScreen(OpticalScreen):
+    def _wavefront(self, *args):
+        raise RuntimeError("Shouldn't reach this")

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -33,11 +33,22 @@ def check_dep(f, *args, **kwargs):
         res = f(*args, **kwargs)
     return res
 
+
 @timer
 def test_gsparams():
     check_dep(galsim.GSParams, allowed_flux_variation=0.90)
     check_dep(galsim.GSParams, range_division_for_extrema=50)
     check_dep(galsim.GSParams, small_fraction_of_flux=1.e-6)
 
+
+@timer
+def test_phase_psf():
+    atm = galsim.Atmosphere(screen_size=10.0, altitude=0, r0_500=0.15, suppress_warning=True)
+    psf = atm.makePSF(exptime=0.02, time_step=0.01, diam=1.1, lam=1000.0)
+    check_dep(galsim.PhaseScreenPSF.__getattribute__, psf, "img")
+    check_dep(galsim.PhaseScreenPSF.__getattribute__, psf, "finalized")
+
+
 if __name__ == "__main__":
     test_gsparams()
+    test_phase_psf()

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -1061,6 +1061,14 @@ def test_withGSP():
     for testimg in testimgs:
         assert testimg == img
 
+    # Also test OpticalPSF
+    optPSF = galsim.OpticalPSF(lam=500, diam=1.0)
+    optPSF2 = optPSF.withGSParams(galsim.GSParams(folding_threshold=6e-3))
+    assert isinstance(optPSF2, galsim.OpticalPSF)
+    # And check that we really did get a different folding_threshold by comparing stepk and default
+    # bounds
+    assert optPSF.stepk != optPSF2.stepk
+    assert optPSF.drawImage().bounds != optPSF2.drawImage().bounds
 
 if __name__ == "__main__":
     test_aperture()

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -433,7 +433,7 @@ def test_opt_indiv_aberrations():
     psf2 = galsim.PhaseScreenList(screen2).makePSF(diam=4.0, lam=500.0)
 
     np.testing.assert_array_equal(
-            psf1.img, psf2.img,
+            psf1._img, psf2._img,
             "Individually specified aberrations differs from aberrations specified as list.")
 
 

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -985,6 +985,18 @@ def test_gc():
     assert not any([isinstance(it, galsim.phase_psf.PhaseScreenPSF) for it in gc.get_objects()])
 
 
+@timer
+def test_withGSP():
+    class DummyScreen(galsim.OpticalScreen):
+        def _wavefront(self, *args):
+            raise RuntimeError("Shouldn't reach this")
+
+    screen = DummyScreen(1.0)
+    psl = galsim.PhaseScreenList(screen)
+    psf = psl.makePSF(exptime=0.02, time_step=0.01, diam=1.1, lam=1000.0)
+    psf2 = psf.withGSParams(galsim.GSParams(folding_threshold=6e-3))
+
+
 if __name__ == "__main__":
     test_aperture()
     test_atm_screen_size()
@@ -1003,3 +1015,4 @@ if __name__ == "__main__":
     test_speedup()
     test_instantiation_check()
     test_gc()
+    test_withGSP()

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -995,7 +995,8 @@ def test_withGSP():
     psl = galsim.PhaseScreenList(screen)
     psf = psl.makePSF(exptime=0.02, time_step=0.01, diam=1.1, lam=1000.0)
     psf2 = psf.withGSParams(galsim.GSParams(folding_threshold=6e-3))
-
+    do_pickle(psf)
+    
 
 if __name__ == "__main__":
     test_aperture()

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -987,7 +987,7 @@ def test_gc():
 
 @timer
 def test_withGSP():
-    screen = galsim._DummyScreen(1.0, aberrations=[0,0,0,0,1])
+    screen = galsim.phase_screens._DummyScreen(1.0, aberrations=[0,0,0,0,1])
     # Make sure screen really fails if we try to access _wavefront
     with np.testing.assert_raises(RuntimeError):
         screen._wavefront()

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -988,6 +988,9 @@ def test_gc():
 @timer
 def test_withGSP():
     screen = galsim._DummyScreen(1.0, aberrations=[0,0,0,0,1])
+    # Make sure screen really fails if we try to access _wavefront
+    with np.testing.assert_raises(RuntimeError):
+        screen._wavefront()
     psl = galsim.PhaseScreenList(screen)
     psf = psl.makePSF(exptime=0.02, time_step=0.01, diam=1.1, lam=1000.0)
     psfGSP = psf.withGSParams(galsim.GSParams(folding_threshold=6e-3))


### PR DESCRIPTION
I think I'm happy with this now.  I avoided using copy/pickle in `withGSParams()`, and also updated the pickling so that it doesn't assume that `prepareDraw` has been called.  There a bunch more tests in place to check that A) `_wavefront()` isn't needed in order to pickle/copy/change GSParams or draw using photon-shooting and B) make sure that copying, changing GSParams, and drawing are appropriately commutative.

