### PR TITLE
Use shared memory for AtmosphericScreen

### DIFF
--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -835,8 +835,8 @@ class PhaseScreenList(object):
         """
         if pool is not None:
             import sys
-            assert sys.version_info >= (3,4),
-                "instantiating PhaseScreenList with pool requires python version >= 3.4"
+            assert_str = "instantiating PhaseScreenList with pool requires python version >= 3.4"
+            assert sys.version_info >= (3,4), assert_str
         for layer in self:
             results = []
             try:

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -833,6 +833,10 @@ class PhaseScreenList(object):
         @param pool      A multiprocessing.Pool object to use to instantiate screens in parallel.
         @param **kwargs  Keyword arguments to forward to screen.instantiate().
         """
+        if pool is not None:
+            import sys
+            assert sys.version_info >= (3,4),
+                "instantiating PhaseScreenList with pool requires python version >= 3.4"
         for layer in self:
             results = []
             try:

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -65,6 +65,7 @@ Atmosphere
   Convenience function to quickly assemble multiple AtmosphericScreens into a PhaseScreenList.
 """
 
+import sys
 from past.builtins import basestring
 from itertools import chain
 from builtins import range
@@ -834,7 +835,6 @@ class PhaseScreenList(object):
         @param **kwargs  Keyword arguments to forward to screen.instantiate().
         """
         if pool is not None:
-            import sys
             assert_str = "instantiating PhaseScreenList with pool requires python version >= 3.4"
             assert sys.version_info >= (3,4), assert_str
 

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -842,7 +842,7 @@ class PhaseScreenList(object):
             for layer in self:
                 try:
                     results.append(pool.apply_async(layer.instantiate, kwds=kwargs))
-                except AttributeError: # why did I need this?
+                except AttributeError:  # OpticalScreen has no instantiate method
                     pass
                 if _bar:  # pragma: no cover
                     _bar.update()

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -837,20 +837,25 @@ class PhaseScreenList(object):
             import sys
             assert_str = "instantiating PhaseScreenList with pool requires python version >= 3.4"
             assert sys.version_info >= (3,4), assert_str
-        for layer in self:
+
             results = []
-            try:
-                if pool is not None:
+            for layer in self:
+                try:
                     results.append(pool.apply_async(layer.instantiate, kwds=kwargs))
-                else:
-                    layer.instantiate(**kwargs)
-            except AttributeError:
-                pass
-            if _bar:  # pragma: no cover
-                _bar.update()
-        if pool is not None:
+                except AttributeError: # why did I need this?
+                    pass
+                if _bar:  # pragma: no cover
+                    _bar.update()
             for r in results:
                 r.wait()
