### PR TITLE
#1026 Add vectorized versions of toWorld and toImage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,16 @@ API Changes
 
 New Features
 ------------
-- Added r0_500 argument to VonKarman.
 - Updated WFIRST WCS and PSF routines to use Cycle 7 specifications for detector configurations,
   pupil planes, and aberrations. In particular, there is now a different
   pupil plane image for shorter- and longer-wavelength bands.  (#919)
 - Enabled Zernikes up to 22 (previously 11) in WFIRST PSFs, and added dependence on position
   within the SCA. (#919)
 - Added WFIRST fermi persistence model. (#992)
+- Added `r0_500` argument to VonKarman. (#1005)
+- Added array versions of `wcs.toWorld` and `wcs.toImage`. (#1026)
 
 Bug Fixes
 ---------
+
+- Fixed error in `wcs.makeSkyImage` when crossing ra=0 line for some WCS classes. (#1030)

--- a/galsim/fitswcs.py
+++ b/galsim/fitswcs.py
@@ -209,19 +209,16 @@ class AstropyWCS(CelestialWCS):
 
         # astropy outputs ra, dec in degrees.  Need to convert to radians.
         factor = degrees / radians
-        ra *= factor
-        dec *= factor
 
-        try:
-            # If the inputs were numpy arrays, return the same
-            len(x)
-        except TypeError:
-            # Otherwise, return scalars
-            #assert len(ra) == 1
-            #assert len(dec) == 1
-            ra = ra[0]
-            dec = dec[0]
-        return ra, dec
+        if np.ndim(x) == np.ndim(y) == 0:
+            return ra[0] * factor, dec[0] * factor
+        else:
+            # Sanity checks that the inputs are the same shape.
+            assert np.ndim(x) == np.ndim(y)
+            assert x.shape == y.shape
+            ra *= factor
+            dec *= factor
+            return ra, dec
 
     def _xy(self, ra, dec, color=None):
         factor = radians / degrees
@@ -232,12 +229,14 @@ class AstropyWCS(CelestialWCS):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             x, y = self.wcs.all_world2pix(r1, d1, 1, ra_dec_order=True)
-        try:
-            len(ra)
-        except TypeError:
-            x = x[0]
-            y = y[0]
-        return x, y
+
+        if np.ndim(ra) == np.ndim(dec) == 0:
+            return x[0], y[0]
+        else:
+            # Sanity checks that the inputs are the same shape.
+            assert np.ndim(ra) == np.ndim(dec)
+            assert ra.shape == dec.shape
+            return x, y
 
     def _newOrigin(self, origin):
         ret = self.copy()
@@ -471,26 +470,25 @@ class PyAstWCS(CelestialWCS):
         ra, dec = self.wcsinfo.tran( xy )
         # PyAst returns ra, dec in radians, so we're good.
 
-        try:
-            len(x)
-        except TypeError:
-            # If the inputs weren't numpy arrays, return scalars
-            #assert len(ra) == 1
-            #assert len(dec) == 1
-            ra = ra[0]
-            dec = dec[0]
-        return ra, dec
+        if np.ndim(x) == np.ndim(y) == 0:
+            return ra[0], dec[0]
+        else:
+            # Sanity checks that the inputs are the same shape.
+            assert np.ndim(x) == np.ndim(y)
+            assert x.shape == y.shape
+            return ra, dec
 
     def _xy(self, ra, dec, color=None):
         rd = np.array([np.atleast_1d(ra), np.atleast_1d(dec)], dtype=float)
         x, y = self.wcsinfo.tran( rd, False )
 
-        try:
-            len(ra)
-        except TypeError:
-            x = x[0]
-            y = y[0]
-        return x, y
+        if np.ndim(ra) == np.ndim(dec) == 0:
+            return x[0], y[0]
+        else:
+            # Sanity checks that the inputs are the same shape.
+            assert np.ndim(ra) == np.ndim(dec)
+            assert ra.shape == dec.shape
+            return x, y
 
     def _newOrigin(self, origin):
         ret = self.copy()
@@ -714,15 +712,13 @@ class WcsToolsWCS(CelestialWCS): # pragma: no cover
         # wcstools reports ra, dec in degrees, so convert to radians
         factor = degrees / radians
 
-        try:
-            len(x)
-            # If the inputs were numpy arrays, return the same
-            return np.array(ra)*factor, np.array(dec)*factor
-        except TypeError:
-            # Otherwise return scalars
-            #assert len(ra) == 1
-            #assert len(dec) == 1
+        if np.ndim(x) == np.ndim(y) == 0:
             return ra[0]*factor, dec[0]*factor
+        else:
+            # Sanity checks that the inputs are the same shape.
+            assert np.ndim(x) == np.ndim(y)
+            assert x.shape == y.shape
+            return np.array(ra)*factor, np.array(dec)*factor
 
     def _xy(self, ra, dec, color=None):
         import subprocess
@@ -773,15 +769,13 @@ class WcsToolsWCS(CelestialWCS): # pragma: no cover
                 x.append(float(vals[4]))
                 y.append(float(vals[5]))
 
-        try:
-            len(ra)
-            # If the inputs were numpy arrays, return the same
-            return np.array(x), np.array(y)
-        except TypeError:
-            # Otherwise return scalars
-            #assert len(ra) == 1
-            #assert len(dec) == 1
+        if np.ndim(ra) == np.ndim(dec) == 0:
             return x[0], y[0]
+        else:
+            # Sanity checks that the inputs are the same shape.
+            assert np.ndim(ra) == np.ndim(dec)
+            assert ra.shape == dec.shape
+            return np.array(x), np.array(y)
 
     def _newOrigin(self, origin):
         ret = self.copy()
@@ -1326,15 +1320,14 @@ class GSFitsWCS(CelestialWCS):
         u, v = self._uv(x, y)
         # Then convert from (u,v) to (ra, dec) using the appropriate projection.
         ra, dec = self.center.deproject_rad(u, v, projection=self.projection)
-        try:
-            len(x)
-            # If the inputs were numpy arrays, return the same
-            return ra, dec
-        except TypeError:
-            # Otherwise return scalars
-            #assert len(ra) == 1
-            #assert len(dec) == 1
+
+        if np.ndim(x) == np.ndim(y) == 0:
             return ra[0], dec[0]
+        else:
+            # Sanity checks that the inputs are the same shape.
+            assert np.ndim(x) == np.ndim(y)
+            assert x.shape == y.shape
+            return ra, dec
 
     def _invert_pv(self, u, v):
         # Do this in C++ layer for speed.

--- a/galsim/fitswcs.py
+++ b/galsim/fitswcs.py
@@ -233,7 +233,7 @@ class AstropyWCS(CelestialWCS):
             warnings.simplefilter("ignore")
             x, y = self.wcs.all_world2pix(r1, d1, 1, ra_dec_order=True)
         try:
-            len(x)
+            len(ra)
         except TypeError:
             x = x[0]
             y = y[0]
@@ -486,7 +486,7 @@ class PyAstWCS(CelestialWCS):
         x, y = self.wcsinfo.tran( rd, False )
 
         try:
-            len(x)
+            len(ra)
         except TypeError:
             x = x[0]
             y = y[0]

--- a/galsim/wcs.py
+++ b/galsim/wcs.py
@@ -54,6 +54,7 @@ from .position import Position, PositionI, PositionD
 from .celestial import CelestialCoord
 from .shear import Shear
 from .errors import GalSimError, GalSimIncompatibleValuesError, GalSimNotImplementedError
+from .errors import GalSimValueError
 
 class BaseWCS(object):
     """The base class for all other kinds of WCS transformations.
@@ -238,7 +239,7 @@ class BaseWCS(object):
         elif len(args) == 2:
             return self.xyToWorld(*args, **kwargs)
         else:
-            raise TypeError("toWorld() takes either 1 or 2 positional arguments but 3 were given")
+            raise TypeError("toWorld() takes either 1 or 2 positional arguments")
 
     def posToWorld(self, image_pos, color=None, **kwargs):
         """Convert a position from image coordinates to world coordinates.

--- a/galsim/wcs.py
+++ b/galsim/wcs.py
@@ -211,7 +211,7 @@ class BaseWCS(object):
 
         2. The second is nearly the same, but takes x and y values directly and returns
            either u, v or ra, dec, depending on the kind of wcs being used.  For this version,
-           x and y maybe be numpy arrays, in which case the returned values are also numpy
+           x and y may be numpy arrays, in which case the returned values are also numpy
            arrays.
 
                >>> u, v = wcs.toWorld(x, y)                 # For EuclideanWCS types
@@ -268,7 +268,7 @@ class BaseWCS(object):
 
         It is also equivalent to `wcs.posToWorld(galsim.PositionD(x,y))` when x and y are scalars;
         however, this routine allows x and y to be numpy arrays, in which case, the calculation
-        will be vectorized, which is often much faster than using a Position instance.
+        will be vectorized, which is often much faster than using the pos interface.
 
         @param x            The x value(s) in image coordinates
         @param y            The y value(s) in image coordinates
@@ -328,7 +328,7 @@ class BaseWCS(object):
 
         2. The second is nearly the same, but takes either u and v values or ra and dec values
            (depending on the kind of wcs being used) directly and returns x and y values.
-           For this version, the inputs maybe be numpy arrays, in which case the returned values
+           For this version, the inputs may be numpy arrays, in which case the returned values
            are also numpy arrays.
 
                >>> x, y = wcs.toImage(u, v)                 # For EuclideanWCS types
@@ -842,12 +842,12 @@ class EuclideanWCS(BaseWCS):
 
         This is equivalent to `wcs.toWorld(u,v)`.
 
-        It is also equivalent to `wcs.posToImage(galsim.PositionD(u,v))`; however, this routine
-        allows u and v to be numpy arrays, in which case, the calculation will be vectorized,
-        which is often much faster than using the pos interface.
+        It is also equivalent to `wcs.posToImage(galsim.PositionD(u,v))` when u and v are scalars;
+        however, this routine allows u and v to be numpy arrays, in which case, the calculation
+        will be vectorized, which is often much faster than using the pos interface.
 
-        @param u            The u or ra value(s) in world coordinates
-        @param v            The v or dec value(s) in world coordinates
+        @param u            The u value(s) in world coordinates
+        @param v            The v value(s) in world coordinates
         @param color        For color-dependent WCS's, the color term to use. [default: None]
         """
         if color is None: color = self._color
@@ -1094,13 +1094,14 @@ class CelestialWCS(BaseWCS):
 
         This is equivalent to `wcs.toWorld(ra,dec)`.
 
-        It is also equivalent to `wcs.posToImage(galsim.CelestialCoord(ra * units, dec * units))`;
-        however, this routine allows ra and dec to be numpy arrays, in which case, the calculation
-        will be vectorized, which is often much faster than using the pos interface.
+        It is also equivalent to `wcs.posToImage(galsim.CelestialCoord(ra * units, dec * units))`
+        when ra and dec are scalars; however, this routine allows ra and dec to be numpy arrays,
+        in which case, the calculation will be vectorized, which is often much faster than using
+        the pos interface.
 
         @param ra           The ra value(s) in world coordinates
         @param dec          The dec value(s) in world coordinates
-        @param units        The units to use for the returned ra, dec values.
+        @param units        The units to use for the input ra, dec values.
         @param color        For color-dependent WCS's, the color term to use. [default: None]
         """
         from .angle import AngleUnit

--- a/galsim/wcs.py
+++ b/galsim/wcs.py
@@ -826,19 +826,9 @@ class EuclideanWCS(BaseWCS):
         """
         from .angle import AngleUnit
         if color is None: color = self._color
-        if self.isCelestial():
-            if units is None:
-                raise TypeError("units is required for CelestialWCS types")
-            elif isinstance(units, str):
-                units = AngleUnit.from_name(units)
-            elif not isinstance(units, AngleUnit):
-                raise GalSimValueError("units must be either an AngleUnit or a string", units,
-                                       AngleUnit.valid_names)
-            return self._xyTouv(x, y, units, color)
-        else:
-            if units is not None:
-                raise TypeError("units is not valid for EuclideanWCS types")
-            return self._xyTouv(x, y, color=color)
+        if units is not None:
+            raise TypeError("units is not valid for EuclideanWCS types")
+        return self._xyTouv(x, y, color=color)
 
     def uvToxy(self, u, v, color=None):
         """Convert u,v from world coordinates to image coordinates.
@@ -1112,19 +1102,14 @@ class CelestialWCS(BaseWCS):
         """
         from .angle import AngleUnit
         if color is None: color = self._color
-        if self.isCelestial():
-            if units is None:
-                raise TypeError("units is required for CelestialWCS types")
-            elif isinstance(units, str):
-                units = AngleUnit.from_name(units)
-            elif not isinstance(units, AngleUnit):
-                raise GalSimValueError("units must be either an AngleUnit or a string", units,
-                                       AngleUnit.valid_names)
-            return self._xyToradec(x, y, units, color)
-        else:
-            if units is not None:
-                raise TypeError("units is not valid for EuclideanWCS types")
-            return self._xyToradec(x, y, color=color)
+        if units is None:
+            raise TypeError("units is required for CelestialWCS types")
+        elif isinstance(units, str):
+            units = AngleUnit.from_name(units)
+        elif not isinstance(units, AngleUnit):
+            raise GalSimValueError("units must be either an AngleUnit or a string", units,
+                                    AngleUnit.valid_names)
+        return self._xyToradec(x, y, units, color)
 
     def radecToxy(self, ra, dec, units, color=None):
         """Convert ra,dec from world coordinates to image coordinates.

--- a/galsim/wcs.py
+++ b/galsim/wcs.py
@@ -2356,26 +2356,38 @@ class UVFunction(EuclideanWCS):
         if self._uses_color:
             try:
                 return self._ufunc(x,y,color)
-            except TypeError:
+            except Exception as e:
                 # If that didn't work, we have to do it manually for each position. :(  (SLOW!)
-                return np.array([self._ufunc(x1,y1,color) for [x1,y1] in zip(x,y)])
+                try:
+                    return np.array([self._ufunc(x1,y1,color) for [x1,y1] in zip(x,y)])
+                except Exception:  # pragma: no cover
+                    raise e  # Raise the original if this fails, since it's probably more relevant.
         else:
             try:
                 return self._ufunc(x,y)
-            except TypeError:
-                return np.array([self._ufunc(x1,y1) for [x1,y1] in zip(x,y)])
+            except Exception as e:
+                try:
+                    return np.array([self._ufunc(x1,y1) for [x1,y1] in zip(x,y)])
+                except Exception:  # pragma: no cover
+                    raise e
 
     def _v(self, x, y, color=None):
         if self._uses_color:
             try:
                 return self._vfunc(x,y,color)
-            except TypeError:
-                return np.array([self._vfunc(x1,y1,color) for [x1,y1] in zip(x,y)])
+            except Exception as e:
+                try:
+                    return np.array([self._vfunc(x1,y1,color) for [x1,y1] in zip(x,y)])
+                except Exception:  # pragma: no cover
+                    raise e
         else:
             try:
                 return self._vfunc(x,y)
-            except TypeError:
-                return np.array([self._vfunc(x1,y1) for [x1,y1] in zip(x,y)])
+            except Exception as e:
+                try:
+                    return np.array([self._vfunc(x1,y1) for [x1,y1] in zip(x,y)])
+                except Exception:  # pragma: no cover
+                    raise e
 
     def _x(self, u, v, color=None):
         if self._xfunc is None:
@@ -2385,13 +2397,19 @@ class UVFunction(EuclideanWCS):
             if self._uses_color:
                 try:
                     return self._xfunc(u,v,color)
-                except TypeError:
-                    return np.array([self._xfunc(u1,v1,color) for [u1,v1] in zip(u,v)])
+                except Exception as e:
+                    try:
+                        return np.array([self._xfunc(u1,v1,color) for [u1,v1] in zip(u,v)])
+                    except Exception:  # pragma: no cover
+                        raise e
             else:
                 try:
                     return self._xfunc(u,v)
-                except TypeError:
-                    return np.array([self._xfunc(u1,v1) for [u1,v1] in zip(u,v)])
+                except Exception as e:
+                    try:
+                        return np.array([self._xfunc(u1,v1) for [u1,v1] in zip(u,v)])
+                    except Exception:  # pragma: no cover
+                        raise e
 
     def _y(self, u, v, color=None):
         if self._yfunc is None:
@@ -2401,13 +2419,19 @@ class UVFunction(EuclideanWCS):
             if self._uses_color:
                 try:
                     return self._yfunc(u,v,color)
-                except TypeError:
-                    return np.array([self._yfunc(u1,v1,color) for [u1,v1] in zip(u,v)])
+                except Exception as e:
+                    try:
+                        return np.array([self._yfunc(u1,v1,color) for [u1,v1] in zip(u,v)])
+                    except Exception:  # pragma: no cover
+                        raise e
             else:
                 try:
                     return self._yfunc(u,v)
-                except TypeError:
-                    return np.array([self._yfunc(u1,v1) for [u1,v1] in zip(u,v)])
+                except Exception as e:
+                    try:
+                        return np.array([self._yfunc(u1,v1) for [u1,v1] in zip(u,v)])
+                    except Exception:  # pragma: no cover
+                        raise e
 
     def _newOrigin(self, origin, world_origin):
         return UVFunction(self._orig_ufunc, self._orig_vfunc, self._orig_xfunc, self._orig_yfunc,

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,5 +22,5 @@ pyyaml>=3.12  # This one is required to run tests.
 pandas>=0.20
 
 # This is not in conda.  Let pip install these.
-LSSTDESC.Coord>=1.0.5
+LSSTDESC.Coord>=1.1.2
 starlink-pyast>=3.9.0  # Also not required, but useful.

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -193,7 +193,7 @@ def do_wcs_pos(wcs, ufunc, vfunc, name, x0=0, y0=0, color=None):
                 'wcs.posToWorld returned wrong world position for '+name)
 
         u1,v1 = wcs.toWorld(x+x0, y+y0, color=color)
-        u2,v2 = wcs.xyToWorld(x+x0, y+y0, color=color)
+        u2,v2 = wcs.xyTouv(x+x0, y+y0, color=color)
         np.testing.assert_almost_equal(
                 u1, u, digits2,
                 'wcs.toWorld(x,y) returned wrong u position for '+name)
@@ -202,10 +202,10 @@ def do_wcs_pos(wcs, ufunc, vfunc, name, x0=0, y0=0, color=None):
                 'wcs.toWorld(x,y) returned wrong v position for '+name)
         np.testing.assert_almost_equal(
                 u2, u, digits2,
-                'wcs.xyToWorld(x,y) returned wrong u position for '+name)
+                'wcs.xyTouv(x,y) returned wrong u position for '+name)
         np.testing.assert_almost_equal(
                 v2, v, digits2,
-                'wcs.xyToWorld(x,y) returned wrong v position for '+name)
+                'wcs.xyTouv(x,y) returned wrong v position for '+name)
 
         scale = wcs.maxLinearScale(image_pos, color=color)
         try:
@@ -233,7 +233,7 @@ def do_wcs_pos(wcs, ufunc, vfunc, name, x0=0, y0=0, color=None):
                     'wcs.posToImage returned wrong image position for '+name)
 
             x1,y1 = wcs.toImage(u, v, color=color)
-            x2,y2 = wcs.uvToImage(u, v, color=color)
+            x2,y2 = wcs.uvToxy(u, v, color=color)
             np.testing.assert_almost_equal(
                     x1, x+x0, digits2,
                     'wcs.toImage(u,v) returned wrong x position for '+name)
@@ -242,14 +242,14 @@ def do_wcs_pos(wcs, ufunc, vfunc, name, x0=0, y0=0, color=None):
                     'wcs.toImage(u,v) returned wrong y position for '+name)
             np.testing.assert_almost_equal(
                     x2, x+x0, digits2,
-                    'wcs.uvToImage(u,v) returned wrong x position for '+name)
+                    'wcs.uvToxy(u,v) returned wrong x position for '+name)
             np.testing.assert_almost_equal(
                     y2, y+y0, digits2,
-                    'wcs.uvToImage(u,v) returned wrong y position for '+name)
+                    'wcs.uvToxy(u,v) returned wrong y position for '+name)
 
