### PR TITLE
#1064 Fix bug in RandomKnots when multiplying by an SED

### DIFF
--- a/galsim/knots.py
+++ b/galsim/knots.py
@@ -305,8 +305,11 @@ class RandomKnots(GSObject):
 
     @doc_inherit
     def withScaledFlux(self, flux_ratio):
-        return RandomKnots(self._npoints, profile=self._profile.withScaledFlux(flux_ratio),
-                           rng=self._orig_rng.duplicate(), gsparams=self._gsparams)
+        if hasattr(flux_ratio, '__call__'):
+            return GSObject.withScaledFlux(self, flux_ratio)
+        else:
+            return RandomKnots(self._npoints, profile=self._profile.withScaledFlux(flux_ratio),
+                               rng=self._orig_rng.duplicate(), gsparams=self._gsparams)
 
     @doc_inherit
     def expand(self, scale):

--- a/tests/test_knots.py
+++ b/tests/test_knots.py
@@ -408,6 +408,17 @@ def test_knots_transform():
         test_op(rw, 'magnify(1.2)')
         test_op(rw, 'lens(0.03, 0.07, 1.12)')
 
+@timer
+def test_knots_sed():
+    """Test RandomKnots with an SED
+
+    This test is in response to isse #1064, a bug discovered by Troxel.
+    """
+    sed = galsim.SED('CWW_E_ext.sed', 'A', 'flambda')
+    knots = galsim.RandomKnots(10, half_light_radius=1.3, flux=100)
+    gal = knots * sed  # This line used to fail.
+    do_pickle(gal)
+
 
 if __name__ == "__main__":
     test_knots_defaults()
@@ -417,3 +428,4 @@ if __name__ == "__main__":
     test_knots_config()
     test_knots_hlr()
     test_knots_transform()
+    test_knots_sed()

--- a/tests/test_knots.py
+++ b/tests/test_knots.py
@@ -416,8 +416,19 @@ def test_knots_sed():
     """
     sed = galsim.SED('CWW_E_ext.sed', 'A', 'flambda')
     knots = galsim.RandomKnots(10, half_light_radius=1.3, flux=100)
-    gal = knots * sed  # This line used to fail.
-    do_pickle(gal)
+    gal1 = galsim.ChromaticObject(knots) * sed
+    gal2 = knots * sed  # This line used to fail.
+    do_pickle(gal1)
+    do_pickle(gal2)
+
+    # They don't test as ==, since they are formed differently.  But they are functionally equal:
+    bandpass = galsim.Bandpass('LSST_r.dat', 'nm')
+    psf = galsim.Gaussian(fwhm=0.7)
+    final1 = galsim.Convolve(gal1, psf)
+    final2 = galsim.Convolve(gal2, psf)
+    im1 = final1.drawImage(bandpass, scale=0.4)
+    im2 = final2.drawImage(bandpass, scale=0.4)
+    np.testing.assert_array_equal(im1.array, im2.array)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The optimizations to RandomKnots done in #1051 introduced a bug when a RandomKnots object is multiplied by an SED.  The bug was discovered by @matroxel and @masayamn and reported in issue #1064.

The solution implemented here is to check for this and call back to the GSObject implementation in that case.