### PR TITLE
Add _force_stepk to VonKarman

### DIFF
--- a/include/galsim/LRUCache.h
+++ b/include/galsim/LRUCache.h
@@ -26,8 +26,8 @@
 namespace galsim {
 
     // A very simple tuple class that just does what we need for the LRUCache.
-    // It can hold up to a maximum of 4 parameters.
-    template <typename T1, typename T2=int, typename T3=int, typename T4=int>
+    // It can hold up to a maximum of 5 parameters.
+    template <typename T1, typename T2=int, typename T3=int, typename T4=int, typename T5=int>
     class Tuple
     {
     public:
@@ -35,15 +35,20 @@ namespace galsim {
         T2 second;
         T3 third;
         T4 fourth;
+        T5 fifth;
 
-        Tuple(const T1& a) : first(a), second(0), third(0), fourth(0) {}
-        Tuple(const T1& a, const T2& b) : first(a), second(b), third(0), fourth(0) {}
-        Tuple(const T1& a, const T2& b, const T3& c) : first(a), second(b), third(c), fourth(0) {}
+        Tuple(const T1& a) : first(a), second(0), third(0), fourth(0), fifth(0) {}
+        Tuple(const T1& a, const T2& b) : first(a), second(b), third(0), fourth(0), fifth(0) {}
+        Tuple(const T1& a, const T2& b, const T3& c) :
+            first(a), second(b), third(c), fourth(0), fifth(0) {}
         Tuple(const T1& a, const T2& b, const T3& c, const T4& d) :
-            first(a), second(b), third(c), fourth(d) {}
+            first(a), second(b), third(c), fourth(d), fifth(0) {}
+        Tuple(const T1& a, const T2& b, const T3& c, const T4& d, const T5& e) :
+            first(a), second(b), third(c), fourth(d), fifth(e) {}
 
         Tuple(const Tuple& rhs) :
-            first(rhs.first), second(rhs.second), third(rhs.third), fourth(rhs.fourth) {}
+            first(rhs.first), second(rhs.second), third(rhs.third), fourth(rhs.fourth),
+            fifth(rhs.fifth) {}
 
         Tuple& operator=(const Tuple& rhs)
         {
@@ -52,6 +57,7 @@ namespace galsim {
                 second = rhs.second;
                 third = rhs.third;
                 fourth = rhs.fourth;
+                fifth = rhs.fifth;
             }
             return *this;
         }
@@ -66,6 +72,8 @@ namespace galsim {
                 third < rhs.third ? true :
                 rhs.third < third ? false :
                 fourth < rhs.fourth ? true :
+                rhs.fourth < fourth ? false :
+                fifth < rhs.fifth ? true :
                 false);
         }
     };
@@ -82,6 +90,9 @@ namespace galsim {
     template <typename T1, typename T2, typename T3, typename T4>
     Tuple<T1,T2,T3,T4> MakeTuple(const T1& a, const T2& b, const T3& c, const T4& d)
     { return Tuple<T1,T2,T3,T4>(a,b,c,d); }
+    template <typename T1, typename T2, typename T3, typename T4, typename T5>
+    Tuple<T1,T2,T3,T4,T5> MakeTuple(const T1& a, const T2& b, const T3& c, const T4& d, const T5& e)
+    { return Tuple<T1,T2,T3,T4,T5>(a,b,c,d,e); }
 
     // Helper to build a Value from a Key
     // Normal case is that the Value take Key as a single parameter
@@ -120,6 +131,16 @@ namespace galsim {
         static Value* NewValue(const Tuple<Key1,Key2,Key3,Key4>& key)
         {
             return new Value(key.first, key.second, key.third, key.fourth);
+        }
+    };
+
+    template <typename Value, typename Key1, typename Key2, typename Key3, typename Key4,
+              typename Key5>
+    struct LRUCacheHelper<Value,Tuple<Key1,Key2,Key3,Key4,Key5> >
+    {
+        static Value* NewValue(const Tuple<Key1,Key2,Key3,Key4,Key5>& key)
+        {
+            return new Value(key.first, key.second, key.third, key.fourth, key.fifth);
         }
     };
 

--- a/include/galsim/SBVonKarman.h
+++ b/include/galsim/SBVonKarman.h
@@ -48,7 +48,8 @@ namespace galsim {
          * @param[in] gsparams     GSParams.
          */
         SBVonKarman(double lam, double r0, double L0, double flux,
-                    double scale, bool doDelta, const GSParams& gsparams);
+                    double scale, bool doDelta, const GSParams& gsparams,
+                    double force_stepk);
 
         /// @brief Copy constructor
         SBVonKarman(const SBVonKarman& rhs);

--- a/include/galsim/SBVonKarmanImpl.h
+++ b/include/galsim/SBVonKarmanImpl.h
@@ -44,7 +44,10 @@ namespace galsim {
 
         ~VonKarmanInfo() {}
 
-        double stepK() const { return _stepk; }
+        double stepK() const {
+            if(_stepk == 0.0) _buildRadialFunc();
+            return _stepk;
+        }
         double maxK() const { return _maxk; }
         double getDelta() const { return _delta; }
         double getHalfLightRadius() const {

--- a/pysrc/SBVonKarman.cpp
+++ b/pysrc/SBVonKarman.cpp
@@ -25,7 +25,7 @@ namespace galsim {
     void pyExportSBVonKarman(PY_MODULE& _galsim)
     {
         py::class_<SBVonKarman, BP_BASES(SBProfile)>(GALSIM_COMMA "SBVonKarman" BP_NOINIT)
-            .def(py::init<double,double,double,double,double,bool,GSParams>())
+            .def(py::init<double,double,double,double,double,bool,GSParams,double>())
             .def("getDelta", &SBVonKarman::getDelta)
             .def("getHalfLightRadius", &SBVonKarman::getHalfLightRadius)
             .def("structureFunction", &SBVonKarman::structureFunction)

--- a/src/SBVonKarman.cpp
+++ b/src/SBVonKarman.cpp
@@ -129,12 +129,12 @@ namespace galsim {
                                  const GSParamsPtr& gsparams, double force_stepk) :
         _lam(lam), _L0(L0),
         _L0_invcuberoot(fast_pow(_L0, -1./3)), _L053(fast_pow(L0, 5./3)),
-        _stepk(0.0), _maxk(0.0),
+        _stepk(force_stepk), _maxk(0.0),
         _delta(exp(-0.5*magic1*_L053)),
         _deltaScale(1./(1.-_delta)),
         _lam_arcsec(_lam * ARCSEC2RAD / (2.*M_PI)),
         _doDelta(doDelta), _gsparams(gsparams),
-        _radial(Table::spline), _sampler(nullptr)
+        _radial(Table::spline)
     {
         // determine maxK
         // want kValue(maxK)/kValue(0.0) = _gsparams->maxk_threshold;
@@ -160,12 +160,6 @@ namespace galsim {
         dbg<<"_maxk = "<<_maxk<<" arcsec^-1\n";
         dbg<<"SB(maxk) = "<<kValue(_maxk)<<'\n';
         dbg<<"_delta = "<<_delta<<'\n';
-
-        // build the radial function, and along the way, set _stepk, _hlr.
-        if (force_stepk == 0.0)
-            _buildRadialFunc();
-        else
-            _stepk = force_stepk;
     }
 
     double vkStructureFunction(double rho, double L0, double L0_invcuberoot, double L053) {

--- a/tests/test_vonkarman.py
+++ b/tests/test_vonkarman.py
@@ -169,7 +169,7 @@ def test_vk_ne():
             galsim.VonKarman(lam=550.0, r0=0.1, L0=20.0, do_delta=True),
             galsim.VonKarman(lam=550.0, r0=0.1, L0=20.0, scale_unit=galsim.arcmin),
             galsim.VonKarman(lam=550.0, r0=0.1, L0=20.0, gsparams=gsp),
-            galsim.VonKarman(lam=550.0, r0=0.1, L0=20.0, gsparams=gsp, _force_stepk=1.0)]
+            galsim.VonKarman(lam=550.0, r0=0.1, L0=20.0, gsparams=gsp, force_stepk=1.0)]
     all_obj_diff(objs)
 
 
@@ -287,7 +287,7 @@ def test_vk_r0():
 def test_vk_force_stepk():
     """Check that manually forcing stepk works"""
     vk1 = galsim.VonKarman(r0_500=0.1, L0=25.0, lam=750.0)
-    vk2 = galsim.VonKarman(r0_500=0.1, L0=25.0, lam=750.0, _force_stepk=10.0)
+    vk2 = galsim.VonKarman(r0_500=0.1, L0=25.0, lam=750.0, force_stepk=10.0)
 
     # Make sure we get expected stepk
     assert vk1.stepk != vk2.stepk
@@ -318,11 +318,16 @@ def test_vk_force_stepk():
 
     # Check works with scale
     vk3 = galsim.VonKarman(
-        r0_500=0.1, L0=25.0, lam=750.0, _force_stepk=10.0,
+        r0_500=0.1, L0=25.0, lam=750.0, force_stepk=10.0,
         scale_unit=galsim.radians
     )
     assert vk3.stepk == 10.0
     assert vk3.scale_unit == galsim.radians
+
+    # force_stepk is retained through a reflux
+    vk4 = vk3.withFlux(11.0)
+    assert vk4.flux == 11.0
+    assert vk3.force_stepk == vk4.force_stepk
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds undocumented `_force_stepk` kwarg to `VonKarman`.  If present, then calculation of real-space profile is delayed until needed by photon shooting, `getHalfLightRadius`, or `xValue`.  

I decided that in the case where the table build is triggered, it was simplest to repeat exactly the same calculation as if `_force_stepk` was not specified.  The only difference is that `_stepk` is not updated from its previously forced value.

Most functionality is therefore the same between the forced and unforced version of `VonKarman`, with the notable exceptions of speed for the create-through-drawFFT cycle, and `getGoodImageSize`.

In the Piff atmospheric PSF fitting context, using `_force_stepk` leads to a 10x speed improvement.