### PR TITLE
#1038 Updates to Interpolant classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Changes from v2.1 to v2.2
 Deprecated Features
 -------------------
 
+- Deprecated the `tol` parameter of the various Interpolant classes.  Users should use the
+  `kvalue_accuracy` parameter of `gsparams` instead. (#1038)
+
 API Changes
 -----------
 
@@ -20,6 +23,7 @@ New Features
 - Added WFIRST fermi persistence model. (#992)
 - Added `r0_500` argument to VonKarman. (#1005)
 - Added array versions of `wcs.toWorld` and `wcs.toImage`. (#1026)
+- Exposed some methods of Interpolants that had only been in the C++ layer. (#1038)
 
 Bug Fixes
 ---------

--- a/galsim/correlatednoise.py
+++ b/galsim/correlatednoise.py
@@ -969,7 +969,7 @@ class CorrelatedNoise(_BaseCorrelatedNoise):
     @param wcs              If provided, use this as the wcs for the image.  At most one of `scale`
                             or `wcs` may be provided. [default: None]
     @param x_interpolant    The interpolant to use for interpolating the image of the correlation
-                            function. (See below.) [default: galsim.Linear(tol=1.e-4)]
+                            function. (See below.) [default: galsim.Linear()]
     @param correct_periodicity  Whether to correct for the effects of periodicity.  (See below.)
                             [default: True]
     @param subtract_mean    Whether to subtract off the mean value from the image before computing
@@ -994,12 +994,12 @@ class CorrelatedNoise(_BaseCorrelatedNoise):
     The example above instantiates a CorrelatedNoise, but forces the use of the pixel scale
     `scale` to set the units of the internal lookup table.
 
-        >>> cn = galsim.CorrelatedNoise(image, rng=rng, x_interpolant=galsim.Lanczos(5, tol=1.e-4))
+        >>> cn = galsim.CorrelatedNoise(image, rng=rng, x_interpolant=galsim.Lanczos(5))
 
     The example above instantiates a CorrelatedNoise, but forces use of a non-default interpolant
     for interpolation of the internal lookup table in real space.
 
-    The default `x_interpolant` is `galsim.Linear(tol=1.e-4)`, which uses bilinear interpolation.
+    The default `x_interpolant` is `galsim.Linear()`, which uses bilinear interpolation.
     The use of this interpolant is an approximation that gives good empirical results without
     requiring internal convolution of the correlation function profile by a Pixel object when
     applying correlated noise to images: such an internal convolution has been found to be
@@ -1211,7 +1211,7 @@ class CorrelatedNoise(_BaseCorrelatedNoise):
 
         # If x_interpolant not specified on input, use bilinear
         if x_interpolant is None:
-            x_interpolant = Linear(tol=1.e-4)
+            x_interpolant = Linear()
         else:
             x_interpolant = utilities.convert_interpolant(x_interpolant)
 
@@ -1299,13 +1299,13 @@ def getCOSMOSNoise(file_name=None, rng=None, cosmos_scale=0.03, variance=0., x_i
                         noise fields.]
     @param x_interpolant  Forces use of a non-default interpolant for interpolation of the
                         internal lookup table in real space.  See below for more details.
-                        [default: galsim.Linear(tol=1.e-4)]
+                        [default: galsim.Linear()]
     @param gsparams     An optional GSParams argument.  See the docstring for GSParams for
                         details. [default: None]
 
     @returns a _BaseCorrelatedNoise instance representing correlated noise in F814W COSMOS images.
 
-    The default `x_interpolant` is a `galsim.Linear(tol=1.e-4)`, which uses bilinear interpolation.
+    The default `x_interpolant` is a `galsim.Linear()`, which uses bilinear interpolation.
     The use of this interpolant is an approximation that gives good empirical results without
     requiring internal convolution of the correlation function profile by a Pixel object when
     applying correlated noise to images: such an internal convolution has been found to be
@@ -1389,7 +1389,7 @@ def getCOSMOSNoise(file_name=None, rng=None, cosmos_scale=0.03, variance=0., x_i
 
     # If x_interpolant not specified on input, use bilinear
     if x_interpolant is None:
-        x_interpolant = Linear(tol=1.e-4)
+        x_interpolant = Linear()
     else:
         x_interpolant = utilities.convert_interpolant(x_interpolant)
 

--- a/galsim/interpolant.py
+++ b/galsim/interpolant.py
@@ -65,11 +65,11 @@ class Interpolant(object):
         @param tol          [deprecated]
         @param gsparams     An optional GSParams instance [default: None]
         """
-        gsparams = GSParams.check(gsparams)
         if tol is not None:
             from galsim.deprecated import depr
             depr('tol', 2.2, 'gsparams=GSParams(kvalue_accuracy=tol)')
-            gsparams._kvalue_accuracy = tol
+            gsparams = GSParams(kvalue_accuracy=tol)
+        gsparams = GSParams.check(gsparams)
 
         # Do these in rough order of likelihood (most to least)
         if name.lower() == 'quintic':

--- a/galsim/interpolant.py
+++ b/galsim/interpolant.py
@@ -157,7 +157,7 @@ class Interpolant(object):
         else:
             dimen = len(x.shape)
             if dimen > 1:
-                raise ValueError("Input x must be 1-dimensional")
+                raise GalSimValueError("Input x must be 1-dimensional", x)
             self._i.xvalMany(xx.ctypes.data, len(xx))
             return xx
 
@@ -181,7 +181,7 @@ class Interpolant(object):
         else:
             dimen = len(k.shape)
             if dimen > 1:
-                raise ValueError("Input k must be 1-dimensional")
+                raise GalSimValueError("Input k must be 1-dimensional", k)
             self._i.uvalMany(u.ctypes.data, len(u))
             return u
 

--- a/galsim/interpolant.py
+++ b/galsim/interpolant.py
@@ -135,6 +135,53 @@ class Interpolant(object):
     def __hash__(self):
         return hash(repr(self))
 
+    def xval(self, x):
+        """Calculate the value of the interpolant kernel at one or more x values
+
+        Parameters
+        ----------
+            x:      The value (as a flost) or values (as a np.array) at which to compute the
+                    amplitude of the Interpolant kernel.
+
+        Returns
+        -------
+            xval:   The value(s) at the x location(s).  If x was an array, then this is also
+                    an array.
+        """
+        xx = np.array(x, dtype=float, copy=True)
+        if xx.shape == ():
+            return self._i.xval(float(xx))
+        else:
+            dimen = len(x.shape)
+            if dimen > 1:
+                raise ValueError("Input x must be 1-dimensional")
+            self._i.xvalMany(xx.ctypes.data, len(xx))
+            return xx
+
+    def kval(self, k):
+        """Calculate the value of the interpolant kernel in Fourier space at one or more k values.
+
+        Parameters
+        ----------
+            k:      The value (as a flost) or values (as a np.array) at which to compute the
+                    amplitude of the Interpolant kernel in Fourier space.
+
+        Returns
+        -------
+            kval:   The k-value(s) at the k location(s).  If k was an array, then this is also
+                    an array.
+        """
+        # Note: the C++ layer uses u = k/2pi rather than k.
+        u = np.array(k, dtype=float, copy=True) / (2.*np.pi)
+        if u.shape == ():
+            return self._i.uval(float(u))
+        else:
+            dimen = len(k.shape)
+            if dimen > 1:
+                raise ValueError("Input k must be 1-dimensional")
+            self._i.uvalMany(u.ctypes.data, len(u))
+            return u
+
     # Sub-classes should define _i property, repr, and str
 
 

--- a/galsim/interpolant.py
+++ b/galsim/interpolant.py
@@ -106,11 +106,19 @@ class Interpolant(object):
 
     @property
     def positive_flux(self):
+        """The positive-flux fraction of the interpolation kernel."""
         return self._i.getPositiveFlux();
 
     @property
     def negative_flux(self):
+        """The negative-flux fraction of the interpolation kernel."""
         return self._i.getNegativeFlux();
+
+    @property
+    def tol(self):
+        from galsim.deprecated import depr
+        depr('interpolant.tol', 2.2, 'interpolant.gsparams.kvalue_accuracy')
+        return self._gsparams.kvalue_accuracy
 
     def withGSParams(self, gsparams):
         """Create a version of the current interpolant with the given gsparams
@@ -141,13 +149,11 @@ class Interpolant(object):
     def xval(self, x):
         """Calculate the value of the interpolant kernel at one or more x values
 
-        Parameters
-        ----------
+        Parameters:
             x:      The value (as a flost) or values (as a np.array) at which to compute the
                     amplitude of the Interpolant kernel.
 
-        Returns
-        -------
+        Returns:
             xval:   The value(s) at the x location(s).  If x was an array, then this is also
                     an array.
         """
@@ -164,13 +170,11 @@ class Interpolant(object):
     def kval(self, k):
         """Calculate the value of the interpolant kernel in Fourier space at one or more k values.
 
-        Parameters
-        ----------
+        Parameters:
             k:      The value (as a flost) or values (as a np.array) at which to compute the
                     amplitude of the Interpolant kernel in Fourier space.
 
-        Returns
-        -------
+        Returns:
             kval:   The k-value(s) at the k location(s).  If k was an array, then this is also
                     an array.
         """
@@ -218,10 +222,6 @@ class Delta(Interpolant):
         return "galsim.Delta()"
 
     @property
-    def tol(self):
-        return self._gsparams.kvalue_accuracy
-
-    @property
     def xrange(self):
         return 0.
 
@@ -263,10 +263,6 @@ class Nearest(Interpolant):
 
     def __str__(self):
         return "galsim.Nearest()"
-
-    @property
-    def tol(self):
-        return self._gsparams.kvalue_accuracy
 
     @property
     def xrange(self):
@@ -313,10 +309,6 @@ class SincInterpolant(Interpolant):
         return "galsim.SincInterpolant()"
 
     @property
-    def tol(self):
-        return self._gsparams.kvalue_accuracy
-
-    @property
     def xrange(self):
         # Technically infinity, but truncated by the tolerance.
         return 1./(math.pi * self._gsparams.kvalue_accuracy)
@@ -358,10 +350,6 @@ class Linear(Interpolant):
 
     def __str__(self):
         return "galsim.Linear()"
-
-    @property
-    def tol(self):
-        return self._gsparams.kvalue_accuracy
 
     @property
     def xrange(self):
@@ -406,10 +394,6 @@ class Cubic(Interpolant):
         return "galsim.Cubic()"
 
     @property
-    def tol(self):
-        return self._gsparams.kvalue_accuracy
-
-    @property
     def xrange(self):
         return 2.
 
@@ -450,10 +434,6 @@ class Quintic(Interpolant):
 
     def __str__(self):
         return "galsim.Quintic()"
-
-    @property
-    def tol(self):
-        return self._gsparams.kvalue_accuracy
 
     @property
     def xrange(self):
@@ -514,10 +494,6 @@ class Lanczos(Interpolant):
     @property
     def conserve_dc(self):
         return self._conserve_dc
-
-    @property
-    def tol(self):
-        return self._gsparams.kvalue_accuracy
 
     @property
     def xrange(self):

--- a/galsim/interpolant.py
+++ b/galsim/interpolant.py
@@ -21,6 +21,7 @@ Definitions of the various interpolants used by InterpolatedImage and Interpolat
 """
 
 import math
+import numpy as np
 from past.builtins import basestring
 
 from . import _galsim
@@ -100,6 +101,14 @@ class Interpolant(object):
     def gsparams(self):
         return self._gsparams
 
+    @property
+    def positive_flux(self):
+        return self._i.getPositiveFlux();
+
+    @property
+    def negative_flux(self):
+        return self._i.getNegativeFlux();
+
     def withGSParams(self, gsparams):
         """Create a version of the current interpolant with the given gsparams
         """
@@ -157,8 +166,16 @@ class Delta(Interpolant):
         return "galsim.Delta(%s)"%(self._tol)
 
     @property
+    def tol(self):
+        return self._tol
+
+    @property
     def xrange(self):
         return 0.
+
+    @property
+    def ixrange(self):
+        return 0
 
     @property
     def krange(self):
@@ -194,8 +211,16 @@ class Nearest(Interpolant):
         return "galsim.Nearest(%s)"%(self._tol)
 
     @property
+    def tol(self):
+        return self._tol
+
+    @property
     def xrange(self):
         return 0.5
+
+    @property
+    def ixrange(self):
+        return 1
 
     @property
     def krange(self):
@@ -232,9 +257,17 @@ class SincInterpolant(Interpolant):
         return "galsim.SincInterpolant(%s)"%(self._tol)
 
     @property
+    def tol(self):
+        return self._tol
+
+    @property
     def xrange(self):
         # Technically infinity, but truncated by the tolerance.
         return 1./(math.pi * self._tol)
+
+    @property
+    def ixrange(self):
+        return np.inf
 
     @property
     def krange(self):
@@ -269,9 +302,17 @@ class Linear(Interpolant):
         return "galsim.Linear(%s)"%(self._tol)
 
     @property
+    def tol(self):
+        return self._tol
+
+    @property
     def xrange(self):
         # Reduce range slightly so not including points with zero weight.
         return 1. - 0.1*self._tol
+
+    @property
+    def ixrange(self):
+        return 2
 
     @property
     def krange(self):
@@ -304,8 +345,16 @@ class Cubic(Interpolant):
         return "galsim.Cubic(%s)"%(self._tol)
 
     @property
+    def tol(self):
+        return self._tol
+
+    @property
     def xrange(self):
         return 2. - 0.1*self._tol
+
+    @property
+    def ixrange(self):
+        return 4
 
     @property
     def krange(self):
@@ -339,8 +388,16 @@ class Quintic(Interpolant):
         return "galsim.Quintic(%s)"%(self._tol)
 
     @property
+    def tol(self):
+        return self._tol
+
+    @property
     def xrange(self):
         return 3. - 0.1*self._tol
+
+    @property
+    def ixrange(self):
+        return 6
 
     @property
     def krange(self):
@@ -385,8 +442,24 @@ class Lanczos(Interpolant):
         return "galsim.Lanczos(%s, %s)"%(self._n, self._tol)
 
     @property
+    def n(self):
+        return self._n
+
+    @property
+    def conserve_dc(self):
+        return self._conserve_dc
+
+    @property
+    def tol(self):
+        return self._tol
+
+    @property
     def xrange(self):
         return self._n - 0.1*self._tol
+
+    @property
+    def ixrange(self):
+        return 2*self._n
 
     @property
     def krange(self):

--- a/galsim/interpolatedimage.py
+++ b/galsim/interpolatedimage.py
@@ -306,11 +306,11 @@ class InterpolatedImage(GSObject):
         # Set up the interpolants if none was provided by user, or check that the user-provided ones
         # are of a valid type
         if x_interpolant is None:
-            self._x_interpolant = Quintic(tol=1e-4, gsparams=self._gsparams)
+            self._x_interpolant = Quintic(gsparams=self._gsparams)
         else:
             self._x_interpolant = convert_interpolant(x_interpolant).withGSParams(self._gsparams)
         if k_interpolant is None:
-            self._k_interpolant = Quintic(tol=1e-4, gsparams=self._gsparams)
+            self._k_interpolant = Quintic(gsparams=self._gsparams)
         else:
             self._k_interpolant = convert_interpolant(k_interpolant).withGSParams(self._gsparams)
 
@@ -931,7 +931,7 @@ class InterpolatedKImage(GSObject):
         # set up k_interpolant if none was provided by user, or check that the user-provided one
         # is of a valid type
         if k_interpolant is None:
-            self._k_interpolant = Quintic(tol=1e-4, gsparams=self._gsparams)
+            self._k_interpolant = Quintic(gsparams=self._gsparams)
         else:
             self._k_interpolant = convert_interpolant(k_interpolant).withGSParams(self._gsparams)
 

--- a/galsim/real.py
+++ b/galsim/real.py
@@ -1164,7 +1164,7 @@ class ChromaticRealGalaxy(ChromaticSum):
         self.SEDs = SEDs
 
         if k_interpolant is None:
-            k_interpolant = Quintic(tol=1e-4)
+            k_interpolant = Quintic()
         else:
             k_interpolant = convert_interpolant(k_interpolant)
 

--- a/include/galsim/Interpolant.h
+++ b/include/galsim/Interpolant.h
@@ -113,12 +113,26 @@ namespace galsim {
         virtual double xvalWrapped(double x, int N) const;
 
         /**
+         * @brief Calculate xval for array of input values x
+         * @param[in/out]   Each x[i] is replaces by xval[x[i]]
+         * @param[in]       How many x values to calculate
+         */
+        void xvalMany(double* x, int N) const;
+
+        /**
          * @brief Value of interpolant in frequency space
          * @param[in] u Frequency for evaluation (cycles per pixel)
          * @returns Value of interpolant, normalized so uval(0) = 1 for flux-conserving
          * interpolation.
          */
         virtual double uval(double u) const =0;
+
+        /**
+         * @brief Calculate uval for array of input values u
+         * @param[in/out]   Each u[i] is replaces by uval[u[i]]
+         * @param[in]       How many u values to calculate
+         */
+        void uvalMany(double* u, int N) const;
 
         /**
          * @brief Report whether interpolation will reproduce values at samples

--- a/pysrc/Interpolant.cpp
+++ b/pysrc/Interpolant.cpp
@@ -23,9 +23,25 @@
 
 namespace galsim {
 
+    static void XvalMany(const Interpolant& interp, size_t ivals, int N)
+    {
+        double* vals = reinterpret_cast<double*>(ivals);
+        interp.xvalMany(vals, N);
+    }
+
+    static void UvalMany(const Interpolant& interp, size_t ivals, int N)
+    {
+        double* vals = reinterpret_cast<double*>(ivals);
+        interp.uvalMany(vals, N);
+    }
+
     void pyExportInterpolant(PY_MODULE& _galsim)
     {
         py::class_<Interpolant BP_NONCOPYABLE>(GALSIM_COMMA "Interpolant" BP_NOINIT)
+            .def("xval", &Interpolant::xval)
+            .def("uval", &Interpolant::uval)
+            .def("xvalMany", &XvalMany)
+            .def("uvalMany", &UvalMany)
             .def("getPositiveFlux", &Interpolant::getPositiveFlux)
             .def("getNegativeFlux", &Interpolant::getNegativeFlux)
             .def("urange", &Interpolant::urange);

--- a/pysrc/Interpolant.cpp
+++ b/pysrc/Interpolant.cpp
@@ -25,7 +25,10 @@ namespace galsim {
 
     void pyExportInterpolant(PY_MODULE& _galsim)
     {
-        py::class_<Interpolant BP_NONCOPYABLE>(GALSIM_COMMA "Interpolant" BP_NOINIT);
+        py::class_<Interpolant BP_NONCOPYABLE>(GALSIM_COMMA "Interpolant" BP_NOINIT)
+            .def("getPositiveFlux", &Interpolant::getPositiveFlux)
+            .def("getNegativeFlux", &Interpolant::getNegativeFlux)
+            .def("urange", &Interpolant::urange);
 
         py::class_<Delta, BP_BASES(Interpolant)>(GALSIM_COMMA "Delta" BP_NOINIT)
             .def(py::init<double,GSParams>());
@@ -37,8 +40,7 @@ namespace galsim {
             .def(py::init<double,GSParams>());
 
         py::class_<Lanczos, BP_BASES(Interpolant)>(GALSIM_COMMA "Lanczos" BP_NOINIT)
-            .def(py::init<int,bool,double,GSParams>())
-            .def("urange", &Lanczos::urange);
+            .def(py::init<int,bool,double,GSParams>());
 
         py::class_<Linear, BP_BASES(Interpolant)>(GALSIM_COMMA "Linear" BP_NOINIT)
             .def(py::init<double,GSParams>());

--- a/pysrc/Interpolant.cpp
+++ b/pysrc/Interpolant.cpp
@@ -47,25 +47,25 @@ namespace galsim {
             .def("urange", &Interpolant::urange);
 
         py::class_<Delta, BP_BASES(Interpolant)>(GALSIM_COMMA "Delta" BP_NOINIT)
-            .def(py::init<double,GSParams>());
+            .def(py::init<GSParams>());
 
         py::class_<Nearest, BP_BASES(Interpolant)>(GALSIM_COMMA "Nearest" BP_NOINIT)
-            .def(py::init<double,GSParams>());
+            .def(py::init<GSParams>());
 
         py::class_<SincInterpolant, BP_BASES(Interpolant)>(GALSIM_COMMA "SincInterpolant" BP_NOINIT)
-            .def(py::init<double,GSParams>());
+            .def(py::init<GSParams>());
 
         py::class_<Lanczos, BP_BASES(Interpolant)>(GALSIM_COMMA "Lanczos" BP_NOINIT)
-            .def(py::init<int,bool,double,GSParams>());
+            .def(py::init<int,bool,GSParams>());
 
         py::class_<Linear, BP_BASES(Interpolant)>(GALSIM_COMMA "Linear" BP_NOINIT)
-            .def(py::init<double,GSParams>());
+            .def(py::init<GSParams>());
 
         py::class_<Cubic, BP_BASES(Interpolant)>(GALSIM_COMMA "Cubic" BP_NOINIT)
-            .def(py::init<double,GSParams>());
+            .def(py::init<GSParams>());
 
         py::class_<Quintic, BP_BASES(Interpolant)>(GALSIM_COMMA "Quintic" BP_NOINIT)
-            .def(py::init<double,GSParams>());
+            .def(py::init<GSParams>());
     }
 
 } // namespace galsim

--- a/src/Interpolant.cpp
+++ b/src/Interpolant.cpp
@@ -885,13 +885,16 @@ namespace galsim {
 
             // Build utab = table of u values
             _utab.reset(new TableBuilder(Table::spline));
+            // The peak second derivative of the Lanczos kernel if Fourier space empirically
+            // seems to a bit over ~100.  Use 200 to be conservative, so this mean use
+            // h = (kvalue_accuracy/200)**0.25
             const double uStep =
-                gsparams.table_spacing * std::pow(gsparams.kvalue_accuracy/10.,0.25) / _nd;
+                gsparams.table_spacing * std::pow(gsparams.kvalue_accuracy/200.,0.25) / _nd;
             _uMax = 0.;
             for (double u=0.; u - _uMax < 1./_nd || u<1.1; u+=uStep) {
                 double uval = uCalc(u);
                 _utab->addEntry(u, uval);
-                if (std::abs(uval) > _tolerance) _uMax = u;
+                if (std::abs(uval) > gsparams.kvalue_accuracy) _uMax = u;
             }
             _utab->finalize();
             // Save these values in the cache.

--- a/src/Interpolant.cpp
+++ b/src/Interpolant.cpp
@@ -133,6 +133,19 @@ namespace galsim {
         }
     }
 
+    void Interpolant::xvalMany(double* x, int N) const
+    {
+        // x is both input and output here.
+        // x_i <- xval(x_i)
+        for (; N; --N, ++x) *x = xval(*x);
+    }
+
+    void Interpolant::uvalMany(double* u, int N) const
+    {
+        // u is both input and output here.
+        // u_i <- uval(u_i)
+        for (; N; --N, ++u) *u = uval(*u);
+    }
 
     //
     // Delta

--- a/tests/test_correlatednoise.py
+++ b/tests/test_correlatednoise.py
@@ -1007,7 +1007,7 @@ def test_convolve_cosmos():
     # Now start the test...
     # First we generate a COSMOS noise field (cosimage), read it into an InterpolatedImage and
     # then convolve it with psf, making sure we pad the edges
-    interp=galsim.Linear(tol=1.e-4) # interpolation kernel to use in making convimages
+    interp=galsim.Linear() # interpolation kernel to use in making convimages
     # Number of tests needs to be a little larger to beat down noise here, but see the script
     # in devel/external/test_cf/test_cf_convolution_detailed.py
     cosimage_padded = galsim.ImageD(

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -52,34 +52,34 @@ def test_phase_psf():
 def test_interpolant():
     d = check_dep(galsim.Delta, tol=1.e-2)
     assert d.gsparams.kvalue_accuracy == 1.e-2
-    assert d.tol == d.gsparams.kvalue_accuracy
+    assert check_dep(getattr, d, 'tol') == d.gsparams.kvalue_accuracy
     n = check_dep(galsim.Nearest, tol=1.e-2)
     assert n.gsparams.kvalue_accuracy == 1.e-2
-    assert n.tol == n.gsparams.kvalue_accuracy
+    assert check_dep(getattr, n, 'tol') == n.gsparams.kvalue_accuracy
     s = check_dep(galsim.SincInterpolant, tol=1.e-2)
     assert s.gsparams.kvalue_accuracy == 1.e-2
-    assert s.tol == s.gsparams.kvalue_accuracy
+    assert check_dep(getattr, s, 'tol') == s.gsparams.kvalue_accuracy
     l = check_dep(galsim.Linear, tol=1.e-2)
     assert l.gsparams.kvalue_accuracy == 1.e-2
-    assert l.tol == l.gsparams.kvalue_accuracy
+    assert check_dep(getattr, l, 'tol') == l.gsparams.kvalue_accuracy
     c = check_dep(galsim.Cubic, tol=1.e-2)
     assert c.gsparams.kvalue_accuracy == 1.e-2
-    assert c.tol == c.gsparams.kvalue_accuracy
+    assert check_dep(getattr, c, 'tol') == c.gsparams.kvalue_accuracy
     q = check_dep(galsim.Quintic, tol=1.e-2)
     assert q.gsparams.kvalue_accuracy == 1.e-2
-    assert q.tol == q.gsparams.kvalue_accuracy
+    assert check_dep(getattr, q, 'tol') == q.gsparams.kvalue_accuracy
     l3 = check_dep(galsim.Lanczos, 3, tol=1.e-2)
     assert l3.gsparams.kvalue_accuracy == 1.e-2
-    assert l3.tol == l3.gsparams.kvalue_accuracy
+    assert check_dep(getattr, l3, 'tol') == l3.gsparams.kvalue_accuracy
     ldc = check_dep(galsim.Lanczos, 3, False, tol=1.e-2)
     assert ldc.gsparams.kvalue_accuracy == 1.e-2
-    assert ldc.tol == ldc.gsparams.kvalue_accuracy
+    assert check_dep(getattr, ldc, 'tol') == ldc.gsparams.kvalue_accuracy
     l8 = check_dep(galsim.Lanczos, 8, tol=1.e-2)
     assert l8.gsparams.kvalue_accuracy == 1.e-2
-    assert l8.tol == l8.gsparams.kvalue_accuracy
+    assert check_dep(getattr, l8, 'tol') == l8.gsparams.kvalue_accuracy
     l11 = check_dep(galsim.Interpolant.from_name, 'lanczos11', tol=1.e-2)
     assert l11.gsparams.kvalue_accuracy == 1.e-2
-    assert l11.tol == l11.gsparams.kvalue_accuracy
+    assert check_dep(getattr, l11, 'tol') == l11.gsparams.kvalue_accuracy
 
 if __name__ == "__main__":
     test_gsparams()

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -52,22 +52,34 @@ def test_phase_psf():
 def test_interpolant():
     d = check_dep(galsim.Delta, tol=1.e-2)
     assert d.gsparams.kvalue_accuracy == 1.e-2
+    assert d.tol == d.gsparams.kvalue_accuracy
     n = check_dep(galsim.Nearest, tol=1.e-2)
     assert n.gsparams.kvalue_accuracy == 1.e-2
+    assert n.tol == n.gsparams.kvalue_accuracy
     s = check_dep(galsim.SincInterpolant, tol=1.e-2)
     assert s.gsparams.kvalue_accuracy == 1.e-2
+    assert s.tol == s.gsparams.kvalue_accuracy
     l = check_dep(galsim.Linear, tol=1.e-2)
     assert l.gsparams.kvalue_accuracy == 1.e-2
+    assert l.tol == l.gsparams.kvalue_accuracy
     c = check_dep(galsim.Cubic, tol=1.e-2)
     assert c.gsparams.kvalue_accuracy == 1.e-2
+    assert c.tol == c.gsparams.kvalue_accuracy
     q = check_dep(galsim.Quintic, tol=1.e-2)
     assert q.gsparams.kvalue_accuracy == 1.e-2
+    assert q.tol == q.gsparams.kvalue_accuracy
     l3 = check_dep(galsim.Lanczos, 3, tol=1.e-2)
     assert l3.gsparams.kvalue_accuracy == 1.e-2
+    assert l3.tol == l3.gsparams.kvalue_accuracy
     ldc = check_dep(galsim.Lanczos, 3, False, tol=1.e-2)
     assert ldc.gsparams.kvalue_accuracy == 1.e-2
+    assert ldc.tol == ldc.gsparams.kvalue_accuracy
     l8 = check_dep(galsim.Lanczos, 8, tol=1.e-2)
     assert l8.gsparams.kvalue_accuracy == 1.e-2
+    assert l8.tol == l8.gsparams.kvalue_accuracy
+    l11 = check_dep(galsim.Interpolant.from_name, 'lanczos11', tol=1.e-2)
+    assert l11.gsparams.kvalue_accuracy == 1.e-2
+    assert l11.tol == l11.gsparams.kvalue_accuracy
 
 if __name__ == "__main__":
     test_gsparams()

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -48,7 +48,28 @@ def test_phase_psf():
     check_dep(galsim.PhaseScreenPSF.__getattribute__, psf, "img")
     check_dep(galsim.PhaseScreenPSF.__getattribute__, psf, "finalized")
 
+@timer
+def test_interpolant():
+    d = check_dep(galsim.Delta, tol=1.e-2)
+    assert d.gsparams.kvalue_accuracy == 1.e-2
+    n = check_dep(galsim.Nearest, tol=1.e-2)
+    assert n.gsparams.kvalue_accuracy == 1.e-2
+    s = check_dep(galsim.SincInterpolant, tol=1.e-2)
+    assert s.gsparams.kvalue_accuracy == 1.e-2
+    l = check_dep(galsim.Linear, tol=1.e-2)
+    assert l.gsparams.kvalue_accuracy == 1.e-2
+    c = check_dep(galsim.Cubic, tol=1.e-2)
+    assert c.gsparams.kvalue_accuracy == 1.e-2
+    q = check_dep(galsim.Quintic, tol=1.e-2)
+    assert q.gsparams.kvalue_accuracy == 1.e-2
+    l3 = check_dep(galsim.Lanczos, 3, tol=1.e-2)
+    assert l3.gsparams.kvalue_accuracy == 1.e-2
+    ldc = check_dep(galsim.Lanczos, 3, False, tol=1.e-2)
+    assert ldc.gsparams.kvalue_accuracy == 1.e-2
+    l8 = check_dep(galsim.Lanczos, 8, tol=1.e-2)
+    assert l8.gsparams.kvalue_accuracy == 1.e-2
 
 if __name__ == "__main__":
     test_gsparams()
     test_phase_psf()
+    test_interpolant()

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -451,7 +451,10 @@ def test_exceptions():
 
     # Can't shoot II with SincInterpolant
     ii = galsim.InterpolatedImage(image=galsim.ImageF(5, 5, scale=1, init_value=1.),
-                                  x_interpolant='sinc')
+                                  x_interpolant='sinc',
+                                  # Use larger than normal kvalue_accuracy to avoid image being
+                                  # really huge for SincInterpolant before exception is raised.
+                                  gsparams=galsim.GSParams(kvalue_accuracy=1.e-3))
     with assert_raises(galsim.GalSimError):
         ii.drawImage(method='phot')
     with assert_raises(galsim.GalSimError):

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -382,6 +382,22 @@ def test_interpolant():
             print('Lanczos(%s,conserve_dc=True) sum = '%n,np.sum(lndc.xval(x)))
             assert np.isclose(np.sum(lndc.xval(x)), 7.0, rtol=1.e-4)
 
+            # The math for kval (at least when conserve_dc=False) is complicated, but tractable.
+            # It uses the Si function, so only test this bit if scipy is available
+            try:
+                from scipy.special import sici
+            except ImportError:
+                continue
+            vp = n * (x/np.pi + 1)
+            vm = n * (x/np.pi - 1)
+            true_kval = ( (vm-1) * sici(np.pi*(vm-1))[0]
+                         -(vm+1) * sici(np.pi*(vm+1))[0]
+                         -(vp-1) * sici(np.pi*(vp-1))[0]
+                         +(vp+1) * sici(np.pi*(vp+1))[0] ) / (2*np.pi)
+            print('tol = ',tol)
+            np.testing.assert_allclose(ln.kval(x), true_kval, rtol=1.e-4, atol=1.e-8)
+            assert np.isclose(ln.kval(x[12]), true_kval[12])
+
 
     # Base class is invalid.
     assert_raises(NotImplementedError, galsim.Interpolant)

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -368,6 +368,14 @@ def test_interpolant():
     # Base class is invalid.
     assert_raises(NotImplementedError, galsim.Interpolant)
 
+    # 2d arrays are invalid.
+    x2d = np.ones((5,5))
+    with assert_raises(galsim.GalSimValueError):
+        q.xval(x2d)
+    with assert_raises(galsim.GalSimValueError):
+        q.kval(x2d)
+
+
 @timer
 def test_fluxnorm():
     """Test that InterpolatedImage class responds properly to instructions about flux normalization.


### PR DESCRIPTION
The main thing here is to expose some of the Interpolant functions that had been confined to the C++ layer.  In particular the ability to calculate xval and kval for an array of input values.  This is Issue #1038.  We want this functionality (the xval part) for use in Piff.

Along the way, I significantly beefed up the unit testing of the Interpolant classes.  No significant bugs found, which was good.  However, I did notice that our use of the `tol` parameter isn't really consistent with the rest of GalSim.  It was basically being used the way we normally use `kvalue_accuracy`.  And the default of `1.e-4` doesn't match the default `kvalue_accuracy=1.e-5`.  Furthermore, quite a few of the classes don't even use `tol` for anything now that they have working analytic functions for everything.

So I think it makes sense to deprecate the `tol` parameter and encourage users to use `kvalue_accuracy` for this purpose instead.  So that's here too.