### PR TITLE
Add Refraction surface op

### DIFF
--- a/galsim/__init__.py
+++ b/galsim/__init__.py
@@ -130,7 +130,7 @@ from .errors import GalSimWarning, GalSimDeprecationWarning
 from .image import Image, ImageS, ImageI, ImageF, ImageD, ImageCF, ImageCD, ImageUS, ImageUI, _Image
 
 # PhotonArray
-from .photon_array import PhotonArray, WavelengthSampler, FRatioAngles, PhotonDCR
+from .photon_array import PhotonArray, WavelengthSampler, FRatioAngles, PhotonDCR, Refraction
 
 # Noise
 from .random import BaseDeviate, UniformDeviate, GaussianDeviate, PoissonDeviate, DistDeviate

--- a/galsim/photon_array.py
+++ b/galsim/photon_array.py
@@ -673,7 +673,34 @@ class Refraction(object):
             index_ratio = self.index_ratio(photon_array.wavelength)
         else:
             index_ratio = self.index_ratio
-        normsqr = 1 + photon_array.dxdz**2 + photon_array.dydz**2
+        # Here's the math avoiding any actual trig function calls:
+        #
+        #        x1 = dr/dz
+        #        ------+
+        #         \    |
+        #          \   |
+        #           \  |  dz/dz = 1
+        #            \ |
+        #             \|         n1
+        #  ------------------------
+        #              |\        n2
+        #              |\
+        # dz'/dz' = 1  | \
+        #              | \
+        #              |  \
+        #              +---
+        #              x2 = dr'/dz'
+        #
+        # Solve Snell's law for x2 as fn of x1:
+        #   n1 sin(th1) = n2 sin(th2)
+        #   n1 x1 / sqrt(1 + x1^2) = n2 x2 / sqrt(1 + x2^2)
+        #   n1^2 x1^2 (1 + x2^2) = n2^2 x2^2 (1 + x1^2)
+        #   n1^2 x1^2 = x2^2 (n2^2 (1 + x1^2) - n1^2 x1^2)
+        #   x1^2 = x2^2 ((n2/n1)^2 (1 + x1^2) - x1^2)
+        #   x1 = x2 sqrt( (n2/n1)^2 (1 + x1^2) - x1^2 )
+        #      = x2 sqrt( (n2/n1)^2 (1 + x1^2) - (1 + x1^2) + 1 )
+        #      = x2 sqrt( 1 - (1 + x1^2) (1 - (n2/n1)^2) )
+        normsqr = 1 + photon_array.dxdz**2 + photon_array.dydz**2  # (1 + x1^2)
         with np.errstate(invalid='ignore'):
             # NaN below <=> total internal reflection
             factor = np.sqrt(1 - normsqr*(1-index_ratio**2))


### PR DESCRIPTION
Adds Refraction surface operator.  Pretty straightforward.  A couple design choices include:
• Assumes surface normal is along z-axis.  I think this is sufficient for GalSim, we can do something more complicated in ImSim via batoid in the future if desired.
• In case of total internal reflection, NaNs the dxdz and dydz values, and zeros the flux values, but does not otherwise raise any errors or warnings.