### PR TITLE
Make sure PoissonDeviate works with mean=0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 branches:
     only:
         - master
-        - noboost
+        - releases/2.1
 
 language: python
 python:

--- a/galsim/fits.py
+++ b/galsim/fits.py
@@ -1153,6 +1153,9 @@ class FitsHeader(object):
     def get(self, key, default=None):
         return self.header.get(key, default)
 
+    def pop(self, key, default=None):
+        return self.header.pop(key, default)
+
     def items(self):
         return self.header.items()
 

--- a/galsim/fitswcs.py
+++ b/galsim/fitswcs.py
@@ -145,10 +145,8 @@ class AstropyWCS(CelestialWCS):
                         "Cannot provide both pyfits header and wcs", header=header, wcs=wcs)
 
                 # These can mess things up later if they stick around.
-                if 'BZERO' in header:
-                    del header['BZERO']
-                if 'BSCALE' in header:
-                    del header['BSCALE']
+                header.pop('BZERO', None)
+                header.pop('BSCALE', None)
 
                 self.header = fits.FitsHeader(header)
                 try:
@@ -378,10 +376,8 @@ class PyAstWCS(CelestialWCS):
                         header=header, wcsinfo=wcsinfo)
 
                 # These can mess things up later if they stick around.
-                if 'BZERO' in header:
-                    del header['BZERO']
-                if 'BSCALE' in header:
-                    del header['BSCALE']
+                header.pop('BZERO', None)
+                header.pop('BSCALE', None)
 
                 self.header = fits.FitsHeader(header)
                 wcsinfo = self._load_from_header(self.header)

--- a/galsim/noise.py
+++ b/galsim/noise.py
@@ -464,6 +464,7 @@ class CCDNoise(BaseNoise):
         # First add the poisson noise from the signal + sky:
         if self.gain > 0.:
             noise_array *= self.gain  # convert to electrons
+            noise_array = noise_array.clip(0.)
             # The noise_image now has the expectation values for each pixel with the sky added.
             self._pd.generate_from_expectation(noise_array)
             # Subtract off the sky, since we don't want it in the final image.

--- a/galsim/noise.py
+++ b/galsim/noise.py
@@ -331,6 +331,8 @@ class PoissonNoise(BaseNoise):
 
         if self.sky_level != 0.:
             noise_array += self.sky_level
+        # Make sure no negative values
+        noise_array = noise_array.clip(0.)
         # The noise_image now has the expectation values for each pixel with the sky added.
         self._pd.generate_from_expectation(noise_array)
         # Subtract off the sky, since we don't want it in the final image.

--- a/galsim/random.py
+++ b/galsim/random.py
@@ -278,6 +278,12 @@ class UniformDeviate(BaseDeviate):
         """
         return self._rng.generate1()
 
+    def __repr__(self):
+        return 'galsim.UniformDeviate(seed=%r)'%(self._seed_repr())
+    def __str__(self):
+        return 'galsim.UniformDeviate()'
+
+
 class GaussianDeviate(BaseDeviate):
     """Pseudo-random number generator with Gaussian distribution.
 
@@ -337,6 +343,12 @@ class GaussianDeviate(BaseDeviate):
             # array_1d is not a view into the original array.  Need to copy back.
             np.copyto(array, array_1d.reshape(array.shape), casting='unsafe')
 
+    def __repr__(self):
+        return 'galsim.GaussianDeviate(seed=%r, mean=%r, sigma=%r)'%(
+                self._seed_repr(), self.mean, self.sigma)
+    def __str__(self):
+        return 'galsim.GaussianDeviate(mean=%r, sigma=%r)'%(self.mean, self.sigma)
+
 
 class BinomialDeviate(BaseDeviate):
     """Pseudo-random Binomial deviate for `N` trials each of probability `p`.
@@ -385,6 +397,12 @@ class BinomialDeviate(BaseDeviate):
         Returns a Binomial deviate with the given n and p.
         """
         return self._rng.generate1()
+
+    def __repr__(self):
+        return 'galsim.BinomialDeviate(seed=%r, N=%r, p=%r)'%(self._seed_repr(), self.n, self.p)
+    def __str__(self):
+        return 'galsim.BinomialDeviate(N=%r, p=%r)'%(self.n, self.p)
+
 
 class PoissonDeviate(BaseDeviate):
     """Pseudo-random Poisson deviate with specified `mean`.
@@ -444,6 +462,11 @@ class PoissonDeviate(BaseDeviate):
             # array_1d is not a view into the original array.  Need to copy back.
             np.copyto(array, array_1d.reshape(array.shape), casting='unsafe')
 
+    def __repr__(self):
+        return 'galsim.PoissonDeviate(seed=%r, mean=%r)'%(self._seed_repr(), self.mean)
+    def __str__(self):
+        return 'galsim.PoissonDeviate(mean=%r)'%(self.mean)
+
 
 class WeibullDeviate(BaseDeviate):
     """Pseudo-random Weibull-distributed deviate for shape parameter `a` and scale parameter `b`.
