### PR TITLE
#1024 A few bug fixes I'd like to add to v2.1 series (v2.1.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ Changes from v2.1.4 to v2.1.5
 Bug Fixes
 ---------
 
-- Switched to yaml.safe_load to avoid PyYAML v5.0 warnings
-- Fixed some cases where numpy objected to subtracting floats from ints.
 - Fixed error in use of non-integer grid_spacing in PowerSpectrum (#1020)
 - Fixed FitsHeader to not unnecessarily read data of fits file. (#1024)
+- Switched to yaml.safe_load to avoid PyYAML v5.0 warnings (#1025)
+- Fixed some cases where numpy objected to subtracting floats from ints. (#1025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,9 +58,21 @@ Bug Fix
 Changes from v2.1.3 to v2.1.4
 =============================
 
-Bug Fix
--------
+Bug Fixes
+---------
 
 - Fixed Convolve and Sum to recognize when objects all have the same gsparams,
   and thus avoid making gratuitous copies of the components.
 - Added some caching for some non-trivial calculations for PhaseScreens.
+
+
+Changes from v2.1.4 to v2.1.5
+=============================
+
+Bug Fixes
+---------
+
+- Switched to yaml.safe_load to avoid PyYAML v5.0 warnings
+- Fixed some cases where numpy objected to subtracting floats from ints.
+- Fixed error in use of non-integer grid_spacing in PowerSpectrum (#1020)
+- Fixed FitsHeader to not unnecessarily read data of fits file. (#1024)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Changes from v2.1.4 to v2.1.5
 Bug Fixes
 ---------
 
+- Fixed error when using non-int integer types as seed of BaseDeviate (#1009)
 - Fixed error in use of non-integer grid_spacing in PowerSpectrum (#1020)
 - Fixed FitsHeader to not unnecessarily read data of fits file. (#1024)
 - Switched to yaml.safe_load to avoid PyYAML v5.0 warnings (#1025)

--- a/galsim/catalog.py
+++ b/galsim/catalog.py
@@ -276,7 +276,7 @@ class Dict(object):
         elif file_type == 'YAML':
             import yaml
             with open(self.file_name, 'r') as f:
-                self.dict = yaml.load(f)
+                self.dict = yaml.safe_load(f)
         else:  # JSON
             import json
             with open(self.file_name, 'r') as f:

--- a/galsim/fits.py
+++ b/galsim/fits.py
@@ -324,14 +324,15 @@ def _add_hdu(hdu_list, data, pyfits_compress):
     return hdu
 
 
-def _check_hdu(hdu, pyfits_compress):
+def _check_hdu(hdu, pyfits_compress, header_only=False):
     """Check that an input `hdu` is valid
     """
     from ._pyfits import pyfits
     # Check for fixable verify errors
     try:
         hdu.header
-        hdu.data
+        if not header_only:
+            hdu.data
     except pyfits.VerifyError:
         hdu.verify('fix')
 
@@ -344,7 +345,7 @@ def _check_hdu(hdu, pyfits_compress):
             raise OSError('Found invalid HDU type reading FITS file (expected an ImageHDU)')
 
 
-def _get_hdu(hdu_list, hdu, pyfits_compress):
+def _get_hdu(hdu_list, hdu, pyfits_compress, header_only=False):
     from ._pyfits import pyfits
     if isinstance(hdu_list, pyfits.HDUList):
         # Note: Nothing special needs to be done when reading a compressed hdu.
@@ -364,7 +365,7 @@ def _get_hdu(hdu_list, hdu, pyfits_compress):
         hdu = hdu_list
     else:
         raise TypeError("Invalid hdu_list: %s",hdu_list)
-    _check_hdu(hdu, pyfits_compress)
+    _check_hdu(hdu, pyfits_compress, header_only)
     return hdu
 
 
@@ -1099,7 +1100,7 @@ class FitsHeader(object):
                 hdu_list, fin = _read_file(file_name, dir, file_compress)
 
         if hdu_list:
-            hdu = _get_hdu(hdu_list, hdu, pyfits_compress)
+            hdu = _get_hdu(hdu_list, hdu, pyfits_compress, header_only=True)
             header = hdu.header
 
         if file_name and not text_file:

--- a/galsim/fitswcs.py
+++ b/galsim/fitswcs.py
@@ -459,7 +459,7 @@ class PyAstWCS(CelestialWCS):
         # Need this to look like
         #    [ [ x1, x2, x3... ], [ y1, y2, y3... ] ]
         # if input is either scalar x,y or two arrays.
-        xy = np.array([np.atleast_1d(x), np.atleast_1d(y)])
+        xy = np.array([np.atleast_1d(x), np.atleast_1d(y)], dtype=float)
 
         ra, dec = self.wcsinfo.tran( xy )
         # PyAst returns ra, dec in radians, so we're good.
@@ -475,7 +475,7 @@ class PyAstWCS(CelestialWCS):
         return ra, dec
 
     def _xy(self, ra, dec, color=None):
-        rd = np.array([np.atleast_1d(ra), np.atleast_1d(dec)])
+        rd = np.array([np.atleast_1d(ra), np.atleast_1d(dec)], dtype=float)
         x, y = self.wcsinfo.tran( rd, False )
         return x[0], y[0]
 
@@ -633,7 +633,7 @@ class WcsToolsWCS(CelestialWCS): # pragma: no cover
         # Need this to look like
         #    [ x1, y1, x2, y2, ... ]
         # if input is either scalar x,y or two arrays.
-        xy = np.array([x, y]).transpose().ravel()
+        xy = np.array([x, y], dtype=float).transpose().ravel()
 
         # The OS cannot handle arbitrarily long command lines, so we may need to split up
         # the list into smaller chunks.
@@ -711,7 +711,7 @@ class WcsToolsWCS(CelestialWCS): # pragma: no cover
 
     def _xy(self, ra, dec, color=None):
         import subprocess
-        rd = np.array([ra, dec])
+        rd = np.array([ra, dec], dtype=float)
         rd *= radians / degrees
         for digits in range(10,5,-1):
             rd_strs = [ str(z) for z in rd ]
@@ -1252,8 +1252,8 @@ class GSFitsWCS(CelestialWCS):
         # Most of the work for _radec.  But stop at (u,v).
 
         # Start with (u,v) = the image position
-        x = np.ascontiguousarray(x)
-        y = np.ascontiguousarray(y)
+        x = np.ascontiguousarray(x, dtype=float)
+        y = np.ascontiguousarray(y, dtype=float)
 
         x -= self.crpix[0]
         y -= self.crpix[1]
@@ -1347,7 +1347,7 @@ class GSFitsWCS(CelestialWCS):
         # We also need to keep track of the position along the way, so we have to repeat many
         # of the steps in _radec.
 
-        p1 = np.array( [ image_pos.x, image_pos.y ] )
+        p1 = np.array([image_pos.x, image_pos.y], dtype=float)
 
         # Start with unit jacobian
         jac = np.diag([1,1])
@@ -1540,8 +1540,8 @@ def TanWCS(affine, world_origin, units=arcsec):
     origin = affine.origin
     # The - signs are because the Fits standard is in terms of +u going east, rather than west
     # as we have defined.  So just switch the sign in the CD matrix.
-    cd = np.array( [ [ -dudx, -dudy ], [ dvdx, dvdy ] ] )
-    crpix = np.array( [ origin.x, origin.y ] )
+    cd = np.array([[ -dudx, -dudy ], [ dvdx, dvdy ]], dtype=float)
+    crpix = np.array([ origin.x, origin.y ], dtype=float)
 
     # We also need to absorb the affine world_origin back into crpix, since GSFits is expecting
     # crpix to be the location of the tangent point in image coordinates. i.e. where (u,v) = (0,0)

--- a/galsim/integ.py
+++ b/galsim/integ.py
@@ -68,7 +68,6 @@ def midpt(fvals, x):
 
     @returns midpoint rule approximation of the integral.
     """
-    x = np.array(x)
     dx = [x[1]-x[0]]
     dx.extend(0.5*(x[2:]-x[0:-2]))
     dx.append(x[-1]-x[-2])

--- a/galsim/lensing_ps.py
+++ b/galsim/lensing_ps.py
@@ -491,7 +491,7 @@ class PowerSpectrum(object):
         grid_spacing *= scale_fac
 
         # The final grid spacing that will be in the computed images is grid_spacing/kmax_factor.
-        self.grid_spacing = grid_spacing // kmax_factor
+        self.grid_spacing = grid_spacing / kmax_factor
         self.center = center
 
         # It is also convenient to store the bounds within which an input position is allowed.

--- a/galsim/main.py
+++ b/galsim/main.py
@@ -169,7 +169,7 @@ def ParseVariables(variables, logger):
         try:
             try:
                 import yaml
-                value = yaml.load(value)
+                value = yaml.safe_load(value)
             except ImportError:
                 # Don't require yaml.  json usually works for these.
                 import json

--- a/galsim/nfw_halo.py
+++ b/galsim/nfw_halo.py
@@ -221,7 +221,7 @@ class NFWHalo(object):
         """
         # convenience: call with single number
         if not isinstance(x, np.ndarray):
-            return self.__kappa(np.array([x], dtype='float'), np.array([ks], dtype='float'))[0]
+            return self.__kappa(np.array([x], dtype=float), np.array([ks], dtype=float))[0]
         out = np.zeros_like(x, dtype=float)
 
         # 3 cases: x > 1, x < 1, and |x-1| < 0.001
@@ -246,7 +246,7 @@ class NFWHalo(object):
         """
         # convenience: call with single number
         if not isinstance(x, np.ndarray):
-            return self.__gamma(np.array([x], dtype='float'), np.array([ks], dtype='float'))[0]
+            return self.__gamma(np.array([x], dtype=float), np.array([ks], dtype=float))[0]
         out = np.zeros_like(x, dtype=float)
 
         mask = np.where(x > 0.01)[0]

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -1288,7 +1288,7 @@ class PhaseScreenPSF(GSObject):
         else:
             maxk = self.aper._getMaxK(self.lam, self.scale_unit)
         image = _Image(np.array([[self._flux]], dtype=np.float),
-                             _BoundsI(1, 1, 1, 1), PixelScale(1.))
+                       _BoundsI(1, 1, 1, 1), PixelScale(1.))
         interpolant = 'delta'  # Use delta so it doesn't contribute to stepk
         return InterpolatedImage(
                 image, pad_factor=1.0, x_interpolant=interpolant,

--- a/galsim/random.py
+++ b/galsim/random.py
@@ -794,8 +794,8 @@ class DistDeviate(BaseDeviate):
             if npoints is None: npoints = 256
             xarray = x_min+(1.*x_max-x_min)/(npoints-1)*np.array(range(npoints),float)
             # Integrate over the range of x in case the function is doing something weird here.
-            pdf = [0] + [integ.int1d(function, xarray[i], xarray[i+1])
-                         for i in range(npoints - 1)]
+            pdf = [0.] + [integ.int1d(function, xarray[i], xarray[i+1])
+                          for i in range(npoints - 1)]
             pdf = np.array(pdf)
 
         # Check that the probability is nonnegative

--- a/galsim/random.py
+++ b/galsim/random.py
@@ -26,6 +26,7 @@ import weakref
 from . import _galsim
 from .errors import GalSimRangeError, GalSimValueError, GalSimIncompatibleValuesError
 from .errors import convert_cpp_errors
+from .utilities import isinteger
 
 class BaseDeviate(object):
     """Base class for all the various random deviates.
@@ -118,12 +119,15 @@ class BaseDeviate(object):
         """
         if isinstance(seed, BaseDeviate):
             self._reset(seed)
-        elif isinstance(seed, (str, int)):
+        elif isinstance(seed, str):
             with convert_cpp_errors():
                 self._rng = self._rng_type(_galsim.BaseDeviateImpl(seed), *self._rng_args)
         elif seed is None:
             with convert_cpp_errors():
                 self._rng = self._rng_type(_galsim.BaseDeviateImpl(0), *self._rng_args)
+        elif isinteger(seed):
+            with convert_cpp_errors():
+                self._rng = self._rng_type(_galsim.BaseDeviateImpl(int(seed)), *self._rng_args)
         else:
             raise TypeError("BaseDeviate must be initialized with either an int or another "
                             "BaseDeviate")

--- a/galsim/table.py
+++ b/galsim/table.py
@@ -200,7 +200,7 @@ class LookupTable(object):
         if self.x_log:
             x = np.log(x)
 
-        x = np.asarray(x)
+        x = np.asarray(x, dtype=float)
         if x.shape == ():
             f = self._tab.interp(float(x))
         else:
@@ -341,7 +341,7 @@ class LookupTable(object):
             x = np.exp(np.linspace(np.log(x_min), np.log(x_max), npoints))
         else:
             x = np.linspace(x_min, x_max, npoints)
-        f = np.array([func(xx) for xx in x])
+        f = np.array([func(xx) for xx in x], dtype=float)
         return cls(x, f, interpolant=interpolant, x_log=x_log, f_log=f_log)
 
     def __getstate__(self):

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -31,6 +31,16 @@ from .errors import GalSimError, GalSimValueError, GalSimIncompatibleValuesError
 from .errors import galsim_warn
 
 
+def isinteger(value):
+    """Check if a value is an integer type (including np.int64, long, etc.)
+
+    Specifically, it checks whether value == int(value).
+    """
+    try:
+        return value == int(value)
+    except TypeError:
+        return False
+
 def roll2d(image, shape):
     """Perform a 2D roll (circular shift) on a supplied 2D NumPy array, conveniently.
 

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -278,8 +278,8 @@ def _convertPositions(pos, units, func):
     # The only other options allow pos[0], so if this is invalid, an exception
     # will be raised:
     elif isinstance(pos[0], Position):
-        pos = [ np.array([p.x for p in pos], dtype='float'),
-                np.array([p.y for p in pos], dtype='float') ]
+        pos = [ np.array([p.x for p in pos], dtype=float),
+                np.array([p.y for p in pos], dtype=float) ]
 
     # Now pos must be a tuple of length 2
     elif len(pos) != 2:
@@ -291,8 +291,8 @@ def _convertPositions(pos, units, func):
             pos = [ float(pos[0]), float(pos[1]) ]
         except TypeError:
             # Only other valid option is ( xlist , ylist )
-            pos = [ np.array(pos[0], dtype='float'),
-                    np.array(pos[1], dtype='float') ]
+            pos = [ np.array(pos[0], dtype=float),
+                    np.array(pos[1], dtype=float) ]
 
     # Check validity of units
     if isinstance(units, str):
@@ -393,8 +393,8 @@ def thin_tabulated_values(x, f, rel_err=1.e-4, trim_zeros=True, preserve_range=T
 
     split_fn = _lin_approx_split if fast_search else _exact_lin_approx_split
 
-    x = np.array(x)
-    f = np.array(f)
+    x = np.asarray(x, dtype=float)
+    f = np.asarray(f, dtype=float)
 
     # Check for valid inputs
     if len(x) != len(f):
@@ -491,8 +491,8 @@ def old_thin_tabulated_values(x, f, rel_err=1.e-4, preserve_range=False): # prag
 
     @returns a tuple of lists `(x_new, y_new)` with the thinned tabulation.
     """
-    x = np.array(x)
-    f = np.array(f)
+    x = np.asarray(x, dtype=float)
+    f = np.asarray(f, dtype=float)
 
     # Check for valid inputs
     if len(x) != len(f):
@@ -598,8 +598,8 @@ def horner(x, coef, dtype=None):
         x = np.ascontiguousarray(x, dtype=float)
         coef = np.ascontiguousarray(coef, dtype=float)
     else:
-        x = np.array(x, copy=False)
-        coef = np.array(coef, copy=False)
+        x = np.array(x, copy=False, dtype=float)
+        coef = np.array(coef, copy=False, dtype=float)
     if len(coef.shape) != 1:
         raise GalSimValueError("coef must be 1-dimensional", coef)
     _horner(x, coef, result)
@@ -642,9 +642,9 @@ def horner2d(x, y, coefs, dtype=None, triangle=False):
         y = np.ascontiguousarray(y, dtype=float)
         coefs = np.ascontiguousarray(coefs, dtype=float)
     else:
-        x = np.array(x, copy=False)
-        y = np.array(y, copy=False)
-        coefs = np.array(coefs, copy=False)
+        x = np.array(x, copy=False, dtype=float)
+        y = np.array(y, copy=False, dtype=float)
+        coefs = np.array(coefs, copy=False, dtype=float)
 
     if len(x) != len(y):
         raise GalSimIncompatibleValuesError("x and y are not the same size",

--- a/galsim/wcs.py
+++ b/galsim/wcs.py
@@ -839,8 +839,8 @@ class EuclideanWCS(BaseWCS):
         dx = 1
         dy = 1
 
-        xlist = np.array([ x0+dx, x0-dx, x0,    x0    ])
-        ylist = np.array([ y0,    y0,    y0+dy, y0-dy ])
+        xlist = np.array([ x0+dx, x0-dx, x0,    x0    ], dtype=float)
+        ylist = np.array([ y0,    y0,    y0+dy, y0-dy ], dtype=float)
         try :
             # Try using numpy arrays first, since it should be faster if it works.
             u = self._u(xlist,ylist,color)
@@ -1013,8 +1013,8 @@ class CelestialWCS(BaseWCS):
         dx = 1
         dy = 1
 
-        xlist = np.array([ x0, x0+dx, x0-dx, x0,    x0    ])
-        ylist = np.array([ y0, y0,    y0,    y0+dy, y0-dy ])
+        xlist = np.array([ x0, x0+dx, x0-dx, x0,    x0    ], dtype=float)
+        ylist = np.array([ y0, y0,    y0,    y0+dy, y0-dy ], dtype=float)
         try :
             # Try using numpy arrays first, since it should be faster if it works.
             ra, dec = self._radec(xlist,ylist,color)
@@ -1059,8 +1059,8 @@ class CelestialWCS(BaseWCS):
         except Exception:
             # If that didn't work, we have to do it manually for each position. :(  (SLOW!)
             rd = [ self._radec(x1,y1,color) for x1,y1 in zip(x.ravel(),y.ravel()) ]
-            ra = np.array([ radec[0] for radec in rd ])
-            dec = np.array([ radec[1] for radec in rd ])
+            ra = np.array([ radec[0] for radec in rd ], dtype=float)
+            dec = np.array([ radec[1] for radec in rd ], dtype=float)
         ra = np.reshape(ra, x.shape)
         dec = np.reshape(dec, x.shape)
 
@@ -1457,8 +1457,8 @@ class JacobianWCS(LocalWCS):
                 numpy.array( [[ dudx, dudy ],
                               [ dvdx, dvdy ]] )
         """
-        return np.array( [[ self._dudx, self._dudy ],
-                          [ self._dvdx, self._dvdy ]] )
+        return np.array([[ self._dudx, self._dudy ],
+                         [ self._dvdx, self._dvdy ]], dtype=float)
 
     def getDecomposition(self):
         """Get the equivalent expansion, shear, rotation and possible flip corresponding to

--- a/galsim/zernike.py
+++ b/galsim/zernike.py
@@ -427,7 +427,7 @@ class Zernike(object):
     @param R_inner  Inner radius.  [default: 0.0]
     """
     def __init__(self, coef, R_outer=1.0, R_inner=0.0):
-        self.coef = np.asarray(coef)
+        self.coef = np.asarray(coef, dtype=float)
         self.R_outer = float(R_outer)
         self.R_inner = float(R_inner)
 

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -1710,7 +1710,7 @@ def test_int64():
               np.array(123).astype(np.int64)]
 
     if sys.version_info < (3,):
-        ivalues.append(long(1234))
+        ivalues.append(long(123))
 
     for i in ivalues:
         rng2 = galsim.BaseDeviate(i)

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -1683,6 +1683,40 @@ def test_ne():
     assert repr(d1) == repr(d2)
     assert d1 != d2
 
+@timer
+def test_int64():
+    # cf. #1009
+    # Check that various possible integer types work as seeds.
+
+    rng1 = galsim.BaseDeviate(int(123))
+    # cf. https://www.numpy.org/devdocs/user/basics.types.html
+    ivalues =[np.int8(123),  # Note this one requires i < 128
+              np.int16(123),
+              np.int32(123),
+              np.int64(123),
+              np.uint8(123),
+              np.uint16(123),
+              np.uint32(123),
+              np.uint64(123),
+              np.short(123),
+              np.ushort(123),
+              np.intc(123),
+              np.uintc(123),
+              np.intp(123),
+              np.uintp(123),
+              np.int_(123),
+              np.longlong(123),
+              np.ulonglong(123),
+              np.array(123).astype(np.int64)]
+
+    if sys.version_info < (3,):
+        ivalues.append(long(1234))
+
+    for i in ivalues:
+        rng2 = galsim.BaseDeviate(i)
+        assert rng2 == rng1
+
+
 if __name__ == "__main__":
     test_uniform()
     test_gaussian()
@@ -1698,3 +1732,4 @@ if __name__ == "__main__":
     test_multiprocess()
     test_permute()
     test_ne()
+    test_int64()

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -21,6 +21,7 @@ import numpy as np
 import os
 import sys
 import warnings
+import time
 
 import galsim
 from galsim_test_helpers import *
@@ -2325,6 +2326,34 @@ def test_int_args():
         print('posi_roundtrip = ',posi_roundtrip)
         assert np.isclose(posi_roundtrip.x, posi.x)
         assert np.isclose(posi_roundtrip.y, posi.y)
+
+    # Also check a DES file.
+    # Along the way, check issue #1024 where Erin noticed that reading the WCS from the
+    # header of a compressed file was spending lots of time decompressing the data, which
+    # is unnecessary.
+    dir = 'des_data'
+    file_name = 'DECam_00158414_01.fits.fz'
+    with profile():
+        t0 = time.time()
+        wcs = galsim.FitsWCS(file_name, dir=dir)
+        t1 = time.time()
+    # Before fixing #1024, this took about 0.5 sec.
+    # Now it takes about 0.04 sec.  Testing at 0.2 seems like a reasonable midpoint.
+    print('Time = ',t1-t0)
+    assert t1-t0 < 0.2
+
+    posi = galsim.PositionI(5,6)
+    posd = galsim.PositionD(5,6)
+
+    local_wcs1 = wcs.local(posd)
+    local_wcs2 = wcs.local(posi)
+    assert local_wcs1 == local_wcs2
+
+    wposi = wcs.toWorld(posi)
+    posi_roundtrip = wcs.toImage(wposi)
+    print('posi_roundtrip = ',posi_roundtrip)
+    assert np.isclose(posi_roundtrip.x, posi.x)
+    assert np.isclose(posi_roundtrip.y, posi.y)
 
 
 if __name__ == "__main__":

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -2297,6 +2297,35 @@ def test_coadd():
     np.testing.assert_almost_equal(mom.moments_centroid.x, 24.5, decimal=2)
     np.testing.assert_almost_equal(mom.moments_centroid.y, 24.5, decimal=2)
 
+def test_int_args():
+    """Test that integer arguments for various things work correctly.
+    """
+    # Some of these used to trigger
+    # TypeError: Cannot cast ufunc subtract output from dtype('float64') to dtype('int64')
+    #            with casting rule 'same_kind'
+    # This started with numpy v1.10.
+
+    test_tags = all_tags
+
+    dir = 'fits_files'
+
+    for tag in test_tags:
+        file_name, ref_list = references[tag]
+        wcs = galsim.FitsWCS(file_name, dir=dir)
+
+        posi = galsim.PositionI(5,6)
+        posd = galsim.PositionD(5,6)
+
+        local_wcs1 = wcs.local(posd)
+        local_wcs2 = wcs.local(posi)
+        assert local_wcs1 == local_wcs2
+
+        wposi = wcs.toWorld(posi)
+        posi_roundtrip = wcs.toImage(wposi)
+        print('posi_roundtrip = ',posi_roundtrip)
+        assert np.isclose(posi_roundtrip.x, posi.x)
+        assert np.isclose(posi_roundtrip.y, posi.y)
+
 
 if __name__ == "__main__":
     test_pixelscale()
@@ -2313,3 +2342,4 @@ if __name__ == "__main__":
     test_scamp()
     test_compateq()
     test_coadd()
+    test_int_args()


### PR DESCRIPTION
This PR includes a few bug fixes I think we should include in the 2.1 series as v2.1.5:

1. @aamon pointed out a bug in the WCS functions where things like `local` would fail when given a PositionI input rather than a PositionD.  This is a casualty of a few-years-old change in numpy behavior to disallow subtracting a float from an int with `-=` (and similar ops).  But apparently it's rare enough that no one noticed it being a problem until now.  Anyway, the fix is just to build most of our numpy arrays with `dtype=float`.  I went through and checked them all and fixed the ones that looked potentially problematic, but I only added a unit test for the error that Alex was getting.
2. PyYAML changed its `load` function to raise ugly errors telling people to switch to `safe_load` instead or explicitly use a non-safe `Loader`.  I'm pretty sure we don't ever need a non-safe loader, so I switched to `safe_load`.
3. I fixed the inefficient decompression step that gets triggered by `FitsHeader`, even though it doesn't actually need the data, just the header info.  (cf. #1024, reported by @esheldon)
4. I cherry-picked @rmandelb's fix to #1020, since I thought we might as well include that in v2.1.5 as well.  (Ping @beckermr)\
5. I fixed the seed checks for BaseDeviate to allow non-int integers (cf. #1009, reported by @matroxel).

Note: This is set to merge to releases/2.1.  I will cherry-pick them over to master by hand.