### PR TITLE
Add obj.makePhot method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,7 @@ matrix:
             # This one doesn't have problems with /System stuff, but one of the dependencies
             # wants to write into /usr/local/man.  So use --user to avoid that.
             - __USER=--user
+            - PATH=/Users/travis/Library/Python/3.7/bin:$PATH
           name: OSX (Python 3.7)
 
         # Check 3.8-dev, but less concerned if this fails.

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ before_install:
     - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
     # Install the non-python dependencies: fftw, libav, eigen
     - if [[ $TRAVIS_OS_NAME == "linux" ]]; then sudo -H apt-get -qq update; sudo -H apt-get install -y python-dev libfftw3-dev libav-tools libeigen3-dev; fi
-    - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew update; brew install fftw libav eigen wget; brew cask install gfortran; fi
+    - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew update; brew install fftw libav eigen wget; brew cask install gfortran; brew upgrade; fi
 
     # List current contents of directories that should be being cached.
     - ls -l $HOME

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,6 +92,9 @@ before_install:
     # Install the non-python dependencies: fftw, libav, eigen
     - if [[ $TRAVIS_OS_NAME == "linux" ]]; then sudo -H apt-get -qq update; sudo -H apt-get install -y python-dev libfftw3-dev libav-tools libeigen3-dev; fi
     - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew update; brew install fftw libav eigen; brew cask install gfortran; fi
+    # This next line fixes a problem with using OpenSSL 1.1.  Just roll back to v1.0.0
+    # cf. https://github.com/kelaberetiv/TagUI/issues/86
+    - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew uninstall openssl; brew uninstall openssl; brew install https://github.com/tebelorg/Tump/releases/download/v1.0.0/openssl.rb; fi
 
     # List current contents of directories that should be being cached.
     - ls -l $HOME

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,10 +91,7 @@ before_install:
     - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
     # Install the non-python dependencies: fftw, libav, eigen
     - if [[ $TRAVIS_OS_NAME == "linux" ]]; then sudo -H apt-get -qq update; sudo -H apt-get install -y python-dev libfftw3-dev libav-tools libeigen3-dev; fi
-    - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew update; brew install fftw libav eigen; brew cask install gfortran; fi
-    # This next line fixes a problem with using OpenSSL 1.1.  Just roll back to v1.0.0
-    # cf. https://github.com/kelaberetiv/TagUI/issues/86
-    - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew uninstall openssl; brew uninstall openssl; brew install https://github.com/tebelorg/Tump/releases/download/v1.0.0/openssl.rb; fi
+    - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew update; brew install fftw libav eigen wget; brew cask install gfortran; fi
 
     # List current contents of directories that should be being cached.
     - ls -l $HOME

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ before_install:
     - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
     # Install the non-python dependencies: fftw, libav, eigen
     - if [[ $TRAVIS_OS_NAME == "linux" ]]; then sudo -H apt-get -qq update; sudo -H apt-get install -y python-dev libfftw3-dev libav-tools libeigen3-dev; fi
-    - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew update; brew install fftw libav eigen wget; brew cask install gfortran; brew upgrade; fi
+    - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew update; brew install fftw libav eigen wget; brew cask install gfortran; brew upgrade wget; fi
 
     # List current contents of directories that should be being cached.
     - ls -l $HOME

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ matrix:
             #       since existing versions of some packages (e.g. numpy) live in /System/
             #       directory where delete operations are forbidden.
             - __USER=--user
+            - __USER2=--user
             - PATH=/Users/travis/Library/Python/2.7/bin:$PATH
           name: OSX (Python 2.7)
 
@@ -149,7 +150,7 @@ install:
 
 script:
     # Install GalSim
-    - $PYTHON setup.py install $__USER
+    - $PYTHON setup.py install $__USER2
 
     # If galsim_download_cosmos.py changed, then run it.
     - echo $TRAVIS_COMMIT_RANGE

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,9 @@ matrix:
           language: shell
           env:
             - TRAVIS_PYTHON_VERSION=3.7
+            # This one doesn't have problems with /System stuff, but one of the dependencies
+            # wants to write into /usr/local/man.  So use --user to avoid that.
+            - __USER=--user
           name: OSX (Python 3.7)
 
         # Check 3.8-dev, but less concerned if this fails.

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,6 +119,7 @@ cache:
     directories:
         - $HOME/des_data
         - $HOME/Library/Caches/Homebrew