+        else:
+            for layer in self:
+                try:
+                    layer.instantiate(**kwargs)
+                except AttributeError:
+                    pass
+                if _bar:
+                    _bar.update()
 
     def _delayCalculation(self, psf):
         """Add psf to delayed calculation list."""

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -835,9 +835,6 @@ class PhaseScreenList(object):
         @param **kwargs  Keyword arguments to forward to screen.instantiate().
         """
         if pool is not None:
-            assert_str = "instantiating PhaseScreenList with pool requires python version >= 3.4"
-            assert sys.version_info >= (3,4), assert_str
-
             results = []
             for layer in self:
                 try:

--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -152,6 +152,10 @@ class AtmosphericScreen(object):
                 "Setting AtmosphericScreen time_step prohibited when alpha == 1.0.  "
                 "Did you mean to set time_step in makePSF or PhaseScreenPSF?",
                 alpha=alpha, time_step=time_step)
+        if (alpha != 1.0 and mp_context is not None):
+            raise GalSimIncompatibleValuesError(
+                "Shared memory use is not supported for time-evolving screens",
+                alpha=alpha, mp_context=mp_context)
         if screen_scale is None:
             # We copy Jee+Tyson(2011) and (arbitrarily) set the screen scale equal to r0 by default.
             screen_scale = r0_500

--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -179,7 +179,10 @@ class AtmosphericScreen(object):
 
         # Use shared memory for screens.  Allocate it here; fill it in on demand.
         global _GSScreenShare
-        ctx = multiprocessing.get_context(mp_context)
+        if isinstance(mp_context, multiprocessing.context.BaseContext):
+            ctx = mp_context
+        else:
+            ctx = multiprocessing.get_context(mp_context)
         self._objDict = {
             'f':ctx.RawArray('d', (self.npix+1)*(self.npix+1)),
             'x':ctx.RawArray('d', self.npix+1),

--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -26,7 +26,7 @@ from .table import LookupTable2D
 from . import utilities
 from . import fft
 from . import zernike
-from .utilities import LRU_Cache
+from .utilities import LRU_Cache, lazy_property
 from .errors import GalSimRangeError, GalSimValueError, GalSimIncompatibleValuesError, galsim_warn
 
 
@@ -163,6 +163,14 @@ class AtmosphericScreen(object):
     @property
     def altitude(self):
         return self._altitude / 1000.  # convert back to km
+
+    @lazy_property
+    def _xs(self):
+        return np.linspace(-0.5, 0.5, self.npix, endpoint=False)*self.screen_size
+
+    @lazy_property
+    def _ys(self):
+        return self._xs
 
     def __str__(self):
         return "galsim.AtmosphericScreen(altitude=%s)" % self.altitude
@@ -313,10 +321,8 @@ class AtmosphericScreen(object):
         # Only need to reset/create tab2d if not frozen or doesn't already exist
         if not self.reversible or not hasattr(self, '_tab2d'):
             self._screen = self._random_screen()
-            self._xs = np.linspace(-0.5*self.screen_size, 0.5*self.screen_size, self.npix,
-                                   endpoint=False)
-            self._ys = self._xs
-            self._tab2d = LookupTable2D(self._xs, self._ys, self._screen, edge_mode='wrap')
+            self._tab2d = LookupTable2D(
+                self._xs, self._ys, self._screen, edge_mode='wrap')
 
     # Note -- use **kwargs here so that AtmosphericScreen.stepk and OpticalScreen.stepk
     # can use the same signature, even though they depend on different parameters.

--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -65,7 +65,7 @@ def initWorker(share):
 
     See AtmosphericScreen docstring for more information.
     """
-    _GSScreenShare.update(share)
+    _GSScreenShare.update(share)  # pragma: no cover  (covered, but in a fork)
 
 
 class AtmosphericScreen(object):
@@ -391,7 +391,8 @@ class AtmosphericScreen(object):
                 with self._objDict['lock']:
                     # Check that another process didn't finish instantiating
                     # while this process was waiting for the lock
-                    if not self._objDict['instantiated'].value:
+                    # Since this is a race, both branches are only covered probabilistically
+                    if not self._objDict['instantiated'].value:  # pragma: no branch
                         self._objDict['kmin'].value = kmin
                         self._objDict['kmax'].value = kmax
                         self._init_psi()

--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -488,12 +488,8 @@ class AtmosphericScreen(object):
         self._objDict['y0'].value = tab2d.y0
         self._objDict['xperiod'].value = tab2d.xperiod
         self._objDict['yperiod'].value = tab2d.yperiod
-        # Need to reset this here in case we did a boiling update
-        self._tab2d = _LookupTable2D(
-            xshare, yshare, fshare, 'linear', 'wrap', 0.0,
-            x0=self._objDict['x0'].value, y0=self._objDict['y0'].value,
-            xperiod=self._objDict['xperiod'].value, yperiod=self._objDict['yperiod'].value
-        )
+        if hasattr(self, '_tab2d'):
+            del self._tab2d
 
     @lazy_property
     def _tab2d(self):

--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -487,6 +487,12 @@ class AtmosphericScreen(object):
         self._objDict['y0'].value = tab2d.y0
         self._objDict['xperiod'].value = tab2d.xperiod
         self._objDict['yperiod'].value = tab2d.yperiod
+        # Need to reset this here in case we did a boiling update
+        self._tab2d = _LookupTable2D(
+            xshare, yshare, fshare, 'linear', 'wrap', 0.0,
+            x0=self._objDict['x0'].value, y0=self._objDict['y0'].value,
+            xperiod=self._objDict['xperiod'].value, yperiod=self._objDict['yperiod'].value
+        )
 
     @lazy_property
     def _tab2d(self):

--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -278,7 +278,7 @@ class AtmosphericScreen(object):
                 'yperiod':ctx.RawValue('d', 0.0),
                 'instantiated':ctx.RawValue('b', False),
                 'refcount':ctx.RawValue('i', 1),
