### PR TITLE
#472 A few fixes for negative flux objects.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,6 +47,7 @@ New Features
 Bug Fixes
 ---------
 
+- Fixed a couple places where negative fluxes were not working correctly. (#472)
 - Fixed error in `PhaseScreenPSF` when aberrations has len=1. (#1006, #1029)
 - Fixed error in `BaseWCS.makeSkyImage` when crossing ra=0 line for some WCS classes. (#1030)
 - Fixed slight error in the realized flux of some profiles when using photon shooting.

--- a/galsim/airy.py
+++ b/galsim/airy.py
@@ -236,3 +236,8 @@ class Airy(GSObject):
     @doc_inherit
     def _drawKImage(self, image):
         self._sbp.drawK(image._image, image.scale)
+
+    @doc_inherit
+    def withFlux(self, flux):
+        return Airy(lam_over_diam=self.lam_over_diam, obscuration=self.obscuration,
+                    flux=flux, gsparams=self.gsparams)

--- a/galsim/box.py
+++ b/galsim/box.py
@@ -135,6 +135,9 @@ class Box(GSObject):
     def _drawKImage(self, image):
         self._sbp.drawK(image._image, image.scale)
 
+    @doc_inherit
+    def withFlux(self, flux):
+        return Box(width=self.width, height=self.height, flux=flux, gsparams=self.gsparams)
 
 class Pixel(Box):
     """A class describing a pixel profile.  This is just a 2D square top-hat function.
@@ -173,6 +176,10 @@ class Pixel(Box):
             s += ', flux=%s'%self.flux
         s += ')'
         return s
+
+    @doc_inherit
+    def withFlux(self, flux):
+        return Pixel(scale=self.scale, flux=flux, gsparams=self.gsparams)
 
 
 class TopHat(GSObject):
@@ -276,3 +283,7 @@ class TopHat(GSObject):
     @doc_inherit
     def _drawKImage(self, image):
         self._sbp.drawK(image._image, image.scale)
+
+    @doc_inherit
+    def withFlux(self, flux):
+        return TopHat(radius=self.radius, flux=flux, gsparams=self.gsparams)

--- a/galsim/convolve.py
+++ b/galsim/convolve.py
@@ -621,9 +621,13 @@ class Deconvolution(GSObject):
     @doc_inherit
     def _drawKImage(self, image):
         self.orig_obj._drawKImage(image)
-        do_inverse = image.array > self._min_acc_kvalue
+        do_inverse = np.abs(image.array) > self._min_acc_kvalue
         image.array[do_inverse] = 1./image.array[do_inverse]
         image.array[~do_inverse] = self._inv_min_acc_kvalue
+        kx,ky = image.get_pixel_centers()
+        ksq = (kx**2 + ky**2) * image.scale**2
+        # Set to zero outside of nominal maxk so as not to amplify high frequencies.
+        image.array[ksq > self.maxk**2] = 0.
 
     def __getstate__(self):
         d = self.__dict__.copy()

--- a/galsim/deltafunction.py
+++ b/galsim/deltafunction.py
@@ -119,3 +119,7 @@ class DeltaFunction(GSObject):
     @doc_inherit
     def _drawKImage(self, image):
         image.array[:,:] = self.flux
+
+    @doc_inherit
+    def withFlux(self, flux):
+        return DeltaFunction(flux=flux, gsparams=self.gsparams)

--- a/galsim/exponential.py
+++ b/galsim/exponential.py
@@ -163,3 +163,7 @@ class Exponential(GSObject):
     @doc_inherit
     def _drawKImage(self, image):
         self._sbp.drawK(image._image, image.scale)
+
+    @doc_inherit
+    def withFlux(self, flux):
+        return Exponential(scale_radius=self.scale_radius, flux=flux, gsparams=self.gsparams)

--- a/galsim/gaussian.py
+++ b/galsim/gaussian.py
@@ -187,3 +187,7 @@ class Gaussian(GSObject):
     @doc_inherit
     def _drawKImage(self, image):
         self._sbp.drawK(image._image, image.scale)
+
+    @doc_inherit
+    def withFlux(self, flux):
+        return Gaussian(sigma=self.sigma, flux=flux, gsparams=self.gsparams)

--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -2010,17 +2010,18 @@ class GSObject(object):
             # We want the variance to be equal to flux, so we need an extra:
             # delta Var = (1 - 4*eta + 4*eta^2) * flux
             #           = (1-2eta)^2 * flux
-            mean = eta_factor*eta_factor * flux
+            absflux = abs(flux)
+            mean = eta_factor*eta_factor * absflux
             pd = PoissonDeviate(rng, mean)
-            pd_val = pd() - mean + flux
-            ratio = pd_val / flux
+            pd_val = pd() - mean + absflux
+            ratio = pd_val / absflux
             g *= ratio
             mod_flux *= ratio
 
         if n_photons == 0.:
-            n_photons = mod_flux
+            n_photons = abs(mod_flux)
             if max_extra_noise > 0.:
-                gfactor = 1. + max_extra_noise / self.max_sb
+                gfactor = 1. + max_extra_noise / abs(self.max_sb)
                 n_photons /= gfactor
                 g *= gfactor
 

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -561,6 +561,18 @@ class Image(object):
         """
         return _Image(self.array.copy(), self.bounds, self.wcs)
 
+    def get_pixel_centers(self):
+        """A convenience function to get the x and y values at the centers of the image pixels.
+
+        Returns:
+            (x, y), each of which is a numpy array the same shape as ``self.array``
+        """
+        x,y = np.meshgrid(np.arange(self.array.shape[1], dtype=float),
+                          np.arange(self.array.shape[0], dtype=float))
+        x = x + self.bounds.xmin
+        y = y + self.bounds.ymin
+        return x, y
+
     def _make_empty(self, shape, dtype):
         """Helper function to make an empty numpy array of the given shape, making sure that
         the array is 16-btye aligned so it is usable by FFTW.
@@ -1405,9 +1417,9 @@ class Image(object):
             flux = np.sum(self.array, dtype=float)
 
         # Use radii at centers of pixels as approximation to the radial integral
-        x,y = np.meshgrid(range(self.array.shape[1]), range(self.array.shape[0]))
-        x = x - center.x + self.bounds.xmin
-        y = y - center.y + self.bounds.ymin
+        x,y = self.get_pixel_centers()
+        x -= center.x
+        y -= center.y
         rsq = x*x + y*y
 
         # Sort by radius
@@ -1471,9 +1483,9 @@ class Image(object):
             flux = np.sum(self.array, dtype=float)
 
         # Use radii at centers of pixels as approximation to the radial integral
-        x,y = np.meshgrid(range(self.array.shape[1]), range(self.array.shape[0]))
-        x = x - center.x + self.bounds.xmin
-        y = y - center.y + self.bounds.ymin
+        x,y = self.get_pixel_centers()
+        x -= center.x
+        y -= center.y
 
         if rtype in ('trace', 'both'):
             # Calculate trace measure:
@@ -1528,9 +1540,9 @@ class Image(object):
         if Imax2 > Imax: Imax = Imax2
 
         # Use radii at centers of pixels.
-        x,y = np.meshgrid(range(self.array.shape[1]), range(self.array.shape[0]))
-        x = x - center.x + self.bounds.xmin
-        y = y - center.y + self.bounds.ymin
+        x,y = self.get_pixel_centers()
+        x -= center.x
+        y -= center.y
         rsq = x*x + y*y
 
         # Sort by radius

--- a/galsim/inclined.py
+++ b/galsim/inclined.py
@@ -216,6 +216,12 @@ class InclinedExponential(GSObject):
     def _drawKImage(self, image):
         self._sbp.drawK(image._image, image.scale)
 
+    @doc_inherit
+    def withFlux(self, flux):
+        return InclinedExponential(inclination=self.inclination, scale_radius=self.scale_radius,
+                                   scale_height=self.scale_height, flux=flux,
+                                   gsparams=self.gsparams)
+
 
 class InclinedSersic(GSObject):
     r"""A class describing an inclined sersic profile. This class is general, and so for certain
@@ -464,3 +470,9 @@ class InclinedSersic(GSObject):
     @doc_inherit
     def _drawKImage(self, image):
         self._sbp.drawK(image._image, image.scale)
+
+    @doc_inherit
+    def withFlux(self, flux):
+        return InclinedSersic(n=self.n, inclination=self.inclination,
+                              scale_radius=self.scale_radius, scale_height=self.scale_height,
+                              flux=flux, trunc=self.trunc, gsparams=self.gsparams)

--- a/galsim/kolmogorov.py
+++ b/galsim/kolmogorov.py
@@ -285,3 +285,7 @@ class Kolmogorov(GSObject):
     @doc_inherit
     def _drawKImage(self, image):
         self._sbp.drawK(image._image, image.scale)
+
+    @doc_inherit
+    def withFlux(self, flux):
+        return Kolmogorov(lam_over_r0=self.lam_over_r0, flux=flux, gsparams=self.gsparams)

--- a/galsim/moffat.py
+++ b/galsim/moffat.py
@@ -226,3 +226,8 @@ class Moffat(GSObject):
     @doc_inherit
     def _drawKImage(self, image):
         self._sbp.drawK(image._image, image.scale)
+
+    @doc_inherit
+    def withFlux(self, flux):
+        return Moffat(beta=self.beta, scale_radius=self.scale_radius, trunc=self.trunc,
+                      flux=flux, gsparams=self.gsparams)

--- a/galsim/randwalk.py
+++ b/galsim/randwalk.py
@@ -340,3 +340,8 @@ class RandomWalk(GSObject):
     @doc_inherit
     def _drawKImage(self, image):
         self._sbp.drawK(image._image, image.scale)
+
+    @doc_inherit
+    def withFlux(self, flux):
+        return RandomWalk(npoints=self.npoints, profile=self.profile.withFlux(flux),
+                          gsparams=self.gsparams)

--- a/galsim/second_kick.py
+++ b/galsim/second_kick.py
@@ -245,3 +245,9 @@ class SecondKick(GSObject):
     @doc_inherit
     def _drawKImage(self, image):
         self._sbp.drawK(image._image, image.scale)
+
+    @doc_inherit
+    def withFlux(self, flux):
+        return SecondKick(lam=self.lam, r0=self.r0, diam=self.diam, obscuration=self.obscuration,
+                          kcrit=self.kcrit, flux=flux, scale_unit=self.scale_unit,
+                          gsparams=self.gsparams)

--- a/galsim/sersic.py
+++ b/galsim/sersic.py
@@ -364,6 +364,10 @@ class Sersic(GSObject):
     def _drawKImage(self, image):
         self._sbp.drawK(image._image, image.scale)
 
+    @doc_inherit
+    def withFlux(self, flux):
+        return Sersic(n=self.n, scale_radius=self.scale_radius, trunc=self.trunc, flux=flux,
+                      gsparams=self.gsparams)
 
 class DeVaucouleurs(Sersic):
     r"""A class describing DeVaucouleurs profile objects.
@@ -420,3 +424,8 @@ class DeVaucouleurs(Sersic):
             s += ', flux=%s'%self.flux
         s += ')'
         return s
+
+    @doc_inherit
+    def withFlux(self, flux):
+        return DeVaucouleurs(scale_radius=self.scale_radius, trunc=self.trunc, flux=flux,
+                             gsparams=self.gsparams)

--- a/galsim/spergel.py
+++ b/galsim/spergel.py
@@ -234,3 +234,8 @@ class Spergel(GSObject):
     @doc_inherit
     def _drawKImage(self, image):
         self._sbp.drawK(image._image, image.scale)
+
+    @doc_inherit
+    def withFlux(self, flux):
+        return Spergel(nu=self.nu, scale_radius=self.scale_radius, flux=flux,
+                       gsparams=self.gsparams)

--- a/galsim/vonkarman.py
+++ b/galsim/vonkarman.py
@@ -287,3 +287,9 @@ class VonKarman(GSObject):
     @doc_inherit
     def _drawKImage(self, image):
         self._sbp.drawK(image._image, image.scale)
+
+    @doc_inherit
+    def withFlux(self, flux):
+        return VonKarman(lam=self.lam, r0=self.r0, L0=self.L0, flux=flux,
+                         scale_unit=self.scale_unit, do_delta=self.do_delta,
+                         suppress_warning=self._suppress, gsparams=self.gsparams)

--- a/include/galsim/SBFourierSqrtImpl.h
+++ b/include/galsim/SBFourierSqrtImpl.h
@@ -71,7 +71,6 @@ namespace galsim {
 
     private:
         SBProfile _adaptee;
-        double _maxksq;
 
         void doFillKImage(ImageView<std::complex<double> > im,
                           double kx0, double dkx, int izero,

--- a/src/SBFourierSqrt.cpp
+++ b/src/SBFourierSqrt.cpp
@@ -49,9 +49,7 @@ namespace galsim {
                                                         const GSParams& gsparams) :
         SBProfileImpl(gsparams), _adaptee(adaptee)
     {
-        double maxk = maxK();
-        _maxksq = maxk*maxk;
-        dbg<<"SBFourierSqrt constructor: _maxksq = "<<_maxksq<<std::endl;
+        dbg<<"SBFourierSqrt constructor\n";
     }
 
     // xValue() not implemented for SBFourierSqrt.
@@ -60,7 +58,7 @@ namespace galsim {
 
     std::complex<double> SBFourierSqrt::SBFourierSqrtImpl::kValue(const Position<double>& k) const
     {
-        return (k.x*k.x + k.y*k.y <= _maxksq) ? std::sqrt(_adaptee.kValue(k)) : 0.;
+        return std::sqrt(_adaptee.kValue(k));
     }
 
     template <typename T>
@@ -82,10 +80,9 @@ namespace galsim {
 
         for (int j=0; j<n; ++j,ky0+=dky,ptr+=skip) {
             double kx = kx0;
-            double kysq = ky0*ky0;
             for (int i=0; i<m; ++i,kx+=dkx) {
                 std::complex<T> val = *ptr;
-                *ptr++ = (kx*kx+kysq <= _maxksq) ? std::sqrt(val) : 0.;
+                *ptr++ = std::sqrt(val);
             }
         }
     }
@@ -112,7 +109,7 @@ namespace galsim {
             double ky = ky0;
             for (int i=0; i<m; ++i,kx+=dkx) {
                 std::complex<T> val = *ptr;
-                *ptr++ = (kx*kx+ky*ky <= _maxksq) ? std::sqrt(val) : 0.;
+                *ptr++ = std::sqrt(val);
             }
         }
     }

--- a/tests/galsim_test_helpers.py
+++ b/tests/galsim_test_helpers.py
@@ -124,11 +124,11 @@ def check_basic_x(prof, name, approx_maxsb=False, scale=None):
     #print('  image = ',image[galsim.BoundsI(-2,2,-2,2)].array)
     if approx_maxsb:
         np.testing.assert_array_less(
-                image.array.max(), prof.max_sb * 1.4,
+                np.abs(image.array).max(), np.abs(prof.max_sb) * 1.4,
                 err_msg="%s profile max_sb smaller than maximum pixel value"%name)
     else:
         np.testing.assert_allclose(
-                image.array.max(), prof.max_sb, rtol=1.e-5,
+                np.abs(image.array).max(), np.abs(prof.max_sb), rtol=1.e-5,
                 err_msg="%s profile max_sb did not match maximum pixel value"%name)
     for i,j in ( (2,3), (-4,1), (0,-5), (-3,-3) ):
         x = i*dx

--- a/tests/galsim_test_helpers.py
+++ b/tests/galsim_test_helpers.py
@@ -347,6 +347,14 @@ def do_shoot(prof, img, name):
     assert img.array.max() <= prof.max_sb*dx**2 * 1.4, \
             "Photon shooting for %s produced too high max pixel."%name
 
+    # Test negative flux
+    prof = prof.withFlux(-test_flux)
+    prof.drawImage(img, n_photons=nphot, poisson_flux=False, rng=rng, method='phot')
+    print('img.sum = ',img.array.sum(dtype=float),'  cf. ',-test_flux)
+    np.testing.assert_allclose(
+            img.array.sum(dtype=float), -test_flux, rtol=rtol, atol=atol,
+            err_msg="Photon shooting normalization for %s disagrees when flux < 0"%name)
+
 
 def do_kvalue(prof, im1, name):
     """Test that the k-space values are consistent with the real-space values by drawing the

--- a/tests/galsim_test_helpers.py
+++ b/tests/galsim_test_helpers.py
@@ -143,6 +143,11 @@ def check_basic_x(prof, name, approx_maxsb=False, scale=None):
         assert prof._xValue.__doc__ == galsim.GSObject._xValue.__doc__
         assert prof.__class__._xValue.__doc__ == galsim.GSObject._xValue.__doc__
 
+    # Check negative flux:
+    neg_image = prof.withFlux(-prof.flux).drawImage(method='sb', scale=scale, use_true_center=False)
+    np.testing.assert_almost_equal(neg_image.array/prof.flux, -image.array/prof.flux, 7,
+                                   '%s negative flux drawReal is not negative of +flux image'%name)
+
     # Direct call to drawReal should also work and be equivalent to the above with scale = 1.
     prof.drawImage(image, method='sb', scale=1., use_true_center=False)
     image2 = image.copy()
@@ -195,6 +200,11 @@ def check_basic_k(prof, name):
                 err_msg="%s profile kimage does not match _kValue at %d,%d"%(name,i,j))
         assert prof._kValue.__doc__ == galsim.GSObject._kValue.__doc__
         assert prof.__class__._kValue.__doc__ == galsim.GSObject._kValue.__doc__
+
+    # Check negative flux:
+    neg_image = prof.withFlux(-prof.flux).drawKImage(kimage.copy())
+    np.testing.assert_almost_equal(neg_image.array/prof.flux, -kimage.array/prof.flux, 7,
+                                   '%s negative flux drawK is not negative of +flux image'%name)
 
     # If supposed to be axisymmetric, make sure it is in the kValues.
     if prof.is_axisymmetric:

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -1074,6 +1074,17 @@ def test_shoot():
         psf = galsim.Gaussian(sigma=3, flux=1.e-5)
         psf.drawImage(method='phot')
 
+    # Check negative flux shooting with poisson_flux=True
+    # The do_shoot test in galsim_test_helpers checks negative flux with a fixed number of photons.
+    # But we also want to check that the automatic number of photons is reaonable when the flux
+    # is negative.
+    obj = obj.withFlux(-1.e5)
+    image3 = galsim.ImageF(64,64)
+    obj.drawImage(image3, method='phot', poisson_flux=True, rng=rng)
+    print('image3.sum = ',image3.array.sum())
+    # Only accurate to about sqrt(1.e5) from Poisson realization
+    np.testing.assert_allclose(image3.array.sum(), obj.flux, rtol=0.01)
+
 
 @timer
 def test_drawImage_area_exptime():

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -258,7 +258,7 @@ def test_gaussian_radii():
     assert_raises(AttributeError, getattr, test_gal_flux1, "half_light_radius")
     assert_raises(AttributeError, getattr, test_gal_flux1, "sigma")
 
-    test_gal_flux2 = test_gal.withFlux(3.)
+    test_gal_flux2 = test_gal.withScaledFlux(3.)
     assert_raises(AttributeError, getattr, test_gal_flux2, "fwhm")
     assert_raises(AttributeError, getattr, test_gal_flux2, "half_light_radius")
     assert_raises(AttributeError, getattr, test_gal_flux2, "sigma")

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -82,6 +82,20 @@ def test_OpticalPSF_flux():
         optics_array = optics_test.drawImage(scale=.25*lod, image=image, method='no_pixel').array
         np.testing.assert_almost_equal(optics_array.sum(), 1., 2,
                 err_msg="Unaberrated Optical flux not quite unity.")
+
+        if __name__ == '__main__':
+            optics_test = galsim.OpticalPSF(lam_over_diam=lod, flux=177)
+            optics_im = optics_test.drawImage(scale=.25*lod, image=image, method='no_pixel')
+            np.testing.assert_almost_equal(optics_im.array.sum(), 1., 2,
+                    err_msg="Unaberrated Optical flux not quite unity.")
+            check_basic(optics_test, "OpticalPSF, flux=177")
+
+            optics_test = galsim.OpticalPSF(lam_over_diam=lod, flux=-17)
+            optics_im = optics_test.drawImage(scale=.25*lod, image=image, method='no_pixel')
+            np.testing.assert_almost_equal(optics_im.array.sum(), 1., 2,
+                    err_msg="Unaberrated Optical flux not quite unity.")
+            check_basic(optics_test, "OpticalPSF, flux=-17")
+
     do_pickle(optics_test, lambda x: x.drawImage(nx=20, ny=20, scale=1.7, method='no_pixel'))
     do_pickle(optics_test)
     do_pickle(optics_test._psf)

--- a/tests/test_photon_array.py
+++ b/tests/test_photon_array.py
@@ -21,9 +21,12 @@ import unittest
 import numpy as np
 import os
 import sys
+import warnings
 
 try:
-    import astroplan
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore")
+        import astroplan
     no_astroplan = False
 except ImportError:
     no_astroplan = True

--- a/tests/test_photon_array.py
+++ b/tests/test_photon_array.py
@@ -108,6 +108,14 @@ def test_photon_array():
     np.testing.assert_array_equal(photon_array.dxdz, 0.17)
     np.testing.assert_array_equal(photon_array.dydz, 0.59)
 
+    # Check shooting negative flux
+    obj = galsim.Exponential(flux=-1.7, scale_radius=2.3)
+    rng = galsim.UniformDeviate(1234)
+    neg_photon_array = obj.shoot(nphotons, rng)
+    np.testing.assert_array_equal(neg_photon_array.x, orig_x)
+    np.testing.assert_array_equal(neg_photon_array.y, orig_y)
+    np.testing.assert_array_equal(neg_photon_array.flux, -orig_flux)
+
     # Start over to check that assigning to wavelength leaves dxdz, dydz alone.
     photon_array = obj.shoot(nphotons, rng)
     photon_array.wavelength = 500.
@@ -140,6 +148,10 @@ def test_photon_array():
     np.testing.assert_almost_equal(photon_array.getTotalFlux(), 17*flux)
     photon_array.setTotalFlux(199)
     np.testing.assert_almost_equal(photon_array.getTotalFlux(), 199)
+    photon_array.scaleFlux(-1.7)
+    np.testing.assert_almost_equal(photon_array.getTotalFlux(), -1.7*199)
+    photon_array.setTotalFlux(-199)
+    np.testing.assert_almost_equal(photon_array.getTotalFlux(), -199)
 
     # Check rescaling the positions
     x = photon_array.x.copy()

--- a/tests/test_real.py
+++ b/tests/test_real.py
@@ -611,6 +611,37 @@ def test_ne():
         do_pickle(covspec1, irreprable=True)
 
 @timer
+def test_flux():
+    """ Check that setting flux and flux_rescale work properly"""
+    rgc = galsim.RealGalaxyCatalog(catalog_file, dir=image_dir)
+    psf = galsim.Gaussian(sigma=1.7)
+
+    rg1 = galsim.RealGalaxy(rgc, index=0)
+    rg2 = galsim.RealGalaxy(rgc, index=0, flux=1.7)
+    rg3 = galsim.RealGalaxy(rgc, index=0, flux=17)
+    rg4 = galsim.RealGalaxy(rgc, index=0, flux=-17)
+    rg5 = galsim.RealGalaxy(rgc, index=0, flux_rescale=1.7)
+    rg6 = galsim.RealGalaxy(rgc, index=0, flux_rescale=-17)
+
+    np.testing.assert_almost_equal(rg2.flux, 1.7)
+    np.testing.assert_almost_equal(rg3.flux, 17)
+    np.testing.assert_almost_equal(rg4.flux, -17)
+    np.testing.assert_almost_equal(rg5.flux, 1.7 * rg1.flux)
+    np.testing.assert_almost_equal(rg6.flux, -17 * rg1.flux)
+
+    check_basic(rg2, "RealGalaxy flux=1.7", approx_maxsb=True)
+    check_basic(rg3, "RealGalaxy flux=17", approx_maxsb=True)
+    check_basic(rg4, "RealGalaxy flux=-17", approx_maxsb=True)
+    check_basic(rg5, "RealGalaxy flux_rescale=1.7", approx_maxsb=True)
+    check_basic(rg6, "RealGalaxy flux_rescale=-17", approx_maxsb=True)
+
+    do_pickle(rg2)
+    do_pickle(rg3)
+    do_pickle(rg4)
+    do_pickle(rg5)
+    do_pickle(rg6)
+
+@timer
 def test_noise():
     """Check consistency of noise-related routines."""
     # The RealGalaxyCatalog.getNoise() routine should be tested to ensure consistency of results
@@ -928,6 +959,7 @@ if __name__ == "__main__":
     test_crg_roundtrip()
     test_crg_roundtrip_larger_target_psf()
     test_ne()
+    test_flux()
     test_noise()
     test_area_norm()
     test_crg_noise_draw_transform_commutativity()


### PR DESCRIPTION
A long time ago, @dkirkby had noticed that it was sometimes useful to draw objects with negative flux, and that GalSim basically did the right thing with negative fluxes.  The one exception was photon shooting (with `poisson_flux=True`) where it complained that it couldn't figure out how many photons to draw.

This issue mostly adds new tests that negative flux does in fact work correctly.  There were only a few places where it didn't:

1. The aforementioned poisson calculation for the number of photons needed to be fixed to work with negative fluxes.  Now the poisson mean is based on the absolute value of the flux.
2. InterpolatedImage's calculation of stepk implicitly assumed positive total flux, so that is now fixed.
3. Deconvolve and FourierSqrt were nominally ok, but they did slightly asymmetric things for + and - flux, since one was the python layer implementation and the other was in C++.  I reconciled them to do the same thing in both layers.

I think this is the last issue I want to include in 2.2.