### PR TITLE
Clean up OpticalPSF repr

### DIFF
--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -1830,11 +1830,10 @@ class OpticalPSF(GSObject):
                     lam_over_diam=lam_over_diam, lam=lam, diam=diam)
 
         # Make the optical screen.
-        optics_screen = OpticalScreen(
+        self._screen = OpticalScreen(
                 diam=diam, defocus=defocus, astig1=astig1, astig2=astig2, coma1=coma1, coma2=coma2,
                 trefoil1=trefoil1, trefoil2=trefoil2, spher=spher, aberrations=aberrations,
                 obscuration=obscuration, annular_zernike=annular_zernike, lam_0=lam)
-        self._screens = PhaseScreenList(optics_screen)
 
         # Make the aperture.
         if aper is None:
@@ -1864,7 +1863,7 @@ class OpticalPSF(GSObject):
 
     @lazy_property
     def _psf(self):
-        psf = PhaseScreenPSF(self._screens, lam=self._lam, flux=self._flux,
+        psf = PhaseScreenPSF(PhaseScreenList(self._screen), lam=self._lam, flux=self._flux,
                              aper=self._aper, interpolant=self._interpolant,
                              scale_unit=self._scale_unit, gsparams=self._gsparams,
                              suppress_warning=self._suppress_warning,
@@ -1875,7 +1874,7 @@ class OpticalPSF(GSObject):
         return psf
 
     def __str__(self):
-        screen = self._psf.screen_list[0]
+        screen = self._screen
         s = "galsim.OpticalPSF(lam=%s, diam=%s" % (screen.lam_0, self._aper.diam)
         if any(screen.aberrations):
             s += ", aberrations=[" + ",".join(str(ab) for ab in screen.aberrations) + "]"
@@ -1890,7 +1889,7 @@ class OpticalPSF(GSObject):
         return s
 
     def __repr__(self):
-        screen = self._psf.screen_list[0]
+        screen = self._screen
         s = "galsim.OpticalPSF(lam=%r, diam=%r" % (self._lam, self._aper.diam)
         s += ", aper=%r"%self._aper
         if any(screen.aberrations):
@@ -1920,7 +1919,7 @@ class OpticalPSF(GSObject):
                 (isinstance(other, OpticalPSF) and
                  self._lam == other._lam and
                  self._aper == other._aper and
-                 self._psf.screen_list == other._psf.screen_list and
+                 self._screen == other._screen and
                  self._flux == other._flux and
                  self._interpolant == other._interpolant and
                  self._scale_unit == other._scale_unit and
@@ -1930,7 +1929,7 @@ class OpticalPSF(GSObject):
                  self._gsparams == other._gsparams))
 
     def __hash__(self):
-        return hash(("galsim.OpticalPSF", self._lam, self._aper, self._psf.screen_list[0],
+        return hash(("galsim.OpticalPSF", self._lam, self._aper, self._screen,
                      self._flux, self._interpolant, self._scale_unit, self._force_stepk,
                      self._force_maxk, self._ii_pad_factor, self._gsparams))
 
@@ -1994,7 +1993,7 @@ class OpticalPSF(GSObject):
 
     @doc_inherit
     def withFlux(self, flux):
-        screen = self._psf.screen_list[0]
+        screen = self._screen
         return OpticalPSF(
                 lam=self._lam, diam=self._aper.diam, aper=self._aper,
                 aberrations=screen.aberrations, annular_zernike=screen.annular_zernike,

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -1898,6 +1898,8 @@ class OpticalPSF(GSObject):
         if screen.annular_zernike:
             s += ", annular_zernike=True"
             s += ", obscuration=%r"%self.obscuration
+        if self._interpolant != None:
+            s += ", interpolant=%r"%self._interpolant
         if self._flux != 1.0:
             s += ", flux=%r" % self._flux
         if self._force_stepk != 0.:

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -1900,6 +1900,8 @@ class OpticalPSF(GSObject):
             s += ", obscuration=%r"%self.obscuration
         if self._interpolant != None:
             s += ", interpolant=%r"%self._interpolant
+        if self._scale_unit != arcsec:
+            s += ", scale_unit=%r"%self._scale_unit
         if self._flux != 1.0:
             s += ", flux=%r" % self._flux
         if self._force_stepk != 0.:

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -1876,11 +1876,11 @@ class OpticalPSF(GSObject):
 
     def __str__(self):
         screen = self._psf.screen_list[0]
-        s = "galsim.OpticalPSF(lam=%s, diam=%s" % (screen.lam_0, self._psf.aper.diam)
+        s = "galsim.OpticalPSF(lam=%s, diam=%s" % (screen.lam_0, self._aper.diam)
         if any(screen.aberrations):
             s += ", aberrations=[" + ",".join(str(ab) for ab in screen.aberrations) + "]"
-        if self._psf.aper._pupil_plane_im is None:
-            s += self._psf.aper._geometry_str()
+        if self._aper._pupil_plane_im is None:
+            s += self._aper._geometry_str()
         if screen.annular_zernike:
             s += ", annular_zernike=True"
             s += ", obscuration=%r"%self.obscuration
@@ -1891,8 +1891,8 @@ class OpticalPSF(GSObject):
 
     def __repr__(self):
         screen = self._psf.screen_list[0]
-        s = "galsim.OpticalPSF(lam=%r, diam=%r" % (self._lam, self._psf.aper.diam)
-        s += ", aper=%r"%self._psf.aper
+        s = "galsim.OpticalPSF(lam=%r, diam=%r" % (self._lam, self._aper.diam)
+        s += ", aper=%r"%self._aper
         if any(screen.aberrations):
             s += ", aberrations=[" + ",".join(repr(ab) for ab in screen.aberrations) + "]"
         if screen.annular_zernike:
@@ -1902,6 +1902,8 @@ class OpticalPSF(GSObject):
             s += ", interpolant=%r"%self._interpolant
         if self._scale_unit != arcsec:
             s += ", scale_unit=%r"%self._scale_unit
+        if self._gsparams != GSParams():
+            s += ", gsparams=%r"%self._gsparams
         if self._flux != 1.0:
             s += ", flux=%r" % self._flux
         if self._force_stepk != 0.:
@@ -1994,7 +1996,7 @@ class OpticalPSF(GSObject):
     def withFlux(self, flux):
         screen = self._psf.screen_list[0]
         return OpticalPSF(
-                lam=self._lam, diam=self._psf.aper.diam, aper=self._psf.aper,
+                lam=self._lam, diam=self._aper.diam, aper=self._aper,
                 aberrations=screen.aberrations, annular_zernike=screen.annular_zernike,
                 flux=flux, _force_stepk=self._force_stepk, _force_maxk=self._force_maxk,
                 ii_pad_factor=self._ii_pad_factor)

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -104,6 +104,9 @@ def test_OpticalPSF_flux():
     interpolant_test = galsim.OpticalPSF(lam_over_diam=4., interpolant='linear')
     do_pickle(interpolant_test)
 
+    scale_unit_test = galsim.OpticalPSF(lam_over_diam=4., scale_unit=galsim.arcmin)
+    do_pickle(scale_unit_test)
+
 
 @timer
 def test_OpticalPSF_vs_Airy():

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -101,6 +101,9 @@ def test_OpticalPSF_flux():
     check_basic(optics_test, "OpticalPSF")
     assert optics_test._screens.r0_500_effective is None
 
+    interpolant_test = galsim.OpticalPSF(lam_over_diam=4., interpolant='linear')
+    do_pickle(interpolant_test)
+
 
 @timer
 def test_OpticalPSF_vs_Airy():

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -107,6 +107,9 @@ def test_OpticalPSF_flux():
     scale_unit_test = galsim.OpticalPSF(lam_over_diam=4., scale_unit=galsim.arcmin)
     do_pickle(scale_unit_test)
 
+    gsparams_test = optics_test.withGSParams(galsim.GSParams(minimum_fft_size=64))
+    do_pickle(gsparams_test)
+
 
 @timer
 def test_OpticalPSF_vs_Airy():

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -100,6 +100,7 @@ def test_OpticalPSF_flux():
     do_pickle(optics_test._psf, lambda x: x.drawImage(nx=20, ny=20, scale=1.7, method='no_pixel'))
     check_basic(optics_test, "OpticalPSF")
     assert optics_test._psf._screen_list.r0_500_effective is None
+    assert optics_test._screen == optics_test._psf.screen_list[0]
 
     interpolant_test = galsim.OpticalPSF(lam_over_diam=4., interpolant='linear')
     do_pickle(interpolant_test)
@@ -399,18 +400,6 @@ def test_OpticalPSF_flux_scaling():
         err_msg="Flux param inconsistent after __div__ (result).")
 
 
-try:
-    from contextlib import ExitStack
-except ImportError:
-    # ExitStack was introduced in python 3.3, so need to do something else in python 2.7.
-    # Really just need a dummy context manager, not the real ExitStack, so this is vv simple.
-    class ExitStack():
-        def __enter__(self):
-            return None
-        def __exit__(self, exc_type, exc_value, traceback):
-            return False
-
-
 @timer
 def test_OpticalPSF_pupil_plane():
     """Test the ability to generate a PSF using an image of the pupil plane.
@@ -479,9 +468,10 @@ def test_OpticalPSF_pupil_plane():
         do_pickle(test_psf)
 
     # Make a smaller pupil plane image to test the pickling of this, even without slow tests.
-    with assert_warns(galsim.GalSimWarning) if not do_slow_tests else ExitStack():
+    factor = 4 if not do_slow_tests else 16
+    with assert_warns(galsim.GalSimWarning):
         alt_psf = galsim.OpticalPSF(lam_over_diam, obscuration=obscuration,
-                                    oversampling=1., pupil_plane_im=im.bin(4,4),
+                                    oversampling=1., pupil_plane_im=im.bin(factor,factor),
                                     pad_factor=1.)
         do_pickle(alt_psf)
 

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -99,7 +99,7 @@ def test_OpticalPSF_flux():
     do_pickle(optics_test._psf)
     do_pickle(optics_test._psf, lambda x: x.drawImage(nx=20, ny=20, scale=1.7, method='no_pixel'))
     check_basic(optics_test, "OpticalPSF")
-    assert optics_test._screens.r0_500_effective is None
+    assert optics_test._psf._screen_list.r0_500_effective is None
 
     interpolant_test = galsim.OpticalPSF(lam_over_diam=4., interpolant='linear')
     do_pickle(interpolant_test)


### PR DESCRIPTION
Addresses #1061 .  Adds and tests a few more variants of OpticalPSF and specifically how it `obj == eval(repr(obj))` round trips.