-                'lock':ctx.RLock()
+                'lock':ctx.Lock()
             }
             # A unique id for this screen, created in the parent process, that can be used to find the
             # correct shared memory object in child processes.
@@ -487,10 +487,6 @@ class AtmosphericScreen(object):
         self._objDict['y0'].value = tab2d.y0
         self._objDict['xperiod'].value = tab2d.xperiod
         self._objDict['yperiod'].value = tab2d.yperiod
-        self._tab2d = _LookupTable2D(
-            xshare, yshare, fshare, tab2d.interpolant, tab2d.edge_mode, tab2d.constant,
-            x0=tab2d.x0, y0=tab2d.y0, xperiod=tab2d.xperiod, yperiod=tab2d.yperiod
-        )
 
     @lazy_property
     def _tab2d(self):

--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -826,8 +826,9 @@ def Atmosphere(screen_size, rng=None, _bar=None, **kwargs):
         del kwargs['speed']
         del kwargs['direction']
 
-    # Determine broadcast size
-    nmax = max(len(v) for v in kwargs.values() if hasattr(v, '__len__'))
+    # Determine broadcast size.
+    # Note: treat string as a single scalar value, not a vector of characters
+    nmax = max(len(v) for v in kwargs.values() if hasattr(v, '__len__') and not isinstance(v, str))
 
     # Broadcast r0_500 here, since logical combination of indiv layers' r0s is complex:
     if len(kwargs['r0_500']) == 1:

--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -927,8 +927,8 @@ class OpticalScreen(object):
         # strip any trailing zeros.
         if self.aberrations[-1] == 0:
             self.aberrations = np.trim_zeros(self.aberrations, trim='b')
-            if len(self.aberrations) == 0:  # Don't let it be zero length.
-                self.aberrations = np.array([0])
+            if len(self.aberrations) <= 1:  # Don't let it be length zero or one though.
+                self.aberrations = np.array([0, 0])
         self.annular_zernike = annular_zernike
         self.obscuration = obscuration
         self.lam_0 = lam_0

--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -287,6 +287,7 @@ class AtmosphericScreen(object):
         else:
             self._kmin = None
             self._kmax = None
+            self._instantiated = False
 
     def __setstate__(self, d):
         self.__dict__.update(d)
@@ -399,13 +400,14 @@ class AtmosphericScreen(object):
                             del self._psi, self._screen
                         self._objDict['instantiated'].value = True
         else:
-            self._kmin = kmin
-            self._kmax = kmax
-            self._init_psi()
-            self._reset()
-            # Free some RAM for frozen-flow screens
-            if self.reversible:
-                del self._psi, self._screen
+            if not self._instantiated:
+                self._kmin = kmin
+                self._kmax = kmax
+                self._init_psi()
+                self._reset()
+                # Free some RAM for frozen-flow screens
+                if self.reversible:
+                    del self._psi, self._screen
 
         if check is not None and not self._suppress_warning:
             if check == 'FFT':
@@ -540,9 +542,10 @@ class AtmosphericScreen(object):
                 self._screen = self._random_screen()
                 self._setShare()
         else:
-            if not self.reversible or not hasattr(self, '_tab2d'):
+            if not self.reversible or not self._instantiated:
                 self._screen = self._random_screen()
                 self._tab2d = LookupTable2D(self._xs, self._ys, self._screen, edge_mode='wrap')
+                self._instantiated = True
 
     # Note -- use **kwargs here so that AtmosphericScreen.stepk and OpticalScreen.stepk
     # can use the same signature, even though they depend on different parameters.

--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -29,7 +29,8 @@ from . import utilities
 from . import fft
 from . import zernike
 from .utilities import LRU_Cache, lazy_property
-from .errors import GalSimRangeError, GalSimValueError, GalSimIncompatibleValuesError, galsim_warn
+from .errors import (GalSimRangeError, GalSimValueError, GalSimIncompatibleValuesError, galsim_warn,
+    GalSimNotImplementedError)
 
 
 # Two helper functions to cache the calculation required for _getStepK
@@ -230,9 +231,8 @@ class AtmosphericScreen(object):
                 "Did you mean to set time_step in makePSF or PhaseScreenPSF?",
                 alpha=alpha, time_step=time_step)
         if (alpha != 1.0 and mp_context is not None):
