### PR TITLE
Adds additional location to look for PyBind11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -535,16 +535,20 @@ def add_dirs(builder, output=False):
     import pybind11
     print('PyBind11 is version ',pybind11.__version__)
     print('Looking for pybind11 header files: ')
-    for user in [True, False, None]:
-        if user is None:
+    locations = [pybind11.get_include(user=True),
+                 pybind11.get_include(user=False),
+                 '/usr/include',
+                 None]
+    for try_dir in locations:
+        if try_dir is None:
             # Last time through, raise an error.
             print("Could not find pybind11 header files.")
             print("They should have been in one of the following two locations:")
-            print("   ",pybind11.get_include(True))
-            print("   ",pybind11.get_include(False))
+            for l in locations:
+                if l is not None:
+                    print("   ", l)
             raise OSError("Could not find PyBind11")
 
-        try_dir = pybind11.get_include(user=user)
         print('  ',try_dir,end='')
         if os.path.isfile(os.path.join(try_dir, 'pybind11/pybind11.h')):
             print('  (yes)')


### PR DESCRIPTION
This PR aims to address #984 , as documented in that issue, pybind11 on its own is pretty dumb and wont necessarily the correct path to its header files. 
This is a problem on linux systems where pybind is typically installed as a proper package, not using pip. On Arch and Debian/Ubuntu, the default installation path to pybind11 is `/usr/include` so this PR looks in that folder before aborting the build process, it's not full proof, I haven't found a robust way of locating the headers without cmake, but at least, this should cover 80% of current potential failures on linux.