-    # Test xyToWorld with arrays
+    # Test xyTouv with arrays
     u3,v3 = wcs.toWorld(np.array(x_list)+x0, np.array(y_list)+y0, color=color)
-    u4,v4 = wcs.xyToWorld(np.array(x_list)+x0, np.array(y_list)+y0, color=color)
+    u4,v4 = wcs.xyTouv(np.array(x_list)+x0, np.array(y_list)+y0, color=color)
     np.testing.assert_almost_equal(
             u3, u_list, digits2,
             'wcs.toWorld(x,y) with arrays returned wrong u positions for '+name)
@@ -258,15 +258,15 @@ def do_wcs_pos(wcs, ufunc, vfunc, name, x0=0, y0=0, color=None):
             'wcs.toWorld(x,y) with arrays returned wrong v positions for '+name)
     np.testing.assert_almost_equal(
             u4, u_list, digits2,
-            'wcs.xyToWorld(x,y) with arrays returned wrong u positions for '+name)
+            'wcs.xyTouv(x,y) with arrays returned wrong u positions for '+name)
     np.testing.assert_almost_equal(
             v4, v_list, digits2,
-            'wcs.xyToWorld(x,y) with arrays returned wrong v positions for '+name)
+            'wcs.xyTouv(x,y) with arrays returned wrong v positions for '+name)
 
     if test_reverse:
