### PR TITLE
Fix the flux when shooting some profiles to not be off by ~1.e-3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,4 +25,7 @@ Bug Fixes
 ---------
 
 - Fixed error in `wcs.makeSkyImage` when crossing ra=0 line for some WCS classes. (#1030)
+- Fixed slight error in the realized flux of some profiles when using photon shooting.
+  The bug was most apparent for Kolmogorov and VonKarman, where the realized flux
+  could be too small by about 1.e-3. (#1036)
 - Fixed error in Sersic class when n is very, very close to 0.5. (#1041)

--- a/include/galsim/Interpolant.h
+++ b/include/galsim/Interpolant.h
@@ -192,7 +192,7 @@ namespace galsim {
                 ranges[nKnots-i] = -knot;
                 ranges[nKnots+i-1] = knot;
             }
-            _sampler.reset(new OneDimensionalDeviate(_interp, ranges, false, _gsparams));
+            _sampler.reset(new OneDimensionalDeviate(_interp, ranges, false, 1.0, _gsparams));
         }
     };
 

--- a/include/galsim/OneDimensionalDeviate.h
+++ b/include/galsim/OneDimensionalDeviate.h
@@ -232,6 +232,7 @@ namespace galsim {
          *                         described in class docstring.
          * @param[in] isRadial     Set true for an axisymmetric function on the plane; false
          *                         for linear domain.
+         * @param[in] nominal_flux The expected true integral of the input fluxDensity function.
          * @param[in] gsparams     GSParams object storing constants that control the accuracy of
          *                         operations, if different from the default.
          */

--- a/include/galsim/OneDimensionalDeviate.h
+++ b/include/galsim/OneDimensionalDeviate.h
@@ -237,7 +237,7 @@ namespace galsim {
          */
         OneDimensionalDeviate(
             const FluxDensity& fluxDensity, std::vector<double>& range, bool isRadial,
-            const GSParams& gsparams);
+            double nominal_flux, const GSParams& gsparams);
 
         /// @brief Return total flux in positive regions of FluxDensity
         double getPositiveFlux() const {return _positiveFlux;}

--- a/src/Interpolant.cpp
+++ b/src/Interpolant.cpp
@@ -540,7 +540,7 @@ namespace galsim {
         ranges[3] = -1.;
         for (int i=0; i<4; i++)
             ranges[7-i] = -ranges[i];
-        _sampler.reset(new OneDimensionalDeviate(_interp, ranges, false, _gsparams));
+        _sampler.reset(new OneDimensionalDeviate(_interp, ranges, false, 1.0, _gsparams));
     }
 
     std::map<double,shared_ptr<TableBuilder> > Quintic::_cache_tab;

--- a/src/OneDimensionalDeviate.cpp
+++ b/src/OneDimensionalDeviate.cpp
@@ -358,8 +358,9 @@ namespace galsim {
             // The empirical integral is usually a bit smaller, since the upper limit is finite,
             // so this corrections means the resulting total photon flux is not too small by
             // ~gsparams.shoot_accuracy.  cf. Issue #1036.
-            _positiveFlux *= nominal_flux / empirical_flux;
-            _negativeFlux *= nominal_flux / empirical_flux;
+            double factor = nominal_flux / empirical_flux;
+            _positiveFlux *= factor;
+            _negativeFlux *= factor;
             dbg<<"posFlux => "<<_positiveFlux<<std::endl;
             dbg<<"negFlux => "<<_negativeFlux<<std::endl;
         }

--- a/src/OneDimensionalDeviate.cpp
+++ b/src/OneDimensionalDeviate.cpp
@@ -353,6 +353,11 @@ namespace galsim {
             // There is an edge case to deal with -- SecondKick may give us a function with
             // no flux, which is fine, but don't divide by zero in this case.
             dbg<<"empirical_flux = "<<empirical_flux<<", should be "<<nominal_flux<<std::endl;
+            // Rescale the fluxes according to the expected values of the flux, input as
+            // nominal_flux.  This should be the analytic integral of the input function.
+            // The empirical integral is usually a bit smaller, since the upper limit is finite,
+            // so this corrections means the resulting total photon flux is not too small by
+            // ~gsparams.shoot_accuracy.  cf. Issue #1036.
             _positiveFlux *= nominal_flux / empirical_flux;
             _negativeFlux *= nominal_flux / empirical_flux;
             dbg<<"posFlux => "<<_positiveFlux<<std::endl;

--- a/src/SBAiry.cpp
+++ b/src/SBAiry.cpp
@@ -394,7 +394,7 @@ namespace galsim {
         // NB: don't need floor, since rhs is positive, so floor is superfluous.
         ranges.reserve(int((rmax-rmin+2)/0.5+0.5));
         for(double r=rmin; r<=rmax; r+=0.5) ranges.push_back(r);
-        this->_sampler.reset(new OneDimensionalDeviate(_radial, ranges, true, *_gsparams));
+        this->_sampler.reset(new OneDimensionalDeviate(_radial, ranges, true, 1.0, *_gsparams));
     }
 
     // Now the specializations for when obs = 0
@@ -464,6 +464,6 @@ namespace galsim {
         // NB: don't need floor, since rhs is positive, so floor is superfluous.
         ranges.reserve(int((rmax-rmin+2)/0.5+0.5));
         for(double r=rmin; r<=rmax; r+=0.5) ranges.push_back(r);
-        this->_sampler.reset(new OneDimensionalDeviate(_radial, ranges, true, *_gsparams));
+        this->_sampler.reset(new OneDimensionalDeviate(_radial, ranges, true, 1.0, *_gsparams));
     }
 }

--- a/src/SBExponential.cpp
+++ b/src/SBExponential.cpp
@@ -528,7 +528,7 @@ namespace galsim {
         dbg<<"Made radial"<<std::endl;
         std::vector<double> range(2,0.);
         range[1] = -std::log(gsparams->shoot_accuracy);
-        _sampler.reset(new OneDimensionalDeviate( *_radial, range, true, *gsparams));
+        _sampler.reset(new OneDimensionalDeviate(*_radial, range, true, 2.*M_PI, *gsparams));
         dbg<<"Made sampler"<<std::endl;
 #endif
 

--- a/src/SBKolmogorov.cpp
+++ b/src/SBKolmogorov.cpp
@@ -371,7 +371,7 @@ namespace galsim {
         double sum = 0.;
         double thresh0 = 0.5 / (2.*M_PI*dr);
         double thresh1 = (1.-gsparams->folding_threshold) / (2.*M_PI*dr);
-        double thresh2 = (1.-gsparams->folding_threshold/5.) / (2.*M_PI*dr);
+        double thresh2 = (1.-gsparams->shoot_accuracy) / (2.*M_PI*dr);
         double R = 0., hlr = 0.;
         // Continue until accumulate 0.999 of the flux
         KolmXValue xval_func(*gsparams);
@@ -401,7 +401,7 @@ namespace galsim {
         // Next, set up the sampler for photon shooting
         std::vector<double> range(2,0.);
         range[1] = _radial.argMax();
-        _sampler.reset(new OneDimensionalDeviate(_radial, range, true, *gsparams));
+        _sampler.reset(new OneDimensionalDeviate(_radial, range, true, 1.0, *gsparams));
         dbg<<"made sampler\n";
 
 #ifdef SOLVE_FWHM_HLR

--- a/src/SBSecondKick.cpp
+++ b/src/SBSecondKick.cpp
@@ -317,7 +317,7 @@ namespace galsim {
             range[1] = _radial.argMax();
             dbg<<"range = "<<range[0]<<"  "<<range[1]<<std::endl;
             dbg<<"Make ODD\n";
-            _sampler.reset(new OneDimensionalDeviate(_radial, range, true, *_gsparams));
+            _sampler.reset(new OneDimensionalDeviate(_radial, range, true, 1.0, *_gsparams));
             dbg<<"Made ODD\n";
             return;
         }
@@ -331,7 +331,7 @@ namespace galsim {
         // that encloses (1-folding_threshold) of the flux.
         double thresh0 = (0.5 - _delta) / (2.*M_PI*dr);
         double thresh1 = (1.-_delta-_gsparams->folding_threshold) / (2.*M_PI*dr);
-        double thresh2 = (1.-_delta-_gsparams->folding_threshold/5.) / (2.*M_PI*dr);
+        double thresh2 = (1.-_delta-_gsparams->shoot_accuracy) / (2.*M_PI*dr);
         double R = 0., hlr = 0.;
 
         _radial.addEntry(0., val);
@@ -405,7 +405,7 @@ namespace galsim {
 
         std::vector<double> range(2,0.);
         range[1] = _radial.argMax();
-        _sampler.reset(new OneDimensionalDeviate(_radial, range, true, *_gsparams));
+        _sampler.reset(new OneDimensionalDeviate(_radial, range, true, 1.0, *_gsparams));
         dbg<<"made sampler\n";
         //set_verbose(1);
     }

--- a/src/SBSersic.cpp
+++ b/src/SBSersic.cpp
@@ -841,7 +841,9 @@ namespace galsim {
             double shoot_maxr = calculateMissingFluxRadius(_gsparams->shoot_accuracy);
             if (_truncated && _trunc < shoot_maxr) shoot_maxr = _trunc;
             range[1] = shoot_maxr;
-            _sampler.reset(new OneDimensionalDeviate( *_radial, range, true, *_gsparams));
+            double nominal_flux = 2.*M_PI*_n*_gamma2n * _flux;
+            _sampler.reset(new OneDimensionalDeviate(*_radial, range, true, nominal_flux,
+                                                     *_gsparams));
         }
 
         assert(_sampler.get());

--- a/src/SBSpergel.cpp
+++ b/src/SBSpergel.cpp
@@ -704,7 +704,9 @@ namespace galsim {
                 std::vector<double> range(2,0.);
                 range[1] = shoot_rmax;
                 _radial.reset(new SpergelNuPositiveRadialFunction(_nu, _xnorm0));
-                _sampler.reset(new OneDimensionalDeviate( *_radial, range, true, *_gsparams));
+                double nominal_flux = 2.*M_PI*std::pow(2.,_nu)*_gamma_nup1;
+                _sampler.reset(new OneDimensionalDeviate(*_radial, range, true, nominal_flux,
+                                                         *_gsparams));
             } else {
                 // exact s.b. profile diverges at origin, so replace the inner most circle
                 // (defined such that enclosed flux is shoot_acccuracy) with a linear function
@@ -728,7 +730,9 @@ namespace galsim {
                 range[1] = shoot_rmin;
                 range[2] = shoot_rmax;
                 _radial.reset(new SpergelNuNegativeRadialFunction(_nu, shoot_rmin, a, b));
-                _sampler.reset(new OneDimensionalDeviate( *_radial, range, true, *_gsparams));
+                double nominal_flux = 2.*M_PI*std::pow(2.,_nu)*_gamma_nup1;
+                _sampler.reset(new OneDimensionalDeviate(*_radial, range, true, nominal_flux,
+                                                         *_gsparams));
             }
         }
 

--- a/src/SBVonKarman.cpp
+++ b/src/SBVonKarman.cpp
@@ -280,7 +280,7 @@ namespace galsim {
         // So the relevant thresholds we want are:
         double thresh0 = 0.5 / (2.*M_PI*dlogr);
         double thresh1 = (1.-_gsparams->folding_threshold) / (2.*M_PI*dlogr);
-        double thresh2 = (1.-_gsparams->folding_threshold/5.) / (2.*M_PI*dlogr);
+        double thresh2 = (1.-_gsparams->shoot_accuracy) / (2.*M_PI*dlogr);
         dbg<<"thresh = "<<thresh0<<"  "<<thresh1<<"  "<<thresh2<<std::endl;
         double R = 0.;
         _hlr = 0.;
@@ -317,7 +317,7 @@ namespace galsim {
 
         std::vector<double> range(2, 0.);
         range[1] = _radial.argMax();
-        _sampler.reset(new OneDimensionalDeviate(_radial, range, true, *_gsparams));
+        _sampler.reset(new OneDimensionalDeviate(_radial, range, true, 1.0, *_gsparams));
     }
 
     void VonKarmanInfo::shoot(PhotonArray& photons, UniformDeviate ud) const

--- a/tests/test_airy.py
+++ b/tests/test_airy.py
@@ -223,6 +223,33 @@ def test_airy_flux_scaling():
         obj2.flux, test_flux / 2., decimal=param_decimal,
         err_msg="Flux param inconsistent after __div__ (result).")
 
+@timer
+def test_airy_shoot():
+    """Test Airy with photon shooting.  Particularly the flux of the final image.
+    """
+    # Airy patterns have *very* extended wings, so make this really small and the image really
+    # big to make sure we capture all the photons.
+    rng = galsim.BaseDeviate(1234)
+    obj = galsim.Airy(lam_over_diam=0.01, flux=1.e4)
+    im = galsim.Image(1000,1000, scale=1)
+    im.setCenter(0,0)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    print('obj.flux = ',obj.flux)
+    print('added_flux = ',added_flux)
+    print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
+    print('image flux = ',im.array.sum())
+    assert np.isclose(added_flux, obj.flux)
+    assert np.isclose(im.array.sum(), obj.flux)
+
+    obj = galsim.Airy(lam_over_diam=0.01, flux=1.e4, obscuration=0.4)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    print('obj.flux = ',obj.flux)
+    print('added_flux = ',added_flux)
+    print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
+    print('image flux = ',im.array.sum())
+    assert np.isclose(added_flux, obj.flux)
+    assert np.isclose(im.array.sum(), obj.flux)
+
 
 @timer
 def test_ne():
@@ -242,8 +269,10 @@ def test_ne():
             galsim.Airy(lam_over_diam=1.0, gsparams=gsp)]
     all_obj_diff(gals)
 
+
 if __name__ == "__main__":
     test_airy()
     test_airy_radii()
     test_airy_flux_scaling()
+    test_airy_shoot()
     test_ne()

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -243,6 +243,41 @@ def test_tophat():
 
 
 @timer
+def test_box_shoot():
+    """Test Box with photon shooting.  Particularly the flux of the final image.
+    """
+    rng = galsim.BaseDeviate(1234)
+    obj = galsim.Box(width=1.3, height=2.4, flux=1.e4)
+    im = galsim.Image(100,100, scale=1)
+    im.setCenter(0,0)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    print('obj.flux = ',obj.flux)
+    print('added_flux = ',added_flux)
+    print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
+    print('image flux = ',im.array.sum())
+    assert np.isclose(added_flux, obj.flux)
+    assert np.isclose(im.array.sum(), obj.flux)
+
+    obj = galsim.Pixel(scale=9.3, flux=1.e4)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    print('obj.flux = ',obj.flux)
+    print('added_flux = ',added_flux)
+    print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
+    print('image flux = ',im.array.sum())
+    assert np.isclose(added_flux, obj.flux)
+    assert np.isclose(im.array.sum(), obj.flux)
+
+    obj = galsim.TopHat(radius=4.7, flux=1.e4)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    print('obj.flux = ',obj.flux)
+    print('added_flux = ',added_flux)
+    print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
+    print('image flux = ',im.array.sum())
+    assert np.isclose(added_flux, obj.flux)
+    assert np.isclose(im.array.sum(), obj.flux)
+
+
+@timer
 def test_ne():
     """Test base.py GSObjects for not-equals."""
     # Define some universal gsps
@@ -279,4 +314,5 @@ def test_ne():
 if __name__ == "__main__":
     test_box()
     test_tophat()
+    test_box_shoot()
     test_ne()

--- a/tests/test_exponential.py
+++ b/tests/test_exponential.py
@@ -212,6 +212,23 @@ def test_exponential_flux_scaling():
         err_msg="Flux param inconsistent after __div__ (result).")
 
 @timer
+def test_exponential_shoot():
+    """Test Exponential with photon shooting.  Particularly the flux of the final image.
+    """
+    rng = galsim.BaseDeviate(1234)
+    obj = galsim.Exponential(half_light_radius=3.5, flux=1.e4)
+    im = galsim.Image(100,100, scale=1)
+    im.setCenter(0,0)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    print('obj.flux = ',obj.flux)
+    print('added_flux = ',added_flux)
+    print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
+    print('image flux = ',im.array.sum())
+    assert np.isclose(added_flux, obj.flux)
+    assert np.isclose(im.array.sum(), obj.flux)
+
+
+@timer
 def test_ne():
     """Test base.py GSObjects for not-equals."""
     # Define some universal gsps
@@ -232,4 +249,5 @@ if __name__ == "__main__":
     test_exponential_properties()
     test_exponential_radii()
     test_exponential_flux_scaling()
+    test_exponential_shoot()
     test_ne()

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -330,6 +330,24 @@ def test_gaussian_flux_scaling():
         obj2.flux, test_flux / 2., decimal=param_decimal,
         err_msg="Flux param inconsistent after __div__ (result).")
 
+
+@timer
+def test_gaussian_shoot():
+    """Test Gaussian with photon shooting.  Particularly the flux of the final image.
+    """
+    rng = galsim.BaseDeviate(1234)
+    obj = galsim.Gaussian(fwhm=3.5, flux=1.e4)
+    im = galsim.Image(100,100, scale=1)
+    im.setCenter(0,0)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    print('obj.flux = ',obj.flux)
+    print('added_flux = ',added_flux)
+    print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
+    print('image flux = ',im.array.sum())
+    assert np.isclose(added_flux, obj.flux)
+    assert np.isclose(im.array.sum(), obj.flux)
+
+
 @timer
 def test_ne():
     """Test base.py GSObjects for not-equals."""
@@ -355,4 +373,5 @@ if __name__ == "__main__":
     test_gaussian_properties()
     test_gaussian_radii()
     test_gaussian_flux_scaling()
+    test_gaussian_shoot()
     test_ne()

--- a/tests/test_kolmogorov.py
+++ b/tests/test_kolmogorov.py
@@ -324,6 +324,23 @@ def test_kolmogorov_folding_threshold():
 
 
 @timer
+def test_kolmogorov_shoot():
+    """Test Kolmogorov with photon shooting.  Particularly the flux of the final image.
+    """
+    rng = galsim.BaseDeviate(1234)
+    obj = galsim.Kolmogorov(fwhm=1.5, flux=1.e4)
+    im = galsim.Image(500,500, scale=1)
+    im.setCenter(0,0)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    print('obj.flux = ',obj.flux)
+    print('added_flux = ',added_flux)
+    print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
+    print('image flux = ',im.array.sum())
+    assert np.isclose(added_flux, obj.flux)
+    assert np.isclose(im.array.sum(), obj.flux)
+
+
+@timer
 def test_ne():
     """Test base.py GSObjects for not-equals."""
     # Define some universal gsps
@@ -351,4 +368,5 @@ if __name__ == "__main__":
     test_kolmogorov_radii()
     test_kolmogorov_flux_scaling()
     test_kolmogorov_folding_threshold()
+    test_kolmogorov_shoot()
     test_ne()

--- a/tests/test_moffat.py
+++ b/tests/test_moffat.py
@@ -430,6 +430,34 @@ def test_moffat_flux_scaling():
                 obj2.flux, test_flux / 2., decimal=param_decimal,
                 err_msg="Flux param inconsistent after __div__ (result).")
 
+
+@timer
+def test_moffat_shoot():
+    """Test Moffat with photon shooting.  Particularly the flux of the final image.
+    """
+    rng = galsim.BaseDeviate(1234)
+    obj = galsim.Moffat(fwhm=3.5, beta=4.7, flux=1.e4)
+    im = galsim.Image(500,500, scale=1)
+    im.setCenter(0,0)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    print('obj.flux = ',obj.flux)
+    print('added_flux = ',added_flux)
+    print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
+    print('image flux = ',im.array.sum())
+    assert np.isclose(added_flux, obj.flux)
+    assert np.isclose(im.array.sum(), obj.flux)
+
+    # Note: low beta has large wings, so don't go too low.  Also, reduce fwhm a bit.
+    obj = galsim.Moffat(fwhm=1.5, beta=1.9, flux=1.e4)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    print('obj.flux = ',obj.flux)
+    print('added_flux = ',added_flux)
+    print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
+    print('image flux = ',im.array.sum())
+    assert np.isclose(added_flux, obj.flux)
+    assert np.isclose(im.array.sum(), obj.flux)
+
+
 @timer
 def test_ne():
     """Test base.py GSObjects for not-equals."""
@@ -454,4 +482,5 @@ if __name__ == "__main__":
     test_moffat_properties()
     test_moffat_radii()
     test_moffat_flux_scaling()
+    test_moffat_shoot()
     test_ne()

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -838,8 +838,8 @@ def test_geometric_shoot():
 
         # Use really good seeing, so that the optics contribution actually matters.
         psf = galsim.Convolve(opt_psf, galsim.Kolmogorov(fwhm=0.4))
-        im_shoot = psf.drawImage(nx=32, ny=32, scale=0.2, method='phot', n_photons=100000, rng=u)
-        im_fft = psf.drawImage(nx=32, ny=32, scale=0.2)
+        im_shoot = psf.drawImage(nx=256, ny=256, scale=0.2, method='phot', n_photons=100000, rng=u)
+        im_fft = psf.drawImage(nx=256, ny=256, scale=0.2)
 
         printval(im_fft, im_shoot)
         shoot_moments = galsim.hsm.FindAdaptiveMom(im_shoot)
@@ -865,6 +865,16 @@ def test_geometric_shoot():
         np.testing.assert_allclose(
             shoot_moments.observed_shape.g2, fft_moments.observed_shape.g2, rtol=0, atol=0.01,
             err_msg="")
+
+        # Check the flux
+        # The Airy part sends a lot of flux off the edge, so this test is a little loose.
+        added_flux = im_shoot.added_flux
+        print('psf.flux = ',psf.flux)
+        print('added_flux = ',added_flux)
+        print('image flux = ',im_shoot.array.sum())
+        assert np.isclose(added_flux, psf.flux, rtol=3.e-4)
+        assert np.isclose(im_shoot.array.sum(), psf.flux, rtol=3.e-4)
+
 
 
 if __name__ == "__main__":

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -743,12 +743,12 @@ def test_phase_gradient_shoot():
     vk = galsim.VonKarman(lam=lam, r0=r0_500*(lam/500)**1.2, L0=L0)
     airy = galsim.Airy(lam=lam, diam=diam)
     obj = galsim.Convolve(vk, airy)
-    vkImg = obj.drawImage(nx=48, ny=48, scale=0.05)
+    vkImg = obj.drawImage(nx=256, ny=256, scale=0.05)
     vkMom = galsim.hsm.FindAdaptiveMom(vkImg)
 
     for psf, psf2 in zip(psfs, psfs2):
-        im_shoot = psf.drawImage(nx=48, ny=48, scale=0.05, method='phot', n_photons=100000, rng=rng)
-        im_fft = psf2.drawImage(nx=48, ny=48, scale=0.05)
+        im_shoot = psf.drawImage(nx=256, ny=256, scale=0.05, method='phot', n_photons=100000, rng=rng)
+        im_fft = psf2.drawImage(nx=256, ny=256, scale=0.05)
 
         # at this point, the atms should be different.
         assert atm != atm2
@@ -810,6 +810,13 @@ def test_phase_gradient_shoot():
 
         shoot_moments.append(shoot_moment)
         fft_moments.append(fft_moment)
+
+        # Check the flux
+        # The Airy part sends a lot of flux off the edge, so this test is pretty loose.
+        added_flux = im_shoot.added_flux
+        print('psf.flux = ',psf.flux, added_flux, im_shoot.array.sum())
+        assert np.isclose(added_flux, psf.flux, rtol=1.e-3)
+        assert np.isclose(im_shoot.array.sum(), psf.flux, rtol=1.e-3)
 
     # I cheated.  Here's code to evaluate how small I could potentially set the tolerances above.
     # I think they're all fine, but this is admittedly a tad bit backwards.

--- a/tests/test_second_kick.py
+++ b/tests/test_second_kick.py
@@ -251,6 +251,23 @@ def test_sk_scale():
 
 
 @timer
+def test_sk_shoot():
+    """Test SecondKick with photon shooting.  Particularly the flux of the final image.
+    """
+    rng = galsim.BaseDeviate(1234)
+    obj = galsim.SecondKick(lam=500, r0=0.2, diam=4, flux=1.e4)
+    im = galsim.Image(500,500, scale=1)
+    im.setCenter(0,0)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    print('obj.flux = ',obj.flux)
+    print('added_flux = ',added_flux)
+    print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
+    print('image flux = ',im.array.sum())
+    assert np.isclose(added_flux, obj.flux)
+    assert np.isclose(im.array.sum(), obj.flux)
+
+
+@timer
 def test_sk_ne():
     gsp = galsim.GSParams(maxk_threshold=1.1e-3, folding_threshold=5.1e-3)
 
@@ -283,6 +300,7 @@ if __name__ == '__main__':
     test_limiting_cases()
     test_sk_phase_psf()
     test_sk_scale()
+    test_sk_shoot()
     test_sk_ne()
 
     if args.profile:

--- a/tests/test_sersic.py
+++ b/tests/test_sersic.py
@@ -480,6 +480,46 @@ def test_sersic_1():
         np.testing.assert_almost_equal(sersic.xValue(pos), expon.xValue(pos), decimal=5)
         np.testing.assert_almost_equal(sersic.kValue(pos), expon.kValue(pos), decimal=5)
 
+
+@timer
+def test_sersic_shoot():
+    """Test Sersic with photon shooting.  Particularly the flux of the final image.
+    """
+    rng = galsim.BaseDeviate(1234)
+    obj = galsim.Sersic(n=1.5, half_light_radius=3.5, flux=1.e4)
+    im = galsim.Image(100,100, scale=1)
+    im.setCenter(0,0)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    print('obj.flux = ',obj.flux)
+    print('added_flux = ',added_flux)
+    print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
+    print('image flux = ',im.array.sum())
+    assert np.isclose(added_flux, obj.flux)
+    assert np.isclose(im.array.sum(), obj.flux)
+
+    obj = galsim.DeVaucouleurs(half_light_radius=3.5, flux=1.e4)
+    # Need a larger image for devauc wings
+    im = galsim.Image(1000,1000, scale=1)
+    im.setCenter(0,0)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    print('obj.flux = ',obj.flux)
+    print('added_flux = ',added_flux)
+    print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
+    print('image flux = ',im.array.sum())
+    assert np.isclose(added_flux, obj.flux)
+    assert np.isclose(im.array.sum(), obj.flux)
+
+    # Can do up to around n=6 with this image if hlr is smaller.
+    obj = galsim.Sersic(half_light_radius=0.9, n=6.2, flux=1.e4)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    print('obj.flux = ',obj.flux)
+    print('added_flux = ',added_flux)
+    print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
+    print('image flux = ',im.array.sum())
+    assert np.isclose(added_flux, obj.flux)
+    assert np.isclose(im.array.sum(), obj.flux)
+
+
 @timer
 def test_ne():
     """Test base.py GSObjects for not-equals."""
@@ -534,5 +574,6 @@ if __name__ == "__main__":
     test_sersic_flux_scaling()
     test_sersic_05()
     test_sersic_1()
+    test_sersic_shoot()
     test_ne()
     test_near_05()

--- a/tests/test_spergel.py
+++ b/tests/test_spergel.py
@@ -281,6 +281,42 @@ def test_spergel_05():
         np.testing.assert_almost_equal(spergel.xValue(pos), expon.xValue(pos), decimal=5)
         np.testing.assert_almost_equal(spergel.kValue(pos), expon.kValue(pos), decimal=5)
 
+
+@timer
+def test_spergel_shoot():
+    """Test Spergel with photon shooting.  Particularly the flux of the final image.
+    """
+    rng = galsim.BaseDeviate(1234)
+    obj = galsim.Spergel(nu=0, half_light_radius=3.5, flux=1.e4)
+    im = galsim.Image(100,100, scale=1)
+    im.setCenter(0,0)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    print('obj.flux = ',obj.flux)
+    print('added_flux = ',added_flux)
+    print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
+    print('image flux = ',im.array.sum())
+    assert np.isclose(added_flux, obj.flux)
+    assert np.isclose(im.array.sum(), obj.flux)
+
+    obj = galsim.Spergel(nu=3.2, half_light_radius=3.5, flux=1.e4)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    print('obj.flux = ',obj.flux)
+    print('added_flux = ',added_flux)
+    print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
+    print('image flux = ',im.array.sum())
+    assert np.isclose(added_flux, obj.flux)
+    assert np.isclose(im.array.sum(), obj.flux)
+
+    obj = galsim.Spergel(nu=-0.6, half_light_radius=3.5, flux=1.e4)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    print('obj.flux = ',obj.flux)
+    print('added_flux = ',added_flux)
+    print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
+    print('image flux = ',im.array.sum())
+    assert np.isclose(added_flux, obj.flux)
+    assert np.isclose(im.array.sum(), obj.flux)
+
+
 @timer
 def test_ne():
     """Test base.py GSObjects for not-equals."""
@@ -304,4 +340,5 @@ if __name__ == "__main__":
     test_spergel_radii()
     test_spergel_flux_scaling()
     test_spergel_05()
+    test_spergel_shoot()
     test_ne()

--- a/tests/test_vonkarman.py
+++ b/tests/test_vonkarman.py
@@ -121,6 +121,43 @@ def test_vk_scale():
 
 
 @timer
+def test_vk_shoot():
+    """Test VonKarman with photon shooting.  Particularly the flux of the final image.
+    """
+    rng = galsim.BaseDeviate(1234)
+    obj = galsim.VonKarman(lam=500, r0=0.2, flux=1.e4)
+    im = galsim.Image(100,100, scale=1)
+    im.setCenter(0,0)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    print('obj.flux = ',obj.flux)
+    print('added_flux = ',added_flux)
+    print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
+    print('image flux = ',im.array.sum())
+    assert np.isclose(added_flux, obj.flux)
+    assert np.isclose(im.array.sum(), obj.flux)
+
+    obj = galsim.VonKarman(lam=500, r0=0.2, L0=10., flux=1.e4)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    print('obj.flux = ',obj.flux)
+    print('added_flux = ',added_flux)
+    print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
+    print('image flux = ',im.array.sum())
+    assert np.isclose(added_flux, obj.flux)
+    assert np.isclose(im.array.sum(), obj.flux)
+
+    obj = galsim.VonKarman(lam=700, r0=0.02, L0=10., flux=1.e4)
+    im = galsim.Image(500,500, scale=1)
+    im.setCenter(0,0)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    print('obj.flux = ',obj.flux)
+    print('added_flux = ',added_flux)
+    print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
+    print('image flux = ',im.array.sum())
+    assert np.isclose(added_flux, obj.flux)
+    assert np.isclose(im.array.sum(), obj.flux)
+
+
+@timer
 def test_vk_ne():
     gsp = galsim.GSParams(maxk_threshold=1.1e-3, folding_threshold=5.1e-3)
 
@@ -247,6 +284,7 @@ if __name__ == "__main__":
     test_vk(args.slow)
     test_vk_delta()
     test_vk_scale()
+    test_vk_shoot()
     test_vk_ne()
     test_vk_eq_kolm()
     test_vk_fitting_formulae()


### PR DESCRIPTION
@cwwalter ran across a bug in photon shooting where we were systematically shooting a little bit less total flux than intended for some profiles.  The problem occurred with profiles that use OneDimensionalDeviate for their back-end shooting calculations.  Indeed there were actually two problems:
1. Two profiles, Kolmogorov and VonKarman, used the wrong tolerance value for when to stop the radial profile.  We advertise that errors in the shooting flux should be less than gsparams.shoot_accuracy, which defaults to 1.e-5.  These were erroneously using gsparams.folding_threshold/5 for no obvious reason.  The latter value is only 1.e-3, so this led to the shooting flux values being wrong by 1.e-3 in relative value rather than 1.e-5, which would probably have been tolerable.
2. All profiles that use OneDimensionalDeviate normalized the fluxes using the empirical integral of the radial function from 0 to maxr, using whatever maxr was calculated to be acceptable.  This is nominally ok, but it means that the resulting fluxes are all systematically small by a factor of 1-gsparams.shoot_accuracy.  I changed the OneDimensionalDeviate constructor to take in the true analytic integral of the radial function and use that for the normalization.  This means that rather than all photons coming back with flux = 0.99999, they come back with flux=1, and the total flux comes out correct.  (At least when all photons land on the sensor.)