### PR TITLE
#1041 Fix brackeyUpper failure for Sersic galaxies with n very very close to 0.5.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ Bug Fixes
 ---------
 
 - Fixed error in `wcs.makeSkyImage` when crossing ra=0 line for some WCS classes. (#1030)
+- Fixed error in Sersic class when n is very, very close to 0.5. (#1041)

--- a/include/galsim/Solve.h
+++ b/include/galsim/Solve.h
@@ -194,7 +194,7 @@ namespace galsim {
 
             T delta = uBound-lBound;
             for (int j=1; j<maxSteps; j++) {
-                if (fupper*flower < 0.0) return;
+                if (fupper*flower <= 0.0) return;
                 if (std::abs(flower) < std::abs(fupper)) {
                     uBound = lBound;
                     fupper = flower;
@@ -219,7 +219,7 @@ namespace galsim {
             const T factor=2.0;
             T delta = b-a;
             for (int j=1; j<maxSteps; j++) {
-                if (fa*fb < 0.0) return true;
+                if (fa*fb <= 0.0) return true;
                 a = b;
                 fa = fb;
                 delta *= factor;
@@ -308,7 +308,7 @@ namespace galsim {
             xdbg<<"a,b,c = "<<a<<','<<b<<','<<c<<std::endl;
             xdbg<<"fa,fb = "<<fa<<','<<fb<<std::endl;
             for (int j=1; j<maxSteps; j++) {
-                if (fa*fb < 0.0) return true;
+                if (fa*fb <= 0.0) return true;
                 T bma = b-a; // Do this before overwriting a!
                 T cmb = c-b;
                 a = b;
@@ -381,7 +381,7 @@ namespace galsim {
             f=flower;
             fmid=fupper;
 
-            if (f*fmid >= 0.0)
+            if (f*fmid > 0.0)
                 FormatAndThrow<SolveError> () << "Root is not bracketed: " << lBound
                     << " " << uBound;
             rtb = f < 0.0 ? (dx=uBound-lBound,lBound) : (dx=lBound-uBound,uBound);

--- a/src/SBSersic.cpp
+++ b/src/SBSersic.cpp
@@ -640,6 +640,10 @@ namespace galsim {
             z = 4.*(_n+1.);  // A decent starting guess for a range of n.
             double twonm1 = 2.*_n-1.;
             double z2 = z1 + twonm1 * std::log(z) + twonm1/z + twonm1*(2.*_n-3.)/(2.*z*z);
+            // If n is very, very close to 0.5, this might not be very different.
+            // Make sure the gap is not super tiny.
+            if (z2 > z1 && z2-z1 < 0.01) z2 = z1 + 0.01;
+            else if (z2 < z1 && z2-z1 > -0.01) z2 = z1 - 0.01;
             dbg<<"Initial z from asymptotic expansion: z => "<<z2<<std::endl;
 
             // For larger n, z1 can be negative, which is bad.

--- a/tests/test_sersic.py
+++ b/tests/test_sersic.py
@@ -511,6 +511,22 @@ def test_ne():
             galsim.DeVaucouleurs(half_light_radius=1.0, gsparams=gsp)]
     all_obj_diff(gals)
 
+@timer
+def test_near_05():
+    """Test from issue #1041, where some values of n near but not exactly equal to 0.5 would
+    fail to converge in bracketUpper()
+    """
+    ser1 = galsim.Sersic(n=0.5, half_light_radius=1)
+    ser2 = galsim.Sersic(n=0.499999999999, half_light_radius=1)
+    ser3 = galsim.Sersic(n=0.500000000001, half_light_radius=1)
+
+    im1 = ser1.drawImage()
+    im2 = ser2.drawImage()
+    im3 = ser3.drawImage()
+
+    np.testing.assert_allclose(im2.array, im1.array, atol=1.e-12)
+    np.testing.assert_allclose(im3.array, im1.array, atol=1.e-12)
+
 
 if __name__ == "__main__":
     test_sersic()
@@ -519,3 +535,4 @@ if __name__ == "__main__":
     test_sersic_05()
     test_sersic_1()
     test_ne()
+    test_near_05()


### PR DESCRIPTION
When n is very very close to 0.5, the Sersic class's calculation to determine a good stepk could fail to converge.  My solution here is the just make sure the initial bracketing is at least 0.01.  With this starting point, the bracketing takes only a few iterations, and the Brent solution takes 1 step.  So I think this is a good, efficient solution for this edge case.