-            raise GalSimIncompatibleValuesError(
-                "Shared memory use is not supported for time-evolving screens",
-                alpha=alpha, mp_context=mp_context)
+            raise GalSimNotImplementedError(
+                "Shared memory use is only supported for frozen-flow screens")
         if screen_scale is None:
             # We copy Jee+Tyson(2011) and (arbitrarily) set the screen scale equal to r0 by default.
             screen_scale = r0_500

--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -58,6 +58,10 @@ def initWorkerArgs():
 
     See AtmosphericScreen docstring for more information.
     """
+    for v in _GSScreenShare.values():
+        if v['alpha'].value != 1.0:
+            raise GalSimNotImplementedError(
+                "Shared memory use is only supported for frozen-flow screens")
     return (_GSScreenShare,)
 
 
@@ -276,6 +280,7 @@ class AtmosphericScreen(object):
             'f':RawArray('d', (self.npix+1)*(self.npix+1)),
             'x':RawArray('d', self.npix+1),
             'y':RawArray('d', self.npix+1),
+            'alpha':RawValue('d', alpha),
             'kmin':RawValue('d', -1.0),
             'kmax':RawValue('d', -1.0),
             'x0':RawValue('d', 0.0),

--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -112,7 +112,7 @@ class AtmosphericScreen(object):
         - The mp_context keyword argument to AtmosphericScreen.
             This is used to indicate which multiprocessing process launching context will be used.
             This is important for setting up the shared memory correctly.
-        - The galsim.phase_screens.initWorker() and initWorkerArgs functions.
+        - The galsim.phase_screens.initWorker() and initWorkerArgs() functions.
             These should be used in a call to multiprocessing.Pool to correctly inform the worker
             process where to find AtmosphericScreen shared memory.
 

--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -309,8 +309,9 @@ class AtmosphericScreen(object):
 
             with self._objDict['lock']:
                 self._objDict['refcount'].value -= 1
-            if self._objDict['refcount'].value == 0:
-                del _GSScreenShare[self._shareKey]
+            with self._objDict['lock']:
+                if self._objDict['refcount'].value == 0:
+                    del _GSScreenShare[self._shareKey]
 
     @property
     def altitude(self):

--- a/galsim/table.py
+++ b/galsim/table.py
@@ -611,6 +611,7 @@ class LookupTable2D(object):
                 return _galsim._LookupTable2D(self.x.ctypes.data, self.y.ctypes.data,
                                               self.f.ctypes.data, len(self.x), len(self.y),
                                               self.interpolant)
+
     def getXArgs(self):
         return self.x
 
@@ -879,3 +880,30 @@ class LookupTable2D(object):
 
     def __setstate__(self, d):
         self.__dict__ = d
+
+
+def _LookupTable2D(x, y, f, interpolant, edge_mode, constant,
+                   dfdx=None, dfdy=None, d2fdxdy=None,
+                   x0=None, y0=None, xperiod=None, yperiod=None):
+    """Make a LookupTable2D but without using any of the sanity checks or array manipulation used
+    in the normal initializer.
+    """
+    ret = LookupTable2D.__new__(LookupTable2D)
+    ret.x = x
+    ret.y = y
+    ret.f = f
+    ret.interpolant = interpolant
+    ret.edge_mode = edge_mode
+    ret.constant = constant
+    ret.dfdx = dfdx
+    ret.dfdy = dfdy
+    ret.d2fdxdy = d2fdxdy
+    ret.x0 = x0
+    ret.y0 = y0
+    ret.xperiod = xperiod
+    ret.yperiod = yperiod
+    if interpolant in ('nearest', 'linear', 'ceil', 'floor', 'spline'):
+        ret._interp2d = None
+    else:
+        ret._interp2d = convert_interpolant(interpolant)
+    return ret

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -1083,18 +1083,28 @@ def listify(arg):
     return [arg] if not hasattr(arg, '__iter__') else arg
 
 
-def dol_to_lod(dol, N=None):
+def dol_to_lod(dol, N=None, scalar_string=True):
     """Generate list of dicts from dict of lists (with broadcasting).
     Specifically, generate "scalar-valued" kwargs dictionaries from a kwarg dictionary with values
     that are length-N lists, or possibly length-1 lists or scalars that should be broadcasted up to
     length-N lists.
     """
     if N is None:
-        N = max(len(v) for v in dol.values() if hasattr(v, '__len__'))
+        if scalar_string:
+            lens = [len(v) for v in dol.values()
+                           if hasattr(v, '__len__')
+                           and not isinstance(v, str)]
+        else:
+            lens = [len(v) for v in dol.values()
+                           if hasattr(v, '__len__')]
+        N = max(lens) if lens != [] else 1
     # Loop through broadcast range
     for i in range(N):
         out = {}
         for k, v in iteritems(dol):
+            if scalar_string and isinstance(v, str):
+                out[k] = v
+                continue
             try:
                 out[k] = v[i]
             except IndexError:  # It's list-like, but too short.

--- a/galsim/zernike.py
+++ b/galsim/zernike.py
@@ -428,6 +428,8 @@ class Zernike(object):
     """
     def __init__(self, coef, R_outer=1.0, R_inner=0.0):
         self.coef = np.asarray(coef)
