### PR TITLE
Updates download URL for  COSMOS dataset to Zenodo

### DIFF
--- a/galsim/download_cosmos.py
+++ b/galsim/download_cosmos.py
@@ -394,7 +394,7 @@ def main():
         target_dir = share_dir
         link = False
 
-    url = "http://great3.jb.man.ac.uk/leaderboard/data/public/COSMOS_%s_training_sample.tar.gz"%(
+    url = "https://zenodo.org/record/3242143/files/COSMOS_%s_training_sample.tar.gz"%(
             args.sample)
     file_name = os.path.basename(url)
     target = os.path.join(target_dir, file_name)


### PR DESCRIPTION
This PR simply updates the download link for the COSMOS dataset to use the Zenodo hosted copy of the data. This aims to address  #1033 and #1037 in part.

Note that I'm not digging deaper into the  download mechanism here, we may ultimately want to use something a little bit more robust that can handle download interruptions (this is the reason why the current download from Great3 server was failing, because the server could only download 1GB at a time),