@@ -496,6 +519,11 @@ class WeibullDeviate(BaseDeviate):
         """
         return self._rng.generate1()
 
+    def __repr__(self):
+        return 'galsim.WeibullDeviate(seed=%r, a=%r, b=%r)'%(self._seed_repr(), self.a, self.b)
+    def __str__(self):
+        return 'galsim.WeibullDeviate(a=%r, b=%r)'%(self.a, self.b)
+
 
 class GammaDeviate(BaseDeviate):
     """A Gamma-distributed deviate with shape parameter `k` and scale parameter `theta`.
@@ -544,6 +572,12 @@ class GammaDeviate(BaseDeviate):
         """
         return self._rng.generate1()
 
+    def __repr__(self):
+        return 'galsim.GammaDeviate(seed=%r, k=%r, theta=%r)'%(
+                self._seed_repr(), self.k, self.theta)
+    def __str__(self):
+        return 'galsim.GammaDeviate(k=%r, theta=%r)'%(self.k, self.theta)
+
 
 class Chi2Deviate(BaseDeviate):
     """Pseudo-random Chi^2-distributed deviate for degrees-of-freedom parameter `n`.
@@ -588,6 +622,11 @@ class Chi2Deviate(BaseDeviate):
         Returns a Chi2-distributed deviate with the given number of degrees of freedom.
         """
         return self._rng.generate1()
+
+    def __repr__(self):
+        return 'galsim.Chi2Deviate(seed=%r, n=%r)'%(self._seed_repr(), self.n)
+    def __str__(self):
+        return 'galsim.Chi2Deviate(n=%r)'%(self.n)
 
 
 class DistDeviate(BaseDeviate):

--- a/galsim/random.py
+++ b/galsim/random.py
@@ -414,6 +414,8 @@ class PoissonDeviate(BaseDeviate):
         106
     """
     def __init__(self, seed=None, mean=1.):
+        if mean < 0:
+            raise GalSimValueError("PoissonDeviate is only defined for mean >= 0.", mean)
         self._rng_type = _galsim.PoissonDeviateImpl
         self._rng_args = (float(mean),)
         self.reset(seed)
@@ -433,6 +435,8 @@ class PoissonDeviate(BaseDeviate):
         """Generate many Poisson deviate values using the existing array values as the
         expectation value (aka mean) for each.
         """
+        if np.any(array < 0):
+            raise GalSimValueError("Expectation array may not have values < 0.", array)
         array_1d = np.ascontiguousarray(array.ravel(), dtype=float)
         #assert(array_1d.strides[0] == array_1d.itemsize)
         self._rng.generate_from_expectation(len(array_1d), array_1d.ctypes.data)

--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -374,7 +374,7 @@ namespace galsim {
 
             if (mean != _mean) {
                 _mean = mean;
-                if (mean > MAX_POISSON) setMeanGD(mean);
+                if (mean > MAX_POISSON || mean == 0.) setMeanGD(mean);
                 else setMeanPD(mean);
             }
         }