-        # Test uvToImage with arrays
+        # Test uvToxy with arrays
         x3,y3 = wcs.toImage(np.array(u_list), np.array(v_list), color=color)
-        x4,y4 = wcs.uvToImage(np.array(u_list), np.array(v_list), color=color)
+        x4,y4 = wcs.uvToxy(np.array(u_list), np.array(v_list), color=color)
         np.testing.assert_almost_equal(
                 x3-x0, x_list, digits2,
                 'wcs.toImage(u,v) with arrays returned wrong x positions for '+name)
@@ -275,10 +275,10 @@ def do_wcs_pos(wcs, ufunc, vfunc, name, x0=0, y0=0, color=None):
                 'wcs.toImage(u,v) with arrays returned wrong y positions for '+name)
         np.testing.assert_almost_equal(
                 x4-x0, x_list, digits2,
-                'wcs.uvToImage(u,v) with arrays returned wrong x positions for '+name)
+                'wcs.uvToxy(u,v) with arrays returned wrong x positions for '+name)
         np.testing.assert_almost_equal(
                 y4-y0, y_list, digits2,
-                'wcs.uvToImage(u,v) with arrays returned wrong y positions for '+name)
+                'wcs.uvToxy(u,v) with arrays returned wrong y positions for '+name)
 
     if x0 == 0 and y0 == 0:
         # The last item in list should also work as a PositionI
