### PR TITLE
#1069 FocusDepth surface operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ build
 dist
 .pytest_cache
 .clang_complete
+pytest_session.txt

--- a/devel/lsst/focus_depth.py
+++ b/devel/lsst/focus_depth.py
@@ -1,0 +1,46 @@
+# Compute LSST focus curves including effects of Silicon absorption length and
+# refraction, and the fast f/1.2 beam.
+# Compare this to figure 8 from O'Connor++06 "Study of silicon sensor thickness
+# optimization for LSST".  GalSim results below are grossly consistent, but
+# differ in the exact shape and values that the focus curves take.
+
+import numpy as np
+import matplotlib.pyplot as plt
+import galsim
+
+bd = galsim.BaseDeviate(12)
+depths = np.linspace(-25, 25, 41)  # microns
+obj = galsim.Gaussian(sigma=1e-4)
+sed = galsim.SED("1", wave_type='nm', flux_type='flambda')
+
+fig, ax = plt.subplots()
+oversampling = 16
+for filter in ['g', 'z', 'y']:
+    bandpass = galsim.Bandpass("LSST_{}.dat".format(filter), wave_type='nm')
+    Ts = []
+    for depth in depths:
+        depth_pix = depth / 10
+        surface_ops = [
+            galsim.WavelengthSampler(sed, bandpass, rng=bd),
+            galsim.FRatioAngles(1.234, 0.606, rng=bd),
+            galsim.FocusDepth(depth_pix),
+            galsim.Refraction(3.9)  # approx number for Silicon
+        ]
+        img = obj.drawImage(
+            sensor=galsim.SiliconSensor(),
+            method='phot',
+            n_photons=1_000_000,
+            surface_ops=surface_ops,
+            scale=0.2/oversampling,  # oversample pixels to better resolve PSF size
+            nx=32*oversampling,  # 6.4 arcsec stamp
+            ny=32*oversampling,
+        )
+        Ts.append(img.calculateMomentRadius())
+    Ts = np.array(Ts)/0.2*10*oversampling  # convert arcsec -> micron
+    ax.scatter(depths, Ts, label=filter)
+ax.set_ylim(2, 7)
+ax.axvline(0, c='k')
+ax.legend()
+ax.set_xlabel("<- intrafocal   focus(micron)   extrafocal ->")
+ax.set_ylabel("PSF size (micron)")
+plt.show()

--- a/galsim/__init__.py
+++ b/galsim/__init__.py
@@ -131,6 +131,7 @@ from .image import Image, ImageS, ImageI, ImageF, ImageD, ImageCF, ImageCD, Imag
 
 # PhotonArray
 from .photon_array import PhotonArray, WavelengthSampler, FRatioAngles, PhotonDCR, Refraction
+from .photon_array import FocusDepth
 
 # Noise
 from .random import BaseDeviate, UniformDeviate, GaussianDeviate, PoissonDeviate, DistDeviate

--- a/galsim/photon_array.py
+++ b/galsim/photon_array.py
@@ -49,8 +49,14 @@ class PhotonArray(object):
         x:          The incidence x position at the top of the detector
         y:          The incidence y position at the top of the detector
         flux:       The flux of the photons
-        dxdz:       The tangent of the inclination angles in the x direction
-        dydz:       The tangent of the inclination angles in the y direction
+        dxdz:       The tangent of the inclination angles in the x direction.  Note that we define
+                    the +z direction as towards towards the dielectric medium of the detector and
+                    -z as towards vacuum; consequently, a photon with increasing x in time has
+                    positive dxdz.
+        dydz:       The tangent of the inclination angles in the y direction.  Note that we define
+                    the +z direction as towards towards the dielectric medium of the detector and
+                    -z as towards vacuum; consequently, a photon with increasing y in time has
+                    positive dydz.
         wavelength  The wavelength of the photons (in nm)
 
     Unlike most GalSim objects (but like `Image`), PhotonArrays are mutable.  It is permissible
@@ -716,6 +722,9 @@ class FocusDepth(object):
     Parameters:
         depth:   The z-distance by which to displace the focal surface, in units of pixels.  A
                  positive (negative) number here indicates an extra- (intra-) focal sensor height.
+                 I.e., depth > 0 means the sensor surface intersects the beam after it has
+                 converged, and depth < 0 means the sensor surface intersects the beam before it
+                 has converged.
     """
     def __init__(self, depth):
         self.depth = depth

--- a/galsim/photon_array.py
+++ b/galsim/photon_array.py
@@ -615,7 +615,7 @@ class PhotonDCR(object):
                 raise TypeError("Got unexpected keyword: {0}".format(kw))
 
         self.base_refraction = dcr.get_refraction(self.base_wavelength, self.zenith_angle,
-                                                         **self.kw)
+                                                  **self.kw)
 
     def applyTo(self, photon_array, local_wcs):
         """Apply the DCR effect to the photons
@@ -707,3 +707,21 @@ class Refraction(object):
         photon_array.dxdz /= factor
         photon_array.dydz /= factor
         photon_array.flux = np.where(np.isnan(factor), 0.0, photon_array.flux)
+
+
+class FocusDepth(object):
+    """Surface-layer operator that focuses/defocuses photons by changing the height of the focal
+    surface with respect to the conical beam.
+
+    Parameters:
+        depth:   The z-distance by which to displace the focal surface, in units of pixels.  A
+                 positive (negative) number here indicates an extra- (intra-) focal sensor height.
+    """
+    def __init__(self, depth):
+        self.depth = depth
+
+    def applyTo(self, photon_array, local_wcs=None):
+        if not photon_array.hasAllocatedAngles():
+            raise GalSimError("FocusDepth requires that angles be set")
+        photon_array.x += self.depth * photon_array.dxdz
+        photon_array.y += self.depth * photon_array.dydz


### PR DESCRIPTION
This was mostly straightforward.  

The tricky bit, that TBH I'm not sure I've fully addressed, was figuring out the units of the photon_array `.x` and `.y` attributes, specifically in the context of surface operation `applyTo` methods.  I think these are pixels, which means that the `depth` keyword here also makes the most sense in units of pixels.  (One could use the localwcs to express the depth in arcsec I suppose, but that feels even more confusing than pixels).  It's also not clear to me what one should do if the pixels aren't actually square, but hopefully that's sufficiently unusual as to not be a problem.