+        if len(self.coef) <= 1:
+            self.coef = np.array([0, 0])
         self.R_outer = float(R_outer)
         self.R_inner = float(R_inner)
 

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -420,6 +420,13 @@ def test_phase_psf_batch():
             img1, img2,
             "Individually generated AtmosphericPSF differs from AtmosphericPSF generated in batch")
 
+    import multiprocessing as mp
+    ctx = mp.get_context("spawn")
+    with assert_raises(galsim.GalSimIncompatibleValuesError):
+        atm = galsim.Atmosphere(
+            screen_size=10.0, altitude=10.0, alpha=0.997, time_step=0.01, rng=rng, mp_context=ctx
+        )
+
 
 @timer
 def test_opt_indiv_aberrations():

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -866,7 +866,6 @@ def test_phase_gradient_shoot():
 @timer
 def test_input():
     """Check that exceptions are raised for invalid input"""
-
     # Specifying only one of alpha and time_step is an error.
     assert_raises(ValueError, galsim.AtmosphericScreen, screen_size=10.0, time_step=0.01)
     assert_raises(ValueError, galsim.AtmosphericScreen, screen_size=10.0, alpha=0.997)

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -1089,20 +1089,20 @@ class DummyWork(object):
         rng = galsim.UniformDeviate(i+10)
         theta = (rng()*galsim.degrees, rng()*galsim.degrees)
         psf = atm.makePSF(exptime=1.0, diam=1.1, lam=1000, theta=theta)
-        return psf.drawImage(nx=32, ny=32, scale=0.2, n_photons=10000, method='phot', rng=rng)
+        return psf.drawImage(nx=32, ny=32, scale=0.2, n_photons=1000, method='phot', rng=rng)
 
 
 @timer
 def test_shared_memory():
     """Test that shared memory hooks to AtmosphericScreen work.
     """
+    import multiprocessing as mp
     # Make the atmosphere
     seed = 12345
     r0_500 = 0.15  # m
     L0 = 20.0  # m
     nlayers = 6
     screen_size = 51.2  # m
-    # screen_size = 819.2  # m
     screen_scale = 0.1 # m
     max_speed = 20  # m/s
     rng = galsim.BaseDeviate(seed)
@@ -1124,31 +1124,36 @@ def test_shared_memory():
         dirn.append(u()*360*galsim.degrees)
         r0_500s.append(r0_500*weights[i]**(-3./5))
     rng2 = rng.duplicate()
-    atm = galsim.Atmosphere(r0_500=r0_500, L0=L0, speed=spd, direction=dirn, altitude=alts, rng=rng,
-                            screen_size=screen_size, screen_scale=screen_scale)
 
-    workObj = DummyWork()
+    if __name__ == "__main__":
+        ctxs = [None, mp.get_context("fork"), mp.get_context("spawn"), mp.get_context("forkserver")]
+    else:
+        ctxs = [None]
 