@@ -306,11 +306,11 @@ def do_wcs_pos(wcs, ufunc, vfunc, name, x0=0, y0=0, color=None):
     assert_raises(TypeError, wcs.posToWorld,
                   galsim.CelestialCoord(0*galsim.degrees,0*galsim.degrees))
 
-    assert_raises(TypeError, wcs.xyToWorld)
-    assert_raises(TypeError, wcs.xyToWorld, 3)
-    assert_raises(TypeError, wcs.xyToWorld, 3,4, units=galsim.degrees)
-    assert_raises(TypeError, wcs.xyToWorld, 3,4,5)
-    assert_raises(TypeError, wcs.xyToWorld, galsim.PositionD(3,4))
+    assert_raises(TypeError, wcs.xyTouv)
+    assert_raises(TypeError, wcs.xyTouv, 3)
+    assert_raises(TypeError, wcs.xyTouv, 3,4, units=galsim.degrees)
+    assert_raises(TypeError, wcs.xyTouv, 3,4,5)
+    assert_raises(TypeError, wcs.xyTouv, galsim.PositionD(3,4))
 
     assert_raises(TypeError, wcs.toImage)
     assert_raises(TypeError, wcs.toImage, (3,4))
@@ -326,10 +326,10 @@ def do_wcs_pos(wcs, ufunc, vfunc, name, x0=0, y0=0, color=None):
     assert_raises(TypeError, wcs.posToImage, 3,4)
     assert_raises(TypeError, wcs.posToImage, 3,4,5)
 
