### PR TITLE
 Make sure FitsWCS works if input header has lowercase keys

### DIFF
--- a/galsim/fits.py
+++ b/galsim/fits.py
@@ -1118,9 +1118,6 @@ class FitsHeader(object):
             self.header = pyfits.Header()
             if header is not None:
                 if hasattr(header, 'items'):
-                    # For dicts, make sure all the keys are uppercase.
-                    if isinstance(header, dict):
-                        header = {k.upper(): v for k, v in header.items()}
                     # update() should handle anything that acts like a dict.
                     self.update(header)
                 else:
@@ -1147,7 +1144,7 @@ class FitsHeader(object):
 
     def __setitem__(self, key, value):
         self._tag = None
-        self.header[key] = value
+        self.header[key.upper()] = value
 
     def clear(self):
         self._tag = None
@@ -1177,7 +1174,7 @@ class FitsHeader(object):
     def update(self, dict2):
         self._tag = None
         for key, item in dict2.items():
-            self.header[key] = item
+            self.header[key.upper()] = item
 
     def values(self):
         return self.header.values()
@@ -1194,7 +1191,7 @@ class FitsHeader(object):
                             overwritten with the new entry? [default: True]
         """
         self._tag = None
-        self.header.insert(len(self), (key, value), useblanks=useblanks)
+        self.header.insert(len(self), (key.upper(), value), useblanks=useblanks)
 
     def __repr__(self):
         if self._tag is None:

--- a/galsim/fits.py
+++ b/galsim/fits.py
@@ -1118,8 +1118,10 @@ class FitsHeader(object):
             self.header = pyfits.Header()
             if header is not None:
                 if hasattr(header, 'items'):
+                    # For dicts, make sure all the keys are uppercase.
+                    if isinstance(header, dict):
+                        header = {k.upper(): v for k, v in header.items()}
                     # update() should handle anything that acts like a dict.
-                    header = {k.upper(): v for k, v in header.items()}
                     self.update(header)
                 else:
                     for card in header:

--- a/galsim/fits.py
+++ b/galsim/fits.py
@@ -1156,6 +1156,9 @@ class FitsHeader(object):
     def get(self, key, default=None):
         return self.header.get(key, default)
 
+    def pop(self, key, default=None):
+        return self.header.pop(key, default)
+
     def items(self):
         return self.header.items()
 

--- a/galsim/fits.py
+++ b/galsim/fits.py
@@ -1119,6 +1119,7 @@ class FitsHeader(object):
             if header is not None:
                 if hasattr(header, 'items'):
                     # update() should handle anything that acts like a dict.
+                    header = {k.upper(): v for k, v in header.items()}
                     self.update(header)
                 else:
                     for card in header:

--- a/galsim/fitswcs.py
+++ b/galsim/fitswcs.py
@@ -1638,6 +1638,8 @@ def FitsWCS(file_name=None, dir=None, hdu=None, header=None, compression='auto',
     if header is None:
         raise GalSimIncompatibleValuesError(
             "Must provide either file_name or header", file_name=file_name, header=header)
+    if not isinstance(header, fits.FitsHeader):
+        header = fits.FitsHeader(header)
 
     # For linear WCS specifications, AffineTransformation should work.
     if header.get('CTYPE1', 'LINEAR') == 'LINEAR':

--- a/galsim/fitswcs.py
+++ b/galsim/fitswcs.py
@@ -145,10 +145,8 @@ class AstropyWCS(CelestialWCS):
                         "Cannot provide both pyfits header and wcs", header=header, wcs=wcs)
 
                 # These can mess things up later if they stick around.
-                if 'BZERO' in header:
-                    del header['BZERO']
-                if 'BSCALE' in header:
-                    del header['BSCALE']
+                header.pop('BZERO', None)
+                header.pop('BSCALE', None)
 
                 self.header = fits.FitsHeader(header)
                 try:
@@ -378,10 +376,8 @@ class PyAstWCS(CelestialWCS):
                         header=header, wcsinfo=wcsinfo)
 
                 # These can mess things up later if they stick around.
-                if 'BZERO' in header:
-                    del header['BZERO']
-                if 'BSCALE' in header:
-                    del header['BSCALE']
+                header.pop('BZERO', None)
+                header.pop('BSCALE', None)
 
                 self.header = fits.FitsHeader(header)
                 wcsinfo = self._load_from_header(self.header)

--- a/tests/test_fitsheader.py
+++ b/tests/test_fitsheader.py
@@ -170,7 +170,7 @@ def test_scamp():
     do_pickle(header)
 
 
-def do_test_dict(d):
+def check_dict(d):
     def check_dict(header):
         """Check that the header object has correct values from the given dict
         """
@@ -220,7 +220,7 @@ def test_dict():
     d = { 'TIME-OBS' : '04:28:14.105' ,
           'FILTER'   : 'I',
           'AIRMASS'  : 1.185 }
-    do_test_dict(d)
+    check_dict(d)
 
 @timer
 def test_lowercase():
@@ -229,7 +229,7 @@ def test_lowercase():
     d = { 'Time-Obs' : '04:28:14.105' ,
           'filter'   : 'I',
           'AirMAsS'  : 1.185 }
-    do_test_dict(d)
+    check_dict(d)
 
 
 if __name__ == "__main__":

--- a/tests/test_fitsheader.py
+++ b/tests/test_fitsheader.py
@@ -170,14 +170,7 @@ def test_scamp():
     do_pickle(header)
 
 
-@timer
-def test_dict():
-    """Test that we can create a FitsHeader from a dict
-    """
-    d = { 'TIME-OBS' : '04:28:14.105' ,
-          'FILTER'   : 'I',
-          'AIRMASS'  : 1.185 }
-
+def do_test_dict(d):
     def check_dict(header):
         """Check that the header object has correct values from the given dict
         """
@@ -220,8 +213,27 @@ def test_dict():
     check_dict(header)
     do_pickle(header)
 
+@timer
+def test_dict():
+    """Test that we can create a FitsHeader from a dict
+    """
+    d = { 'TIME-OBS' : '04:28:14.105' ,
+          'FILTER'   : 'I',
+          'AIRMASS'  : 1.185 }
+    do_test_dict(d)
+
+@timer
+def test_lowercase():
+    """Test that lowercase keys are turned into uppercase.
+    """
+    d = { 'Time-Obs' : '04:28:14.105' ,
+          'filter'   : 'I',
+          'AirMAsS'  : 1.185 }
+    do_test_dict(d)
+
 
 if __name__ == "__main__":
     test_read()
     test_scamp()
     test_dict()
+    test_lowercase()

--- a/tests/test_fitsheader.py
+++ b/tests/test_fitsheader.py
@@ -123,6 +123,22 @@ def test_read():
     assert header.get('AIRMASS') == 2
     assert header != orig_header
 
+    # Pop does a similar thing:
+    assert header.pop('AIRMASS') == 2.0
+    assert 'AIRMASS' not in header
+
+    # Works if not preset, given default
+    assert header.pop('AIRMASS', 2.0) == 2.0
+    assert 'AIRMASS' not in header
+    header['AIRMASS'] = 2
+    assert header['AIRMASS'] == 2
+
+    # Get real value if preset and given default value
+    assert header.pop('AIRMASS', 1.9) == 2.0
+    assert 'AIRMASS' not in header
+    header['AIRMASS'] = 2
+    assert header['AIRMASS'] == 2
+
     # Overwrite an existing value
     header['AIRMASS'] = 1.7
     assert header.get('AIRMASS') == 1.7
@@ -138,8 +154,10 @@ def test_read():
     header.update(d)
     assert header.get('AIRMASS') == 1.185
     # We are essentially back to where we started, except the len won't be right.
-    # Deleting a key removed an item, but setting it overwrote a blank item.
-    # But if we add back another one of these, we should be back to the original values.
+    # Deleting a key removed an item each time, but setting it overwrote a blank item.
+    # But if we add back another few of these, we should be back to the original values.
+    header.append('','', useblanks=False)
+    header.append('','', useblanks=False)
     header.append('','', useblanks=False)
     check_tpv(header)
     do_pickle(header)

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -1840,7 +1840,7 @@ def test_pyastwcs():
         test_tags = [ 'HPX', 'TAN', 'TSC', 'STG', 'ZEA', 'ARC', 'ZPN', 'SIP', 'TPV', 'ZPX',
                       'TAN-PV', 'TAN-FLIP', 'REGION', 'TNX' ]
     else:
-        test_tags = [ 'TAN', 'ZPX', 'SIP', 'TAN-PV' ]
+        test_tags = [ 'TAN', 'ZPX', 'SIP', 'TAN-PV', 'TNX' ]
 
     dir = 'fits_files'
     for tag in test_tags:

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -2297,6 +2297,38 @@ def test_coadd():
     np.testing.assert_almost_equal(mom.moments_centroid.x, 24.5, decimal=2)
     np.testing.assert_almost_equal(mom.moments_centroid.y, 24.5, decimal=2)
 
+def test_lowercase():
+    # The WCS parsing should be insensitive to the case of the header key values.
+    # Matt Becker ran into a problem when his wcs dict had lowercase keys.
+    wcs_dict = {
+        'simple': True,
+        'bitpix': -32,
+        'naxis': 2,
+        'naxis1': 10000,
+        'naxis2': 10000,
+        'extend': True,
+        'gs_xmin': 1,
+        'gs_ymin': 1,
+        'gs_wcs': 'GSFitsWCS',
+        'ctype1': 'RA---TAN',
+        'ctype2': 'DEC--TAN',
+        'crpix1': 5000.5,
+        'crpix2': 5000.5,
+        'cd1_1': -7.305555555556e-05,
+        'cd1_2': 0.0,
+        'cd2_1': 0.0,
+        'cd2_2': 7.305555555556e-05,
+        'cunit1': 'deg     ',
+        'cunit2': 'deg     ',
+        'crval1': 86.176841,
+        'crval2': -22.827778}
+    wcs = galsim.FitsWCS(header=wcs_dict)
+    print('wcs = ',wcs)
+    assert isinstance(wcs, galsim.GSFitsWCS)
+    print(wcs.local(galsim.PositionD(0,0)))
+    np.testing.assert_allclose(wcs.local(galsim.PositionD(0,0)).getMatrix().ravel(),
+                               [0.26298, 0.00071,
+                                -0.00072, 0.26298], atol=1.e-4)
 
 if __name__ == "__main__":
     test_pixelscale()
@@ -2313,3 +2345,4 @@ if __name__ == "__main__":
     test_scamp()
     test_compateq()
     test_coadd()
+    test_lowercase()


### PR DESCRIPTION
@beckermr ran into an issue where he had a fits "header" (really just a dict) that had lowercase keys.

The [FITS standard dictates uppercase letters only in header keys](https://fits.gsfc.nasa.gov/standard40/fits_standard40aa-le.pdf) (4.1.2.1), so this is technically user error.  But we should be accommodating, so this PR basically just makes sure to convert all keys to uppercase on creation of a FitsHeader object so the input dict can use either format.