-    import multiprocessing as mp
-    mp = mp.get_context(None)
-    with mp.Pool(
-        4,
-        initializer=galsim.phase_screens.initWorker,
-        initargs=galsim.phase_screens.initWorkerArgs()
-    ) as pool:
-        resultsParallel = []
-        for i in range(100):
-            resultsParallel.append(pool.apply_async(workObj.work, (i, atm)))
-        for r in resultsParallel:
-            r.wait()
-    resultsParallel = [r.get() for r in resultsParallel]
+    for ctx in ctxs:
+        atm = galsim.Atmosphere(r0_500=r0_500, L0=L0, speed=spd, direction=dirn, altitude=alts,
+                                rng=rng, screen_size=screen_size, screen_scale=screen_scale,
+                                mp_context=ctx)
+        workObj = DummyWork()
+        if ctx is None:
+            ctx = mp.get_context(None)
+        with ctx.Pool(
+            None,
+            initializer=galsim.phase_screens.initWorker,
+            initargs=galsim.phase_screens.initWorkerArgs()
+        ) as pool:
+            resultsParallel = []
+            for i in range(10):
+                resultsParallel.append(pool.apply_async(workObj.work, (i, atm)))
+            for r in resultsParallel:
+                r.wait()
+        resultsParallel = [r.get() for r in resultsParallel]
 
-    # Serial comparison
-    resultsSerial = []
-    for i in range(100):
-        resultsSerial.append(workObj.work(i, atm))
-
-    assert resultsSerial == resultsParallel
+        # Serial comparison
+        resultsSerial = []
+        for i in range(10):
+            resultsSerial.append(workObj.work(i, atm))
+        assert resultsSerial == resultsParallel
 
 
 if __name__ == "__main__":

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -1132,13 +1132,13 @@ def test_shared_memory():
         r0_500s.append(r0_500*weights[i]**(-3./5))
     rng2 = rng.duplicate()
 
-    if __name__ == "__main__":
-        if sys.version_info >= (3,4):
+    if sys.version_info >= (3,4):
+        if __name__ == "__main__":
             ctxs = [None, mp.get_context("fork"), mp.get_context("spawn"), "forkserver"]
         else:
-            ctxs = [None]
+            ctxs = [None, mp.get_context("fork")]
     else:
-        ctxs = [None]
+        ctxs = [None]  # Only supported ctx on py27
 
     for ctx in ctxs:
         atmPar = galsim.Atmosphere(

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -21,6 +21,7 @@ import os
 import numpy as np
 
 import galsim
+import unittest
 from galsim_test_helpers import *
 
 
@@ -420,12 +421,14 @@ def test_phase_psf_batch():
             img1, img2,
             "Individually generated AtmosphericPSF differs from AtmosphericPSF generated in batch")
 
-    import multiprocessing as mp
-    ctx = mp.get_context("spawn")
-    with assert_raises(galsim.GalSimIncompatibleValuesError):
-        atm = galsim.Atmosphere(
-            screen_size=10.0, altitude=10.0, alpha=0.997, time_step=0.01, rng=rng, mp_context=ctx
-        )
+    if sys.version_info >= (3,4):
+        import multiprocessing as mp
+        ctx = mp.get_context("spawn")
+        with assert_raises(galsim.GalSimIncompatibleValuesError):
+            atm = galsim.Atmosphere(
+                screen_size=10.0, altitude=10.0, alpha=0.997, time_step=0.01, rng=rng,
+                mp_context=ctx
+            )
 
 
 @timer
@@ -1099,6 +1102,7 @@ class DummyWork(object):
         return psf.drawImage(nx=32, ny=32, scale=0.2, n_photons=1000, method='phot', rng=rng)
 
 