-    assert_raises(TypeError, wcs.uvToImage, 3,4, units=galsim.degrees)
-    assert_raises(TypeError, wcs.uvToImage)
-    assert_raises(TypeError, wcs.uvToImage, 3)
-    assert_raises(TypeError, wcs.uvToImage, world_pos)
+    assert_raises(TypeError, wcs.uvToxy, 3,4, units=galsim.degrees)
+    assert_raises(TypeError, wcs.uvToxy)
+    assert_raises(TypeError, wcs.uvToxy, 3)
+    assert_raises(TypeError, wcs.uvToxy, world_pos)
 
 
 def check_world(pos1, pos2, digits, err_msg):
@@ -870,9 +870,9 @@ def do_celestial_wcs(wcs, name, test_pickle=True, approx=False):
         world_pos2 = wcs.posToWorld(image_pos)
         assert world_pos2 == world_pos
 
-        # xyToWorld also works
+        # xyToradec also works
         ra1, dec1 = wcs.toWorld(x0, y0, units=galsim.radians)
-        ra2, dec2 = wcs.xyToWorld(x0, y0, galsim.degrees)
+        ra2, dec2 = wcs.xyToradec(x0, y0, galsim.degrees)
         ra3, dec3 = wcs.toWorld(x0, y0, units='arcmin')
         assert np.isclose(ra1, world_pos.ra.rad)
         assert np.isclose(dec1, world_pos.dec.rad)
