### PR TITLE
Fix horner and horner2d for complex inputs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,3 +22,4 @@ New Features
 Bug Fixes
 ---------
 
+- Fixed horner and horner2d when inputs are complex. (#1054)

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -659,8 +659,10 @@ def horner(x, coef, dtype=None):
     return result
 
 def _horner(x, coef, result):
-    """Equivalent to `horner`, but ``x``, ``coeff``, and ``result`` must be contiguous arrays
-    with dtype == float.
+    """Equivalent to `horner`, but ``x``, ``coef``, and ``result`` must be contiguous arrays.
+
+    In particular, ``result`` must be already allocated as an array in which to put the answer.
+    This is the thing that is returned from the regular `horner`.
 
     Parameters:
         x:      A numpy array of values at which to evaluate the polynomial.
@@ -710,7 +712,7 @@ def horner2d(x, y, coefs, dtype=None, triangle=False):
         coefs = np.array(coefs, copy=False)
 
     if x.shape != y.shape:
-        raise GalSimIncompatibleValuesError("x and y are not the same size", x=x, y=y)
+        raise GalSimIncompatibleValuesError("x and y are not the same shape", x=x, y=y)
     if len(coefs.shape) != 2:
         raise GalSimValueError("coefs must be 2-dimensional", coefs)
     if triangle and coefs.shape[0] != coefs.shape[1]:
@@ -720,8 +722,12 @@ def horner2d(x, y, coefs, dtype=None, triangle=False):
     return result
 
 def _horner2d(x, y, coefs, result, temp, triangle=False):
-    """Equivalent to `horner2d`, but ``x``, ``y``, ``coeff``, ``result``, and ``temp``
-    must be contiguous arrays with dtype == float.
+    """Equivalent to `horner2d`, but ``x``, ``y``, ``coefs``, ``result``, and ``temp``
+    must be contiguous arrays.
+
+    In particular, ``result`` must be already allocated as an array in which to put the answer.
+    This is the thing that is returned from the regular `horner`.  In addition, ``temp`` must
+    be allocated for the function to use as temporary work space.
 
     Parameters:
         x:          A numpy array of the x values at which to evaluate the polynomial.

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -651,8 +651,8 @@ def horner(x, coef, dtype=None):
         x = np.ascontiguousarray(x, dtype=float)
         coef = np.ascontiguousarray(coef, dtype=float)
     else:
-        x = np.array(x, copy=False, dtype=float)
-        coef = np.array(coef, copy=False, dtype=float)
+        x = np.array(x, copy=False)
+        coef = np.array(coef, copy=False)
     if len(coef.shape) != 1:
         raise GalSimValueError("coef must be 1-dimensional", coef)
     _horner(x, coef, result)
@@ -705,13 +705,12 @@ def horner2d(x, y, coefs, dtype=None, triangle=False):
         y = np.ascontiguousarray(y, dtype=float)
         coefs = np.ascontiguousarray(coefs, dtype=float)
     else:
-        x = np.array(x, copy=False, dtype=float)
-        y = np.array(y, copy=False, dtype=float)
-        coefs = np.array(coefs, copy=False, dtype=float)
+        x = np.array(x, copy=False)
+        y = np.array(y, copy=False)
+        coefs = np.array(coefs, copy=False)
 
-    if len(x) != len(y):
-        raise GalSimIncompatibleValuesError("x and y are not the same size",
-                                            x=x, y=y)
+    if x.shape != y.shape:
+        raise GalSimIncompatibleValuesError("x and y are not the same size", x=x, y=y)
     if len(coefs.shape) != 2:
         raise GalSimValueError("coefs must be 2-dimensional", coefs)
     if triangle and coefs.shape[0] != coefs.shape[1]:

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1258,6 +1258,77 @@ def test_horner2d():
     with assert_raises(galsim.GalSimIncompatibleValuesError):
         galsim.utilities.horner2d(x, y[:10], coef)
 
+@timer
+def test_horner_complex():
+    # Make a random 2d polynomial
+    rcoef = [ [1.2332, 3.4324, 4.1231, -0.2342, 0.4242],
+              [-0.2341, 1.4689, 3.5322, -1.0039, 0.02142],
+              [4.02342, -2.2352, 0.1414, 2.9352, -1.3521] ]
+    icoef = [ [0.1234, -5.4324, 6.12345, 3.9393, -0.7373],
+              [-0.9999, 1.7655, -5.2344, -1.1111, 5.3432],
+              [-1.2345, 3.2130, -4.4444, 0.3242, -8.0013] ]
+    rcoef = np.array(rcoef)
+    icoef = np.array(icoef)
+    coef = rcoef + 1j * icoef
+
+    # Make a random list of values to test
+    rx = np.empty(20)
+    ry = np.empty(20)
+    rng = galsim.UniformDeviate(1234)
+    rng.generate(rx)
+    rng.generate(ry)
+
+    ix = np.empty(20)
+    iy = np.empty(20)
+    rng = galsim.UniformDeviate(1234)
+    rng.generate(ix)
+    rng.generate(iy)
+
+    x = rx + 1j*ix
+    y = ry + 1j*iy
+
+    # Check all combinations of which things are complex and which are real.
+    # First, just 1 of the three complex:
+    result = galsim.utilities.horner2d(rx, ry, coef, dtype=complex)
+    np.testing.assert_almost_equal(result, np.polynomial.polynomial.polyval2d(rx, ry, coef))
+
+    result = galsim.utilities.horner2d(rx, y, rcoef, dtype=complex)
+    np.testing.assert_almost_equal(result, np.polynomial.polynomial.polyval2d(rx, y, rcoef))
+
+    result = galsim.utilities.horner2d(x, ry, rcoef, dtype=complex)
+    np.testing.assert_almost_equal(result, np.polynomial.polynomial.polyval2d(x, ry, rcoef))
+
+    # Now two complex:
+    result = galsim.utilities.horner2d(rx, y, coef, dtype=complex)
+    np.testing.assert_almost_equal(result, np.polynomial.polynomial.polyval2d(rx, y, coef))
+
+    result = galsim.utilities.horner2d(x, ry, coef, dtype=complex)
+    np.testing.assert_almost_equal(result, np.polynomial.polynomial.polyval2d(x, ry, coef))
+
+    result = galsim.utilities.horner2d(x, y, rcoef, dtype=complex)
+    np.testing.assert_almost_equal(result, np.polynomial.polynomial.polyval2d(x, y, rcoef))
+
+    # All three complex
+    result = galsim.utilities.horner2d(x, y, coef, dtype=complex)
+    np.testing.assert_almost_equal(result, np.polynomial.polynomial.polyval2d(x, y, coef))
+
+    # Check scalar complex x, y
+    result = galsim.utilities.horner2d(3.9+2.1j, 1.7-0.9j, coef, dtype=complex)
+    np.testing.assert_almost_equal(result, np.polynomial.polynomial.polyval2d(
+            [3.9+2.1j],[1.7-0.9j],coef))
+
+    # Repeast for 1d
+    result = galsim.utilities.horner(rx, coef[0], dtype=complex)
+    np.testing.assert_almost_equal(result, np.polynomial.polynomial.polyval(rx, coef[0]))
+
+    result = galsim.utilities.horner(x, rcoef[0], dtype=complex)
+    np.testing.assert_almost_equal(result, np.polynomial.polynomial.polyval(x, rcoef[0]))
+
+    result = galsim.utilities.horner(x, coef[0], dtype=complex)
+    np.testing.assert_almost_equal(result, np.polynomial.polynomial.polyval(x, coef[0]))
+
+    result = galsim.utilities.horner(3.9+2.1j, coef[0], dtype=complex)
+    np.testing.assert_almost_equal(result, np.polynomial.polynomial.polyval([3.9+2.1j],coef[0]))
 
 if __name__ == "__main__":
     test_pos()
@@ -1278,3 +1349,4 @@ if __name__ == "__main__":
     test_nCr()
     test_horner()
     test_horner2d()
+    test_horner_complex()


### PR DESCRIPTION
I just discovered that our horner and horner2d functions had a bug when the inputs are complex.

Basically, it was recasting them to float for no good reason.  I guess maybe thinking to recast int or float32 arrays to float, but I don't think that's actually necessary, so better to not bother about that.  Anyway, fixed here.