+        - /usr/local/Cellar/
 
 install:
     # Upate pip executable.  (Needs sudo on some systems.)

--- a/galsim/fitswcs.py
+++ b/galsim/fitswcs.py
@@ -910,6 +910,8 @@ class GSFitsWCS(CelestialWCS):
                 self.projection = 'lambert'
             elif self.wcs_type == 'ARC':
                 self.projection = 'postel'
+            else:
+                raise ValueError("Invalid wcs_type in _data")
             return
 
         # Read the file if given.

--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -2068,7 +2068,7 @@ class GSObject(object):
 
 
     def makePhot(self, n_photons=0, rng=None, max_extra_noise=0., poisson_flux=None,
-                 sensor=None, surface_ops=(), maxN=None, local_wcs=None):
+                 surface_ops=(), local_wcs=None):
         """
         Make photons for a profile.
 
@@ -2125,7 +2125,6 @@ class GSObject(object):
         Returns:
             - a `PhotonArray` with the data about the photons.
         """
-        from .sensor import Sensor
         # Make sure the type of n_photons is correct and has a valid value:
         if n_photons < 0.:
             raise GalSimRangeError("Invalid n_photons < 0.", n_photons, 0., None)

--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -2068,8 +2068,7 @@ class GSObject(object):
 
 
     def makePhot(self, n_photons=0, rng=None, max_extra_noise=0., poisson_flux=None,
-                 sensor=None, surface_ops=(), maxN=None, orig_center=PositionI(0,0),
-                 local_wcs=None):
+                 sensor=None, surface_ops=(), maxN=None, local_wcs=None):
         """
         Make photons for a profile.
 
@@ -2121,8 +2120,6 @@ class GSObject(object):
             surface_ops:    A list of operators that can modify the photon array that will be
                             applied in order before accumulating the photons on the sensor.
                             [default: ()]
-            orig_center:    The position of the image center in the original image coordinates.
-                            [default: (0,0)]
             local_wcs:      The local wcs in the original image. [default: None]
 
         Returns:

--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -357,7 +357,10 @@ class AtmosphericScreen(object):
         with self._objDict['lock']:
             self._objDict['refcount'].value -= 1
         with self._objDict['lock']:
-            if self._objDict['refcount'].value == 0:
+            # Normally, shareKey is present, but on final cleanup, we have no control over
+            # the order than things are deleted, so it might already be gone, in which
+            # case there can be a KeyError here.
+            if self._objDict['refcount'].value == 0 and self._shareKey in _GSScreenShare:
                 del _GSScreenShare[self._shareKey]
 
     def _getScreenShare(self):

--- a/src/PhotonArray.cpp
+++ b/src/PhotonArray.cpp
@@ -97,18 +97,22 @@ namespace galsim {
         scaleFlux(flux / oldFlux);
     }
 
+    struct Scaler
+    {
+        Scaler(double _scale): scale(_scale) {}
+        double operator()(double x) { return x * scale; }
+        double scale;
+    };
+
     void PhotonArray::scaleFlux(double scale)
     {
-        std::transform(_flux, _flux+_N, _flux,
-                       std::bind2nd(std::multiplies<double>(),scale));
+        std::transform(_flux, _flux+_N, _flux, Scaler(scale));
     }
 
     void PhotonArray::scaleXY(double scale)
     {
-        std::transform(_x, _x+_N, _x,
-                       std::bind2nd(std::multiplies<double>(),scale));
-        std::transform(_y, _y+_N, _y,
-                       std::bind2nd(std::multiplies<double>(),scale));
+        std::transform(_x, _x+_N, _x, Scaler(scale));
+        std::transform(_y, _y+_N, _y, Scaler(scale));
     }
 
     void PhotonArray::assignAt(int istart, const PhotonArray& rhs)

--- a/tests/test_airy.py
+++ b/tests/test_airy.py
@@ -233,22 +233,26 @@ def test_airy_shoot():
     obj = galsim.Airy(lam_over_diam=0.01, flux=1.e4)
     im = galsim.Image(1000,1000, scale=1)
     im.setCenter(0,0)
-    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng.duplicate())
     print('obj.flux = ',obj.flux)
     print('added_flux = ',added_flux)
     print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
     print('image flux = ',im.array.sum())
     assert np.isclose(added_flux, obj.flux)
     assert np.isclose(im.array.sum(), obj.flux)
+    photons2 = obj.makePhot(poisson_flux=False, rng=rng)
+    assert photons2 == photons, "Airy makePhot not equivalent to drawPhot"
 
     obj = galsim.Airy(lam_over_diam=0.01, flux=1.e4, obscuration=0.4)
-    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng.duplicate())
     print('obj.flux = ',obj.flux)
     print('added_flux = ',added_flux)
     print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
     print('image flux = ',im.array.sum())
     assert np.isclose(added_flux, obj.flux)
     assert np.isclose(im.array.sum(), obj.flux)
+    photons2 = obj.makePhot(poisson_flux=False, rng=rng)
+    assert photons2 == photons, "Airy makePhot not equivalent to drawPhot"
 
 
 @timer

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -250,31 +250,37 @@ def test_box_shoot():
     obj = galsim.Box(width=1.3, height=2.4, flux=1.e4)
     im = galsim.Image(100,100, scale=1)
     im.setCenter(0,0)
-    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng.duplicate())
     print('obj.flux = ',obj.flux)
     print('added_flux = ',added_flux)
     print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
     print('image flux = ',im.array.sum())
     assert np.isclose(added_flux, obj.flux)
     assert np.isclose(im.array.sum(), obj.flux)
+    photons2 = obj.makePhot(poisson_flux=False, rng=rng)
+    assert photons2 == photons, "Box makePhot not equivalent to drawPhot"
 
     obj = galsim.Pixel(scale=9.3, flux=1.e4)
-    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng.duplicate())
     print('obj.flux = ',obj.flux)
     print('added_flux = ',added_flux)
     print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
     print('image flux = ',im.array.sum())
     assert np.isclose(added_flux, obj.flux)
     assert np.isclose(im.array.sum(), obj.flux)
+    photons2 = obj.makePhot(poisson_flux=False, rng=rng)
+    assert photons2 == photons, "Pixel makePhot not equivalent to drawPhot"
 
     obj = galsim.TopHat(radius=4.7, flux=1.e4)
-    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng.duplicate())
     print('obj.flux = ',obj.flux)
     print('added_flux = ',added_flux)
     print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
     print('image flux = ',im.array.sum())
     assert np.isclose(added_flux, obj.flux)
     assert np.isclose(im.array.sum(), obj.flux)
+    photons2 = obj.makePhot(poisson_flux=False, rng=rng)
+    assert photons2 == photons, "TopHat makePhot not equivalent to drawPhot"
 
 
 @timer

--- a/tests/test_convolve.py
+++ b/tests/test_convolve.py
@@ -152,6 +152,7 @@ def test_convolve():
     assert_raises(galsim.GalSimError, deconv.xValue, galsim.PositionD(0,0))
     assert_raises(galsim.GalSimError, deconv.drawReal, myImg)
     assert_raises(galsim.GalSimError, deconv.drawPhot, myImg, n_photons=10)
+    assert_raises(galsim.GalSimError, deconv.makePhot, n_photons=10)
 
 
 @timer

--- a/tests/test_exponential.py
+++ b/tests/test_exponential.py
@@ -219,13 +219,15 @@ def test_exponential_shoot():
     obj = galsim.Exponential(half_light_radius=3.5, flux=1.e4)
     im = galsim.Image(100,100, scale=1)
     im.setCenter(0,0)
-    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng.duplicate())
     print('obj.flux = ',obj.flux)
     print('added_flux = ',added_flux)
     print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
     print('image flux = ',im.array.sum())
     assert np.isclose(added_flux, obj.flux)
     assert np.isclose(im.array.sum(), obj.flux)
+    photons2 = obj.makePhot(poisson_flux=False, rng=rng)
+    assert photons2 == photons, "Exponential makePhot not equivalent to drawPhot"
 
 
 @timer

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -339,13 +339,15 @@ def test_gaussian_shoot():
     obj = galsim.Gaussian(fwhm=3.5, flux=1.e4)
     im = galsim.Image(100,100, scale=1)
     im.setCenter(0,0)
-    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng.duplicate())
     print('obj.flux = ',obj.flux)
     print('added_flux = ',added_flux)
     print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
     print('image flux = ',im.array.sum())
     assert np.isclose(added_flux, obj.flux)
     assert np.isclose(im.array.sum(), obj.flux)
+    photons2 = obj.makePhot(poisson_flux=False, rng=rng)
+    assert photons2 == photons, "Gaussian makePhot not equivalent to drawPhot"
 
 
 @timer

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -1515,7 +1515,7 @@ def test_ii_shoot():
         flux = 1.e4
     for interp in interp_list:
         obj = galsim.InterpolatedImage(image_in, x_interpolant=interp, scale=3.3, flux=flux)
-        added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+        added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng.duplicate())
         print('interp = ',interp)
         print('obj.flux = ',obj.flux)
         print('added_flux = ',added_flux)
@@ -1533,6 +1533,8 @@ def test_ii_shoot():
             rtol = 1.e-7
         assert np.isclose(added_flux, obj.flux, rtol=rtol)
         assert np.isclose(im.array.sum(), obj.flux, rtol=rtol)
+        photons2 = obj.makePhot(poisson_flux=False, rng=rng)
+        assert photons2 == photons, "InterpolatedImage makePhot not equivalent to drawPhot"
 
 
 @timer

--- a/tests/test_kolmogorov.py
+++ b/tests/test_kolmogorov.py
@@ -331,13 +331,15 @@ def test_kolmogorov_shoot():
     obj = galsim.Kolmogorov(fwhm=1.5, flux=1.e4)
     im = galsim.Image(500,500, scale=1)
     im.setCenter(0,0)
-    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng.duplicate())
     print('obj.flux = ',obj.flux)
     print('added_flux = ',added_flux)
     print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
     print('image flux = ',im.array.sum())
     assert np.isclose(added_flux, obj.flux)
     assert np.isclose(im.array.sum(), obj.flux)
+    photons2 = obj.makePhot(poisson_flux=False, rng=rng)
+    assert photons2 == photons, "Kolmogorov makePhot not equivalent to drawPhot"
 
 
 @timer

--- a/tests/test_moffat.py
+++ b/tests/test_moffat.py
@@ -439,23 +439,27 @@ def test_moffat_shoot():
     obj = galsim.Moffat(fwhm=3.5, beta=4.7, flux=1.e4)
     im = galsim.Image(500,500, scale=1)
     im.setCenter(0,0)
-    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng.duplicate())
     print('obj.flux = ',obj.flux)
     print('added_flux = ',added_flux)
     print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
     print('image flux = ',im.array.sum())
     assert np.isclose(added_flux, obj.flux)
     assert np.isclose(im.array.sum(), obj.flux)
+    photons2 = obj.makePhot(poisson_flux=False, rng=rng)
+    assert photons2 == photons, "Moffat makePhot not equivalent to drawPhot"
 
     # Note: low beta has large wings, so don't go too low.  Also, reduce fwhm a bit.
     obj = galsim.Moffat(fwhm=1.5, beta=1.9, flux=1.e4)
-    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng.duplicate())
     print('obj.flux = ',obj.flux)
     print('added_flux = ',added_flux)
     print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
     print('image flux = ',im.array.sum())
     assert np.isclose(added_flux, obj.flux)
     assert np.isclose(im.array.sum(), obj.flux)
+    photons2 = obj.makePhot(poisson_flux=False, rng=rng)
+    assert photons2 == photons, "Moffat makePhot not equivalent to drawPhot"
 
 
 @timer

--- a/tests/test_photon_array.py
+++ b/tests/test_photon_array.py
@@ -358,9 +358,17 @@ def test_wavelength_sampler():
     rng2 = galsim.BaseDeviate(1234)
     sampler2 = galsim.WavelengthSampler(sed, bandpass, rng2)
     obj.drawImage(im2, method='phot', n_photons=nphotons, use_true_center=False,
-                  surface_ops=[sampler2,clip600], rng=rng2)
+                  surface_ops=[sampler2,clip600], rng=rng2, save_photons=True)
     print('sum = ',im1.array.sum(),im2.array.sum())
     np.testing.assert_array_equal(im1.array, im2.array)
+
+    # Equivalent version just getting photons back
+    rng2.seed(1234)
+    photons = obj.makePhot(n_photons=nphotons, surface_ops=[sampler2,clip600], rng=rng2)
+    print('phot.x = ',photons.x)
+    print('im2.photons.x = ',im2.photons.x)
+    assert photons == im2.photons
+
 
 @timer
 def test_photon_angles():

--- a/tests/test_photon_array.py
+++ b/tests/test_photon_array.py
@@ -682,7 +682,7 @@ def test_dcr_angles():
 
     # Stars that are visible from the north in summer time.
     names = ['Vega', 'Polaris', 'Altair', 'Regulus', 'Spica', 'Algol', 'Fomalhaut', 'Markab',
-             'Deneb', 'Mizar', 'Dubhe', 'Sirius', 'Rigel', 'Etamin', 'Alderamin']
+             'Deneb', 'Mizar', 'Dubhe', 'Sirius', 'Rigel', 'Alderamin']
 
     for name in names:
         try:
@@ -694,15 +694,17 @@ def test_dcr_angles():
             return
         print(star)
 
-        ap_z = subaru.altaz(time, star).zen
-        ap_q = subaru.parallactic_angle(time, star)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            ap_z = subaru.altaz(time, star).zen
+            ap_q = subaru.parallactic_angle(time, star)
+            local_sidereal_time = subaru.local_sidereal_time(time)
         print('According to astroplan:')
         print('  z,q = ', ap_z.deg, ap_q.deg)
 
         # Repeat with GalSim
         coord = galsim.CelestialCoord(star.ra.deg * galsim.degrees, star.dec.deg * galsim.degrees)
         lat = subaru.location.lat.deg * galsim.degrees
-        local_sidereal_time = subaru.local_sidereal_time(time)
         ha = local_sidereal_time.deg * galsim.degrees - coord.ra
         zenith = galsim.CelestialCoord(local_sidereal_time.deg * galsim.degrees, lat)
 

--- a/tests/test_second_kick.py
+++ b/tests/test_second_kick.py
@@ -265,13 +265,15 @@ def test_sk_shoot():
     obj = galsim.SecondKick(lam=500, r0=0.2, diam=4, flux=1.e4)
     im = galsim.Image(500,500, scale=1)
     im.setCenter(0,0)
-    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng.duplicate())
     print('obj.flux = ',obj.flux)
     print('added_flux = ',added_flux)
     print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
     print('image flux = ',im.array.sum())
     assert np.isclose(added_flux, obj.flux)
     assert np.isclose(im.array.sum(), obj.flux)
+    photons2 = obj.makePhot(poisson_flux=False, rng=rng)
+    assert photons2 == photons, "SecondKick makePhot not equivalent to drawPhot"
 
 
 @timer

--- a/tests/test_sersic.py
+++ b/tests/test_sersic.py
@@ -489,35 +489,41 @@ def test_sersic_shoot():
     obj = galsim.Sersic(n=1.5, half_light_radius=3.5, flux=1.e4)
     im = galsim.Image(100,100, scale=1)
     im.setCenter(0,0)
-    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng.duplicate())
     print('obj.flux = ',obj.flux)
     print('added_flux = ',added_flux)
     print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
     print('image flux = ',im.array.sum())
     assert np.isclose(added_flux, obj.flux)
     assert np.isclose(im.array.sum(), obj.flux)
+    photons2 = obj.makePhot(poisson_flux=False, rng=rng)
+    assert photons2 == photons, "Sersic makePhot not equivalent to drawPhot"
 
     obj = galsim.DeVaucouleurs(half_light_radius=3.5, flux=1.e4)
     # Need a larger image for devauc wings
     im = galsim.Image(1000,1000, scale=1)
     im.setCenter(0,0)
-    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng.duplicate())
     print('obj.flux = ',obj.flux)
     print('added_flux = ',added_flux)
     print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
     print('image flux = ',im.array.sum())
     assert np.isclose(added_flux, obj.flux)
     assert np.isclose(im.array.sum(), obj.flux)
+    photons2 = obj.makePhot(poisson_flux=False, rng=rng)
+    assert photons2 == photons, "Sersic makePhot not equivalent to drawPhot"
 
     # Can do up to around n=6 with this image if hlr is smaller.
     obj = galsim.Sersic(half_light_radius=0.9, n=6.2, flux=1.e4)
-    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng.duplicate())
     print('obj.flux = ',obj.flux)
     print('added_flux = ',added_flux)
     print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
     print('image flux = ',im.array.sum())
     assert np.isclose(added_flux, obj.flux)
     assert np.isclose(im.array.sum(), obj.flux)
+    photons2 = obj.makePhot(poisson_flux=False, rng=rng)
+    assert photons2 == photons, "Sersic makePhot not equivalent to drawPhot"
 
 
 @timer

--- a/tests/test_spergel.py
+++ b/tests/test_spergel.py
@@ -290,31 +290,37 @@ def test_spergel_shoot():
     obj = galsim.Spergel(nu=0, half_light_radius=3.5, flux=1.e4)
     im = galsim.Image(100,100, scale=1)
     im.setCenter(0,0)
-    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng.duplicate())
     print('obj.flux = ',obj.flux)
     print('added_flux = ',added_flux)
     print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
     print('image flux = ',im.array.sum())
     assert np.isclose(added_flux, obj.flux)
     assert np.isclose(im.array.sum(), obj.flux)
+    photons2 = obj.makePhot(poisson_flux=False, rng=rng)
+    assert photons2 == photons, "Spergel makePhot not equivalent to drawPhot"
 
     obj = galsim.Spergel(nu=3.2, half_light_radius=3.5, flux=1.e4)
-    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng.duplicate())
     print('obj.flux = ',obj.flux)
     print('added_flux = ',added_flux)
     print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
     print('image flux = ',im.array.sum())
     assert np.isclose(added_flux, obj.flux)
     assert np.isclose(im.array.sum(), obj.flux)
+    photons2 = obj.makePhot(poisson_flux=False, rng=rng)
+    assert photons2 == photons, "Spergel makePhot not equivalent to drawPhot"
 
     obj = galsim.Spergel(nu=-0.6, half_light_radius=3.5, flux=1.e4)
-    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng.duplicate())
     print('obj.flux = ',obj.flux)
     print('added_flux = ',added_flux)
     print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
     print('image flux = ',im.array.sum())
     assert np.isclose(added_flux, obj.flux)
     assert np.isclose(im.array.sum(), obj.flux)
+    photons2 = obj.makePhot(poisson_flux=False, rng=rng)
+    assert photons2 == photons, "Spergel makePhot not equivalent to drawPhot"
 
 
 @timer

--- a/tests/test_vonkarman.py
+++ b/tests/test_vonkarman.py
@@ -128,33 +128,39 @@ def test_vk_shoot():
     obj = galsim.VonKarman(lam=500, r0=0.2, flux=1.e4)
     im = galsim.Image(100,100, scale=1)
     im.setCenter(0,0)
-    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng.duplicate())
     print('obj.flux = ',obj.flux)
     print('added_flux = ',added_flux)
     print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
     print('image flux = ',im.array.sum())
     assert np.isclose(added_flux, obj.flux)
     assert np.isclose(im.array.sum(), obj.flux)
+    photons2 = obj.makePhot(poisson_flux=False, rng=rng)
+    assert photons2 == photons, "VonKarman makePhot not equivalent to drawPhot"
 
     obj = galsim.VonKarman(lam=500, r0=0.2, L0=10., flux=1.e4)
-    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng.duplicate())
     print('obj.flux = ',obj.flux)
     print('added_flux = ',added_flux)
     print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
     print('image flux = ',im.array.sum())
     assert np.isclose(added_flux, obj.flux)
     assert np.isclose(im.array.sum(), obj.flux)
+    photons2 = obj.makePhot(poisson_flux=False, rng=rng)
+    assert photons2 == photons, "VonKarman makePhot not equivalent to drawPhot"
 
     obj = galsim.VonKarman(lam=700, r0=0.02, L0=10., flux=1.e4)
     im = galsim.Image(500,500, scale=1)
     im.setCenter(0,0)
-    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng)
+    added_flux, photons = obj.drawPhot(im, poisson_flux=False, rng=rng.duplicate())
     print('obj.flux = ',obj.flux)
     print('added_flux = ',added_flux)
     print('photon fluxes = ',photons.flux.min(),'..',photons.flux.max())
     print('image flux = ',im.array.sum())
     assert np.isclose(added_flux, obj.flux)
     assert np.isclose(im.array.sum(), obj.flux)
+    photons2 = obj.makePhot(poisson_flux=False, rng=rng)
+    assert photons2 == photons, "VonKarman makePhot not equivalent to drawPhot"
 
 
 @timer

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -2261,6 +2261,7 @@ def test_gsfitswcs():
 
     assert_raises(TypeError, galsim.GSFitsWCS)
     assert_raises(TypeError, galsim.GSFitsWCS, file_name, header='dummy')
+    assert_raises(ValueError, galsim.GSFitsWCS, _data=('invalid',0,0,0,0,0,0))
 
 @timer
 def test_tanwcs():


### PR DESCRIPTION
This PR adds a way to draw photons without actually accumulating them onto an image.

It is functionally equivalent to `_, photons = obj.drawPhot(im, ...)` but without requiring the image.

@cwwalter 