@@ -904,8 +904,8 @@ def do_celestial_wcs(wcs, name, test_pickle=True, approx=False):
             assert np.isclose(image_pos2.y, y0, rtol=1.e-3, atol=atol)
 
             x1, y1 = wcs.toImage(ra1, dec1, units=galsim.radians)
-            x2, y2 = wcs.radecToImage(ra2, dec2, units='deg')
-            x3, y3 = wcs.radecToImage(ra3, dec3, units=galsim.arcmin)
+            x2, y2 = wcs.radecToxy(ra2, dec2, units='deg')
+            x3, y3 = wcs.radecToxy(ra3, dec3, units=galsim.arcmin)
             assert_raises(TypeError, len, x1)
             assert_raises(TypeError, len, y1)
             assert_raises(TypeError, len, x2)
@@ -992,13 +992,13 @@ def do_celestial_wcs(wcs, name, test_pickle=True, approx=False):
                         im1.array, im2.array, digits,
                         'world_profile and image_profile differed when drawn for '+name)
 
-    # Test xyToWorld with array
+    # Test xyToradec with array
     xar = np.array(near_x_list)
     yar = np.array(near_y_list)
     raar = np.array(near_ra_list)
     decar = np.array(near_dec_list)
     ra1, dec1 = wcs.toWorld(xar, yar, units=galsim.radians)