--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -361,7 +361,7 @@ namespace galsim {
 
     struct PoissonDeviate::PoissonDeviateImpl
     {
-        PoissonDeviateImpl(double mean) : _mean(0) { setMean(mean); }
+        PoissonDeviateImpl(double mean) : _mean(-1) { setMean(mean); }
 
         double getMean() { return _mean; }
 

--- a/tests/test_config_image.py
+++ b/tests/test_config_image.py
@@ -418,8 +418,8 @@ def test_reject():
     # This next one can end up with slightly different numerical values depending on numpy version
     #assert "Object 0: Measured flux = 3253.173584 < 0.95 * 3457.712670." in cl.output
     #assert "Object 0: Measured snr = 60.992197 > 50.0." in cl.output
-    assert re.search("Object 0: Measured flux = 3253.17[0-9]* < 0.95 \* 3457.712670.", cl.output)
-    assert re.search("Object 0: Measured snr = 60.992[0-9]* > 50.0.", cl.output)
+    assert re.search(r"Object 0: Measured flux = 3253.17[0-9]* < 0.95 \* 3457.712670.", cl.output)
+    assert re.search(r"Object 0: Measured snr = 60.992[0-9]* > 50.0.", cl.output)
 
     # For test coverage to get all branches, do min_snr and max_snr separately.
     del config['stamp']['max_snr']
@@ -427,7 +427,7 @@ def test_reject():
     with CaptureLog() as cl:
         im_list2 = galsim.config.BuildStamps(nimages, config, do_noise=False, logger=cl.logger)[0]
     #print(cl.output)
-    assert re.search("Object 8: Measured snr = 9.1573[0-9]* < 20.0.", cl.output)
+    assert re.search(r"Object 8: Measured snr = 9.1573[0-9]* < 20.0.", cl.output)
 
     # If we lower the number of retries, we'll max out and abort the image
     config['stamp']['retry_failures'] = 10

--- a/tests/test_fitsheader.py
+++ b/tests/test_fitsheader.py
@@ -123,6 +123,22 @@ def test_read():
     assert header.get('AIRMASS') == 2
     assert header != orig_header
 
+    # Pop does a similar thing:
+    assert header.pop('AIRMASS') == 2.0
+    assert 'AIRMASS' not in header
+
+    # Works if not preset, given default
+    assert header.pop('AIRMASS', 2.0) == 2.0
+    assert 'AIRMASS' not in header
+    header['AIRMASS'] = 2
+    assert header['AIRMASS'] == 2
+
+    # Get real value if preset and given default value
+    assert header.pop('AIRMASS', 1.9) == 2.0
+    assert 'AIRMASS' not in header
+    header['AIRMASS'] = 2
+    assert header['AIRMASS'] == 2
+
     # Overwrite an existing value
     header['AIRMASS'] = 1.7
     assert header.get('AIRMASS') == 1.7
@@ -138,8 +154,10 @@ def test_read():
     header.update(d)
     assert header.get('AIRMASS') == 1.185
     # We are essentially back to where we started, except the len won't be right.
-    # Deleting a key removed an item, but setting it overwrote a blank item.
-    # But if we add back another one of these, we should be back to the original values.
+    # Deleting a key removed an item each time, but setting it overwrote a blank item.
+    # But if we add back another few of these, we should be back to the original values.
+    header.append('','', useblanks=False)
+    header.append('','', useblanks=False)
     header.append('','', useblanks=False)
     check_tpv(header)
     do_pickle(header)

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -791,6 +791,7 @@ def test_poisson_zeromean():
     p = galsim.PoissonDeviate(testseed, mean=0)
     p2 = p.duplicate()
     p3 = galsim.PoissonDeviate(p.serialize(), mean=0)
+    do_pickle(p)
 
     # Test direct draws
     testResult = (p(), p(), p())

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -232,6 +232,10 @@ def test_uniform():
     do_pickle(u, lambda x: x.serialize())
     do_pickle(u, lambda x: (x(), x(), x(), x()))
     do_pickle(u)
+    assert 'UniformDeviate' in repr(u)
+    assert 'UniformDeviate' in str(u)
+    assert isinstance(eval(repr(u)), galsim.UniformDeviate)
+    assert isinstance(eval(str(u)), galsim.UniformDeviate)
 
     # Check that we can construct a UniformDeviate from None, and that it depends on dev/random.
     u1 = galsim.UniformDeviate(None)
@@ -381,6 +385,10 @@ def test_gaussian():
     do_pickle(g, lambda x: (x.serialize(), x.mean, x.sigma))
     do_pickle(g, lambda x: (x(), x(), x(), x()))
     do_pickle(g)
+    assert 'GaussianDeviate' in repr(g)
+    assert 'GaussianDeviate' in str(g)
+    assert isinstance(eval(repr(g)), galsim.GaussianDeviate)
+    assert isinstance(eval(str(g)), galsim.GaussianDeviate)
 
     # Check that we can construct a GaussianDeviate from None, and that it depends on dev/random.
     g1 = galsim.GaussianDeviate(None)
@@ -512,6 +520,10 @@ def test_binomial():
     do_pickle(b, lambda x: (x.serialize(), x.n, x.p))
     do_pickle(b, lambda x: (x(), x(), x(), x()))
     do_pickle(b)
+    assert 'BinomialDeviate' in repr(b)
+    assert 'BinomialDeviate' in str(b)
+    assert isinstance(eval(repr(b)), galsim.BinomialDeviate)
+    assert isinstance(eval(str(b)), galsim.BinomialDeviate)
 
     # Check that we can construct a BinomialDeviate from None, and that it depends on dev/random.
     b1 = galsim.BinomialDeviate(None)
@@ -657,6 +669,10 @@ def test_poisson():
     do_pickle(p, lambda x: (x.serialize(), x.mean))
     do_pickle(p, lambda x: (x(), x(), x(), x()))
     do_pickle(p)
+    assert 'PoissonDeviate' in repr(p)
+    assert 'PoissonDeviate' in str(p)
+    assert isinstance(eval(repr(p)), galsim.PoissonDeviate)
+    assert isinstance(eval(str(p)), galsim.PoissonDeviate)
 
     # Check that we can construct a PoissonDeviate from None, and that it depends on dev/random.
     p1 = galsim.PoissonDeviate(None)
@@ -938,6 +954,10 @@ def test_weibull():
     do_pickle(w, lambda x: (x.serialize(), x.a, x.b))
     do_pickle(w, lambda x: (x(), x(), x(), x()))
     do_pickle(w)
+    assert 'WeibullDeviate' in repr(w)
+    assert 'WeibullDeviate' in str(w)
+    assert isinstance(eval(repr(w)), galsim.WeibullDeviate)
+    assert isinstance(eval(str(w)), galsim.WeibullDeviate)
 
     # Check that we can construct a WeibullDeviate from None, and that it depends on dev/random.
     w1 = galsim.WeibullDeviate(None)
@@ -1065,6 +1085,10 @@ def test_gamma():
     do_pickle(g, lambda x: (x.serialize(), x.k, x.theta))
     do_pickle(g, lambda x: (x(), x(), x(), x()))
     do_pickle(g)
+    assert 'GammaDeviate' in repr(g)
+    assert 'GammaDeviate' in str(g)
+    assert isinstance(eval(repr(g)), galsim.GammaDeviate)
+    assert isinstance(eval(str(g)), galsim.GammaDeviate)
 
     # Check that we can construct a GammaDeviate from None, and that it depends on dev/random.
     g1 = galsim.GammaDeviate(None)
@@ -1192,6 +1216,10 @@ def test_chi2():
     do_pickle(c, lambda x: (x.serialize(), x.n))
     do_pickle(c, lambda x: (x(), x(), x(), x()))
     do_pickle(c)
+    assert 'Chi2Deviate' in repr(c)
+    assert 'Chi2Deviate' in str(c)
+    assert isinstance(eval(repr(c)), galsim.Chi2Deviate)
+    assert isinstance(eval(str(c)), galsim.Chi2Deviate)
 
     # Check that we can construct a Chi2Deviate from None, and that it depends on dev/random.
     c1 = galsim.Chi2Deviate(None)
@@ -1381,6 +1409,10 @@ def test_distfunction():
     # Check picklability
     do_pickle(d, lambda x: (x(), x(), x(), x()))
     do_pickle(d)
+    assert 'DistDeviate' in repr(d)
+    assert 'DistDeviate' in str(d)
+    assert isinstance(eval(repr(d)), galsim.DistDeviate)
+    assert isinstance(eval(str(d)), galsim.DistDeviate)
 
     # Check that we can construct a DistDeviate from None, and that it depends on dev/random.
     c1 = galsim.DistDeviate(None, lambda x:1, 0, 1)
@@ -1534,6 +1566,10 @@ def test_distLookupTable():
     # Check picklability
     do_pickle(d, lambda x: (x(), x(), x(), x()))
     do_pickle(d)
+    assert 'DistDeviate' in repr(d)
+    assert 'DistDeviate' in str(d)
+    assert isinstance(eval(repr(d)), galsim.DistDeviate)
+    assert isinstance(eval(str(d)), galsim.DistDeviate)
 
 
 @timer

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -232,10 +232,13 @@ def test_uniform():
     do_pickle(u, lambda x: x.serialize())
     do_pickle(u, lambda x: (x(), x(), x(), x()))
     do_pickle(u)
+    do_pickle(rng)
     assert 'UniformDeviate' in repr(u)
     assert 'UniformDeviate' in str(u)
     assert isinstance(eval(repr(u)), galsim.UniformDeviate)
     assert isinstance(eval(str(u)), galsim.UniformDeviate)
+    assert isinstance(eval(repr(rng)), galsim.BaseDeviate)
+    assert isinstance(eval(str(rng)), galsim.BaseDeviate)
 
     # Check that we can construct a UniformDeviate from None, and that it depends on dev/random.
     u1 = galsim.UniformDeviate(None)

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -769,6 +769,51 @@ def test_poisson_highmean():
 
 
 @timer
+def test_poisson_zeromean():
+    """Make sure Poisson Deviate behaves sensibly when mean=0.
+    """
+    p = galsim.PoissonDeviate(testseed, mean=0)
+    p2 = p.duplicate()
+    p3 = galsim.PoissonDeviate(p.serialize(), mean=0)
+
+    # Test direct draws
+    testResult = (p(), p(), p())
+    testResult2 = (p2(), p2(), p2())
+    testResult3 = (p3(), p3(), p3())
+    np.testing.assert_allclose(testResult, 0)
+    np.testing.assert_allclose(testResult2, 0)
+    np.testing.assert_allclose(testResult3, 0)
+
+    # Test generate
+    test_array = np.empty(3, dtype=int)
+    p.generate(test_array)
+    np.testing.assert_allclose(test_array, 0)
+    p2.generate(test_array)
+    np.testing.assert_allclose(test_array, 0)
+    p3.generate(test_array)
+    np.testing.assert_allclose(test_array, 0)
+
+    # Test generate_from_expectation
+    test_array = np.array([0,0,0])
+    np.testing.assert_allclose(test_array, 0)
+    test_array = np.array([1,0,4])
+    assert test_array[0] != 0
+    assert test_array[1] == 0
+    assert test_array[2] != 0
+
+    # Error raised if mean<0
+    with assert_raises(ValueError):
+        p = galsim.PoissonDeviate(testseed, mean=-0.1)
+    with assert_raises(ValueError):
+        p = galsim.PoissonDeviate(testseed, mean=-10)
+    test_array = np.array([-1,1,4])
+    with assert_raises(ValueError):
+        p.generate_from_expectation(test_array)
+    test_array = np.array([1,-1,-4])
+    with assert_raises(ValueError):
+        p.generate_from_expectation(test_array)
+
+@timer
 def test_weibull():
     """Test Weibull random number generator
     """

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -796,18 +796,18 @@ def test_poisson_zeromean():
     testResult = (p(), p(), p())
     testResult2 = (p2(), p2(), p2())
     testResult3 = (p3(), p3(), p3())
-    np.testing.assert_allclose(testResult, 0)
-    np.testing.assert_allclose(testResult2, 0)
-    np.testing.assert_allclose(testResult3, 0)
+    np.testing.assert_array_equal(testResult, 0)
+    np.testing.assert_array_equal(testResult2, 0)
+    np.testing.assert_array_equal(testResult3, 0)
 
     # Test generate
     test_array = np.empty(3, dtype=int)
     p.generate(test_array)
-    np.testing.assert_allclose(test_array, 0)
+    np.testing.assert_array_equal(test_array, 0)
     p2.generate(test_array)
-    np.testing.assert_allclose(test_array, 0)
+    np.testing.assert_array_equal(test_array, 0)
     p3.generate(test_array)
-    np.testing.assert_allclose(test_array, 0)
+    np.testing.assert_array_equal(test_array, 0)
 
     # Test generate_from_expectation
     test_array = np.array([0,0,0])
@@ -1685,6 +1685,7 @@ if __name__ == "__main__":
     test_binomial()
     test_poisson()
     test_poisson_highmean()
+    test_poisson_zeromean()
     test_weibull()
     test_gamma()
     test_chi2()

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -1840,7 +1840,7 @@ def test_pyastwcs():
         test_tags = [ 'HPX', 'TAN', 'TSC', 'STG', 'ZEA', 'ARC', 'ZPN', 'SIP', 'TPV', 'ZPX',
                       'TAN-PV', 'TAN-FLIP', 'REGION', 'TNX' ]
     else:
-        test_tags = [ 'TAN', 'ZPX', 'SIP', 'TAN-PV' ]
+        test_tags = [ 'TAN', 'ZPX', 'SIP', 'TAN-PV', 'TNX' ]
 
     dir = 'fits_files'
     for tag in test_tags:


### PR DESCRIPTION
@jchiang87 and @villarrealas were getting seg faults when trying to generate random Poisson deviates with mean=0.  

This PR fixes this, so that PoissonDeviate(mean=0) always generates 0's.  This seems to be the mathematically consistent thing to do, although I'll note that [Wikipedia](https://en.wikipedia.org/wiki/Poisson_distribution) says that the Poisson deviate is only defined for mean > 0.

I also make sure that it raises an appropriate exception when mean < 0.  Also, while debugging this I noticed that our repr for PoissonDeviate actually looked like a BaseDeviate.  We never really check the repr of deviates, since we don't expect them to round trip.  But they should at least round trip to the correct type if not an equivalent object.  So I fixed that too.

I'd request a fast turnaround on a review, since we'd like to get the mean=0 fix into v2.1.2 quickly for the LSST DC2 run, where this bug turned up.