+@unittest.skipIf(sys.version_info < (3,4), 'Requires python version >= 3.4')
 @timer
 def test_shared_memory():
     """Test that shared memory hooks to AtmosphericScreen work.

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -424,7 +424,7 @@ def test_phase_psf_batch():
     if sys.version_info >= (3,4):
         import multiprocessing as mp
         ctx = mp.get_context("spawn")
-        with assert_raises(galsim.GalSimIncompatibleValuesError):
+        with assert_raises(galsim.GalSimNotImplementedError):
             atm = galsim.Atmosphere(
                 screen_size=10.0, altitude=10.0, alpha=0.997, time_step=0.01, rng=rng,
                 mp_context=ctx

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -1148,6 +1148,8 @@ def test_shared_memory():
                                 rng=rng.duplicate(),
                                 screen_size=screen_size, screen_scale=screen_scale,
                                 mp_context=ctx)
+        # Add in an Optical Screen for good measure
+        atm.append(galsim.OpticalScreen(diam=1.1))
         # make a dummy PSF so we can get kmax for screen instantiation
         psf = atm.makePSF(diam=1.1, lam=1000.0)
         kmax = psf.screen_kmax
@@ -1173,6 +1175,7 @@ def test_shared_memory():
                                 rng=rng.duplicate(),
                                 screen_size=screen_size, screen_scale=screen_scale,
                                 mp_context=ctx)
+        atm.append(galsim.OpticalScreen(diam=1.1))
         atm.instantiate(pool=None, kmax=kmax)
 
         resultsSerial = []

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -579,6 +579,16 @@ def test_table2d():
     assert_raises(ValueError, galsim.LookupTable2D, x, y, z, dfdx=z, dfdy=z, d2fdxdy=z[::2],
                   interpolant='spline')
 
+    # Check private shortcut instantiation
+    new_tab2d = galsim.table._LookupTable2D(
+        tab2d.x, tab2d.y, tab2d.f,
+        tab2d.interpolant, tab2d.edge_mode,
+        tab2d.constant, tab2d.dfdx, tab2d.dfdy, tab2d.d2fdxdy
+    )
+    assert tab2d == new_tab2d
+    assert tab2d(2.4, 3.6) == new_tab2d(2.4, 3.6)
+
+
 @timer
 def test_table2d_gradient():
     """Check LookupTable2D gradient function

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1012,6 +1012,7 @@ def test_dol_to_lod():
     l2 = [1, 2]
     l3 = [1, 2, 3]
     d1 = {1:1}
+    s = "abc"
 
     # Should be able to broadcast scalar elements or lists of length 1.
     dd = dict(i0=i0, l2=l2)
@@ -1035,6 +1036,20 @@ def test_dol_to_lod():
     dd = dict(l2=l2, d1=d1)
     with assert_raises(ValueError):
         list(galsim.utilities.dol_to_lod(dd))
+
+    # Strings can either be interpretted as scalar values or as lists of characters
+    dd = dict(i0=i0, s=s)
+    for i, d in enumerate(galsim.utilities.dol_to_lod(dd, scalar_string=False)):
+        assert d == dict(i0=i0, s=s[i])
+    for i, d in enumerate(galsim.utilities.dol_to_lod(dd, scalar_string=True)):
+        assert d == dict(i0=i0, s=s)
+    for i, d in enumerate(galsim.utilities.dol_to_lod(dd, 3, scalar_string=True)):
+        assert d == dict(i0=i0, s=s)
+    dd = dict(l3=l3, s=s)
+    for i, d in enumerate(galsim.utilities.dol_to_lod(dd, scalar_string=True)):
+        assert d == dict(l3=l3[i], s=s)
+    for i, d in enumerate(galsim.utilities.dol_to_lod(dd, scalar_string=False)):
+        assert d == dict(l3=l3[i], s=s[i])
 
 
 @timer

--- a/tests/test_zernike.py
+++ b/tests/test_zernike.py
@@ -411,7 +411,7 @@ def test_gradient():
                 rtol=1e-5, atol=1e-5)
 
     # Make sure the gradient of the zero-Zernike works
-    Z = galsim.zernike.Zernike([0,0])
+    Z = galsim.zernike.Zernike([0])
     assert Z == Z.gradX == Z.gradX.gradX == Z.gradY == Z.gradY.gradY
 
 if __name__ == "__main__":


### PR DESCRIPTION
The PR addresses #1006.  I have:

• Explicitly implemented shared memory for atmospheric screens using `multiprocessing.RawArray` and `.RawValue` classes.  The main impact going forward is that we would no longer need to rely on esoteric *nix fork() + copy-on-write behavior to effect shared memory in applications like ImSim.  A secondary impact is that when using the "spawn" launch context, subprocesses should now be able to safely use OpenMP (I hope, this is untested).
• Added an `mp_context` kwarg to `AtmosphericScreen` so that the user can control what multiprocessing launch context to use.  The default of `None` falls back to the python stdlib default, which is "fork".
• Added a couple of helper functions to ease use of shared memory via `multiprocessing.Pool` objects.  See `AtmosphericScreen` docstring for details.
• Enabled parallel instantiation of multiple screens in a `PhaseScreenList`, which should reduce some of the startup overhead in, e.g., ImSim by a factor of ~nlayers.  (Though, this is at the cost of temporarily requiring more memory during screen instantiation).

The tricky bits in getting this working were in using locks correctly when the shared memory is written to, and implementing some not-automatic-reference counting of the shared memory so that it's released when appropriate (and critically, released at the end of each applicable unit test.)