-    ra2, dec2 = wcs.xyToWorld(xar, yar, galsim.degrees)
+    ra2, dec2 = wcs.xyToradec(xar, yar, galsim.degrees)
     ra3, dec3 = wcs.toWorld(xar, yar, units='arcmin')
     np.testing.assert_allclose(ra1, raar)
     np.testing.assert_allclose(dec1, decar)
@@ -1009,7 +1009,7 @@ def do_celestial_wcs(wcs, name, test_pickle=True, approx=False):
 
     if test_reverse:
         x1, y1 = wcs.toImage(raar, decar, units=galsim.radians)
-        x2, y2 = wcs.radecToImage(raar * (galsim.radians / galsim.degrees),
+        x2, y2 = wcs.radecToxy(raar * (galsim.radians / galsim.degrees),
                                   decar * (galsim.radians / galsim.degrees), galsim.degrees)
         x3, y3 = wcs.toImage(raar * (galsim.radians / galsim.arcmin),
                              decar * (galsim.radians / galsim.arcmin), units='arcmin')
@@ -1033,11 +1033,11 @@ def do_celestial_wcs(wcs, name, test_pickle=True, approx=False):
     assert_raises(TypeError, wcs.posToWorld,
                   galsim.CelestialCoord(0*galsim.degrees,0*galsim.degrees))
 
-    assert_raises(TypeError, wcs.xyToWorld)
-    assert_raises(TypeError, wcs.xyToWorld, 3)
-    assert_raises(TypeError, wcs.xyToWorld, 3,4) # no units
-    assert_raises(TypeError, wcs.xyToWorld, galsim.PositionD(3,4))
-    assert_raises(ValueError, wcs.xyToWorld, 3,4,5)  # 5 interpreted as a unit
+    assert_raises(TypeError, wcs.xyToradec)
+    assert_raises(TypeError, wcs.xyToradec, 3)
+    assert_raises(TypeError, wcs.xyToradec, 3,4) # no units
+    assert_raises(TypeError, wcs.xyToradec, galsim.PositionD(3,4))
+    assert_raises(ValueError, wcs.xyToradec, 3,4,5)  # 5 interpreted as a unit
 
     assert_raises(TypeError, wcs.toImage)
     assert_raises(TypeError, wcs.toImage, (3,4))
@@ -1051,13 +1051,13 @@ def do_celestial_wcs(wcs, name, test_pickle=True, approx=False):
     assert_raises(TypeError, wcs.posToImage, 3,4)
     assert_raises(TypeError, wcs.posToImage, 3,4,5)
 
-    assert_raises(TypeError, wcs.radecToImage)
-    assert_raises(TypeError, wcs.radecToImage, 3,4)
-    assert_raises(TypeError, wcs.radecToImage, units=galsim.degrees)
-    assert_raises(TypeError, wcs.radecToImage, 3, units=galsim.degrees)
-    assert_raises(TypeError, wcs.radecToImage, 3,4,5, units=galsim.degrees)
-    assert_raises(TypeError, wcs.radecToImage, world_pos, units=galsim.degrees)
-    assert_raises(ValueError, wcs.radecToImage, 3,4,5)
+    assert_raises(TypeError, wcs.radecToxy)
+    assert_raises(TypeError, wcs.radecToxy, 3,4)
+    assert_raises(TypeError, wcs.radecToxy, units=galsim.degrees)
+    assert_raises(TypeError, wcs.radecToxy, 3, units=galsim.degrees)
+    assert_raises(TypeError, wcs.radecToxy, 3,4,5, units=galsim.degrees)
+    assert_raises(TypeError, wcs.radecToxy, world_pos, units=galsim.degrees)
+    assert_raises(ValueError, wcs.radecToxy, 3,4,5)
 
     assert_raises(TypeError, wcs.local)
     assert_raises(TypeError, wcs.local, image_pos=image_pos, world_pos=world_pos)

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -1708,11 +1708,13 @@ def test_uvfunction():
                     'UVFunction with color-dependence, string', test_pickle=True, color=1.7)
 
     # 9. A non-trivial color example that fails for arrays
-    ufunc = lambda x,y,c : 0.17 * x * (1. + 1.e-5 * math.sqrt(x**2 + y**2) + c)
-    vfunc = lambda x,y,c : 0.17 * y * (1. + 1.e-5 * math.sqrt(x**2 + y**2) + c)
-    wcs = galsim.UVFunction(ufunc, vfunc, uses_color=True)
-    do_nonlocal_wcs(wcs, lambda x,y: ufunc(x,y,0.3), lambda x,y: vfunc(x,y,0.3),
-                    'UVFunction with math and color-dependence', test_pickle=False, color=0.3)
+    ufunc = lambda x,y,c : math.exp(c * x)
+    vfunc = lambda x,y,c : math.exp(c * y/2)
+    xfunc = lambda u,v,c : math.log(u) / c
+    yfunc = lambda u,v,c : math.log(v) * 2 / c
+    wcs = galsim.UVFunction(ufunc, vfunc, xfunc, yfunc, uses_color=True)
+    do_nonlocal_wcs(wcs, lambda x,y: ufunc(x,y,0.01), lambda x,y: vfunc(x,y,0.01),
+                    'UVFunction with math and color-dependence', test_pickle=False, color=0.01)
 
 @timer
 def test_radecfunction():


### PR DESCRIPTION
@esheldon and @beckermr were finding their use of the `toWorld` method of the WCS classes to be slow, since they were applying to many positions at one, and the only public API requires doing these calculations one at a time using PositionD instances for the positions.

The backend code for our WCS classes allows numpy arrays for the `toWorld` function using either `_uv` or `_radec` (depending on which kind of WCS it is), but there was no public method that gave documented access to these methods.

So this PR adds vectorized front end versions of `toWorld` that work with numpy arrays.  I also added vectorized versions of the reverse operation `toImage`, which required a bit of development on the backend as well, since those hadn't always worked correctly with numpy arrays.

The new front end API options are:
```
       >>> u, v = wcs.toWorld(x, y)                 # For EuclideanWCS types
       >>> ra, dec = wcs.toWorld(x, y, units=units) # For CelestialWCS types
       >>> x, y = wcs.toImage(u, v)                 # For EuclideanWCS types
       >>> x, y = wcs.toImage(ra, dec, units=units) # For CelestialWCS types
```
The CelestialWCS classes require a `units` parameter to declare what units you are using for the angles `ra`, `dec`.  As usual, this can be either a `coord.AngleUnit` or a string that can be parsed as such (e.g. `'rad'` or `'deg'`).