### PR TITLE
Remove future as a dependency

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,10 @@ Changes from v2.2 to v2.3
 =========================
 
 
-Deprecated Features
--------------------
+Dependency Changes
+------------------
+
+- Removed future as a dependency. (#1082)
 
 
 API Changes

--- a/SConstruct
+++ b/SConstruct
@@ -1782,19 +1782,6 @@ def CheckPyFITS(config):
 
     return 1
 
-def CheckFuture(config):
-    config.Message('Checking for future... ')
-
-    result, output = TryScript(config,"import future",python)
-    if not result:
-        ErrorExit("Unable to import future using the python executable:\n" + python)
-    config.Result(1)
-
-    result, future_ver = TryScript(config,"import future; print(future.__version__)",python)
-    print('Future version is',future_ver)
-
-    return 1
-
 def CheckCoord(config):
     config.Message('Checking for coord... ')
 
@@ -2113,7 +2100,6 @@ def DoPyChecks(config):
         config.CheckEigen()
     config.CheckNumPy()
     config.CheckPyFITS()
-    config.CheckFuture()
     config.CheckCoord()
     if config.env['USE_BOOST']:
         config.CheckBoostPython()
@@ -2204,7 +2190,6 @@ def DoConfig(env):
             'CheckEigen' : CheckEigen ,
             'CheckNumPy' : CheckNumPy ,
             'CheckPyFITS' : CheckPyFITS ,
-            'CheckFuture' : CheckFuture ,
             'CheckCoord' : CheckCoord ,
             'CheckPyBind11' : CheckPyBind11 ,
             'CheckBoostPython' : CheckBoostPython ,

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -2,7 +2,6 @@
 #    conda install -y -c conda-forge --file conda_requirements.txt
 setuptools>=38
 numpy>=1.13
-future>=0.15
 astropy>=2.0
 pybind11>=2.2
 pip>=9.0

--- a/galsim/bandpass.py
+++ b/galsim/bandpass.py
@@ -16,7 +16,9 @@
 #    and/or other materials provided with the distribution.
 #
 
-from past.builtins import basestring
+# Python 2/3 compatible definition of basestring without past.builtins
+basestring = ("".__class__, u"".__class__, b"".__class__)
+
 import numpy as np
 from astropy import units
 

--- a/galsim/bandpass.py
+++ b/galsim/bandpass.py
@@ -16,9 +16,6 @@
 #    and/or other materials provided with the distribution.
 #
 
-# Python 2/3 compatible definition of basestring without past.builtins
-basestring = ("".__class__, u"".__class__, b"".__class__)
-
 import numpy as np
 from astropy import units
 
@@ -27,7 +24,7 @@ from .sed import SED
 from . import utilities
 from . import integ
 from . import meta_data
-from .utilities import WeakMethod, combine_wave_list
+from .utilities import WeakMethod, combine_wave_list, basestring
 from .errors import GalSimRangeError, GalSimValueError, GalSimIncompatibleValuesError
 
 class Bandpass(object):

--- a/galsim/catalog.py
+++ b/galsim/catalog.py
@@ -16,7 +16,6 @@
 #    and/or other materials provided with the distribution.
 #
 
-from builtins import zip
 import os
 import numpy as np
 

--- a/galsim/catalog.py
+++ b/galsim/catalog.py
@@ -16,7 +16,6 @@
 #    and/or other materials provided with the distribution.
 #
 
-from future.utils import iteritems, iterkeys, itervalues
 from builtins import zip
 import os
 import numpy as np
@@ -319,13 +318,13 @@ class Dict(object):
         return self.dict.items()
 
     def iterkeys(self):
-        return iterkeys(self.dict)
+        return self.keys()
 
     def itervalues(self):
-        return itervalues(self.dict)
+        return self.values()
 
     def iteritems(self):
-        return iteritems(self.dict)
+        return self.items()
 
     def __repr__(self):
         s = "galsim.Dict(file_name=%r, file_type=%r"%(self.file_name, self.file_type)

--- a/galsim/cdmodel.py
+++ b/galsim/cdmodel.py
@@ -16,7 +16,6 @@
 #    and/or other materials provided with the distribution.
 #
 
-from builtins import int
 import numpy as np
 
 from .image import Image

--- a/galsim/config/extra_truth.py
+++ b/galsim/config/extra_truth.py
@@ -16,7 +16,8 @@
 #    and/or other materials provided with the distribution.
 #
 
-from past.builtins import basestring
+# Python 2/3 compatible definition of basestring without past.builtins
+basestring = ("".__class__, u"".__class__, b"".__class__)
 
 from .extra import ExtraOutputBuilder, RegisterExtraOutput
 from .value import ParseValue, GetCurrentValue

--- a/galsim/config/extra_truth.py
+++ b/galsim/config/extra_truth.py
@@ -16,13 +16,11 @@
 #    and/or other materials provided with the distribution.
 #
 
-# Python 2/3 compatible definition of basestring without past.builtins
-basestring = ("".__class__, u"".__class__, b"".__class__)
-
 from .extra import ExtraOutputBuilder, RegisterExtraOutput
 from .value import ParseValue, GetCurrentValue
 from ..errors import GalSimConfigError
 from ..catalog import OutputCatalog
+from ..utilities import basestring
 
 # The truth extra output type builds an OutputCatalog with truth information about each of the
 # objects being built by the configuration processing.  It stores the appropriate row information

--- a/galsim/config/gsobject.py
+++ b/galsim/config/gsobject.py
@@ -175,9 +175,8 @@ def BuildGSObject(config, key, base=None, gsparams={}, logger=None):
     if type_name in valid_gsobject_types:
         build_func = valid_gsobject_types[type_name]
     elif type_name in galsim_dict:
-        from future.utils import exec_
         gdict = globals().copy()
-        exec_('import galsim', gdict)
+        exec('import galsim', gdict)
         build_func = eval("galsim."+type_name, gdict)
     else:
         raise GalSimConfigValueError("Unrecognised gsobject type", type_name)

--- a/galsim/config/value.py
+++ b/galsim/config/value.py
@@ -18,7 +18,9 @@
 
 from __future__ import print_function
 
-from past.builtins import basestring
+# Python 2/3 compatible definition of basestring without past.builtins
+basestring = ("".__class__, u"".__class__, b"".__class__)
+
 import sys
 
 from .util import PropagateIndexKeyRNGNum, GetIndex, ParseExtendedKey

--- a/galsim/config/value.py
+++ b/galsim/config/value.py
@@ -18,9 +18,6 @@
 
 from __future__ import print_function
 
-# Python 2/3 compatible definition of basestring without past.builtins
-basestring = ("".__class__, u"".__class__, b"".__class__)
-
 import sys
 
 from .util import PropagateIndexKeyRNGNum, GetIndex, ParseExtendedKey
@@ -31,6 +28,7 @@ from ..angle import Angle, AngleUnit, radians, degrees
 from ..position import PositionD
 from ..celestial import CelestialCoord
 from ..shear import Shear
+from ..utilities import basestring
 
 # This file handles the parsing of values given in the config dict.  It includes the basic
 # parsing functionality along with generators for most of the simple value types.

--- a/galsim/config/value_eval.py
+++ b/galsim/config/value_eval.py
@@ -84,17 +84,16 @@ def _GenerateFromEval(config, base, value_type):
         # If the function is not already compiled, then this is the first time through, so do
         # a full parsing of all the possibilities.
 
-        from future.utils import exec_
         # These will be the variables to use for evaluating the eval statement.
         # Start with the current locals and globals, and add extra items to them.
         if 'eval_gdict' not in base:
             gdict = globals().copy()
             # We allow the following modules to be used in the eval string:
-            exec_('import galsim', gdict)
-            exec_('import math', gdict)
-            exec_('import numpy', gdict)
-            exec_('import numpy as np', gdict)
-            exec_('import os', gdict)
+            exec('import galsim', gdict)
+            exec('import math', gdict)
+            exec('import numpy', gdict)
+            exec('import numpy as np', gdict)
+            exec('import os', gdict)
             base['eval_gdict'] = gdict
         else:
             gdict = base['eval_gdict']

--- a/galsim/correlatednoise.py
+++ b/galsim/correlatednoise.py
@@ -17,7 +17,6 @@
 #
 
 import numpy as np
-from future.utils import iteritems
 
 from .image import Image
 from .random import BaseDeviate
@@ -1551,13 +1550,13 @@ class CovarianceSpectrum(object):
 
     def transform(self, dudx, dudy, dvdx, dvdy):
         Sigma = {}
-        for k, v in iteritems(self.Sigma):
+        for k, v in self.Sigma.items():
             Sigma[k] = v.transform(dudx, dudy, dvdx, dvdy)
         return CovarianceSpectrum(Sigma, self.SEDs)
 
     def withScaledVariance(self, variance_ratio):
         Sigma = {}
-        for k, v in iteritems(self.Sigma):
+        for k, v in self.Sigma.items():
             Sigma[k] = v * variance_ratio
         return CovarianceSpectrum(Sigma, self.SEDs)
 
@@ -1610,7 +1609,7 @@ class CovarianceSpectrum(object):
 
     def __hash__(self):
         return hash(("galsim.CovarianceSpectrum", tuple(self.SEDs),
-                     frozenset(iteritems(self.Sigma))))
+                     frozenset(self.Sigma.items())))
 
     def __repr__(self):
         return "galsim.CovarianceSpectrum(%r, %r)" % (self.Sigma, self.SEDs)

--- a/galsim/download_cosmos.py
+++ b/galsim/download_cosmos.py
@@ -224,8 +224,8 @@ def download(url, target, unpack_dir, args, logger):
                 # Skip some keys that don't imply obselescence.
                 if k.startswith('X-') or k.startswith('Retry') or k.startswith('Set-Cookie'):
                     continue
-                if k.lower() == 'date' or k.lower() == 'last-modified':
-                    continue  # These aren't expected to match.
+                if k.lower() == 'date' or k.lower() == 'last-modified' or k.lower == 'server':
+                    continue  # These don't necessarily match
                 elif k not in saved_meta_dict:
                     logger.debug("key %s is missing in saved meta information",k)
                     obsolete = True

--- a/galsim/download_cosmos.py
+++ b/galsim/download_cosmos.py
@@ -224,8 +224,8 @@ def download(url, target, unpack_dir, args, logger):
                 # Skip some keys that don't imply obselescence.
                 if k.startswith('X-') or k.startswith('Retry') or k.startswith('Set-Cookie'):
                     continue
-                if k.lower() == 'date':
-                    continue  # This one isn't expected to match.
+                if k.lower() == 'date' or k.lower() == 'last-modified':
+                    continue  # These aren't expected to match.
                 elif k not in saved_meta_dict:
                     logger.debug("key %s is missing in saved meta information",k)
                     obsolete = True

--- a/galsim/download_cosmos.py
+++ b/galsim/download_cosmos.py
@@ -20,12 +20,18 @@ A program to download the COSMOS RealGalaxy catalog for use with GalSim.
 """
 
 from __future__ import print_function
-from builtins import input
 import os, sys, tarfile, subprocess, shutil, json
 try:
     from urllib2 import urlopen
 except:
     from urllib.request import urlopen
+
+try:
+    # Python 2 version
+    input = raw_input
+except NameError:
+    # Python 3 calls the same functionality input
+    pass
 
 from .utilities import ensure_dir
 

--- a/galsim/errors.py
+++ b/galsim/errors.py
@@ -20,7 +20,6 @@
 # obviously one of the standard python errors.
 
 import warnings
-from builtins import super
 from contextlib import contextmanager
 
 # Note to developers about which exception to throw.
@@ -158,7 +157,7 @@ class GalSimValueError(GalSimError, ValueError):
         message += " Value {0!s}".format(value)
         if allowed_values:
             message += " not in {0!s}".format(allowed_values)
-        super().__init__(message)
+        super(GalSimValueError, self).__init__(message)
 
     def __repr__(self):
         return 'galsim.GalSimValueError(%r,%r,%r)'%(self.message, self.value, self.allowed_values)
@@ -176,7 +175,7 @@ class GalSimKeyError(GalSimError, KeyError):
     def __init__(self, message, key):
         self.message = message
         self.key = key
-        super().__init__(message, key)  # Need to pass key or pickle fails.
+        super(GalSimKeyError, self).__init__(message, key)  # Need to pass key or pickle fails.
 
     def __str__(self):
         return self.message + " Key {0!s}".format(self.key)
@@ -195,7 +194,7 @@ class GalSimIndexError(GalSimError, IndexError):
     def __init__(self, message, index):
         self.message = message
         self.index = index
-        super().__init__(message, index)
+        super(GalSimIndexError, self).__init__(message, index)
 
     def __str__(self):
         return self.message + " Index {0!s}".format(self.index)
@@ -220,7 +219,7 @@ class GalSimRangeError(GalSimError, ValueError):
         self.max = max
 
         message += " Value {0!s} not in range [{1!s}, {2!s}]".format(value, min, max)
-        super().__init__(message)
+        super(GalSimRangeError, self).__init__(message)
 
     def __repr__(self):
         return 'galsim.GalSimRangeError(%r,%r,%r,%r)'%(self.message, self.value, self.min, self.max)
@@ -242,7 +241,7 @@ class GalSimBoundsError(GalSimError, ValueError):
         self.bounds = bounds
 
         message += " {0!s} not in {1!s}".format(pos, bounds)
-        super().__init__(message)
+        super(GalSimBoundsError, self).__init__(message)
 
     def __repr__(self):
         return 'galsim.GalSimBoundsError(%r,%r,%r)'%(self.message, self.pos, self.bounds)
@@ -269,7 +268,7 @@ class GalSimImmutableError(GalSimError):
         self.image = image
 
         message += " Image: {0!s}".format(image)
-        super().__init__(message)
+        super(GalSimImmutableError, self).__init__(message)
 
     def __repr__(self):
         return 'galsim.GalSimImmutableError(%r,%r)'%(self.message, self.image)
@@ -289,7 +288,7 @@ class GalSimIncompatibleValuesError(GalSimError, ValueError, TypeError):
         self.values = dict(values, **kwargs)
 
         message += " Values {0!s}".format(self.values)
-        super().__init__(message)
+        super(GalSimIncompatibleValuesError, self).__init__(message)
 
     # Note: the repr of values can rearrange the items, but the dicts should compare equal.
     def __eq__(self, other):
@@ -316,7 +315,7 @@ class GalSimSEDError(GalSimError, TypeError):
         self.sed = sed
 
         message += " SED: {0!s}".format(sed)
-        super().__init__(message)
+        super(GalSimSEDError, self).__init__(message)
 
     def __repr__(self):
         return 'galsim.GalSimSEDError(%r,%r)'%(self.message, self.sed)
@@ -346,7 +345,7 @@ class GalSimFFTSizeError(GalSimError):
         message += "\nThe required FFT size would be {0} x {0}, which requires ".format(size)
         message += "{0:.2f} GB of memory.\n".format(self.mem)
         message += "If you can handle the large FFT, you may update gsparams.maximum_fft_size."
-        super().__init__(message)
+        super(GalSimFFTSizeError, self).__init__(message)
 
     def __repr__(self):
         return 'galsim.GalSimFFTSizeError(%r,%r)'%(self.message, self.size)

--- a/galsim/fits.py
+++ b/galsim/fits.py
@@ -16,7 +16,6 @@
 #    and/or other materials provided with the distribution.
 #
 
-from future.utils import iteritems, iterkeys, itervalues
 # Python 2/3 compatible definition of basestring without past.builtins
 basestring = ("".__class__, u"".__class__, b"".__class__)
 
@@ -1281,13 +1280,19 @@ class FitsHeader(object):
         return self.header.items()
 
     def iteritems(self):
-        return iteritems(self.header)
+        """Synonym for self.items()
+        """
+        return self.items()
 
     def iterkeys(self):
-        return iterkeys(self.header)
+        """Synonym for self.keys()
+        """
+        return self.keys()
 
     def itervalues(self):
-        return itervalues(self.header)
+        """Synonym for self.values()
+        """
+        return self.values()
 
     def keys(self):
         """Get all header keys.  Works like dict.keys

--- a/galsim/fits.py
+++ b/galsim/fits.py
@@ -16,14 +16,12 @@
 #    and/or other materials provided with the distribution.
 #
 
-# Python 2/3 compatible definition of basestring without past.builtins
-basestring = ("".__class__, u"".__class__, b"".__class__)
-
 import os
 import numpy as np
 
 from .image import Image
 from .errors import GalSimError, GalSimValueError, GalSimIncompatibleValuesError, galsim_warn
+from .utilities import basestring
 
 
 ##############################################################################################

--- a/galsim/fits.py
+++ b/galsim/fits.py
@@ -17,7 +17,9 @@
 #
 
 from future.utils import iteritems, iterkeys, itervalues
-from past.builtins import basestring
+# Python 2/3 compatible definition of basestring without past.builtins
+basestring = ("".__class__, u"".__class__, b"".__class__)
+
 import os
 import numpy as np
 

--- a/galsim/interpolant.py
+++ b/galsim/interpolant.py
@@ -18,7 +18,6 @@
 
 import math
 import numpy as np
-from past.builtins import basestring
 
 from . import _galsim
 from .gsparams import GSParams

--- a/galsim/interpolatedimage.py
+++ b/galsim/interpolatedimage.py
@@ -16,9 +16,6 @@
 #    and/or other materials provided with the distribution.
 #
 
-# Python 2/3 compatible definition of basestring without past.builtins
-basestring = ("".__class__, u"".__class__, b"".__class__)
-
 import numpy as np
 import math
 
@@ -28,7 +25,7 @@ from .image import Image
 from .bounds import _BoundsI
 from .position import PositionD
 from .interpolant import Quintic, Interpolant, SincInterpolant
-from .utilities import convert_interpolant, lazy_property, doc_inherit
+from .utilities import convert_interpolant, lazy_property, doc_inherit, basestring
 from .random import BaseDeviate
 from . import _galsim
 from . import fits

--- a/galsim/interpolatedimage.py
+++ b/galsim/interpolatedimage.py
@@ -16,7 +16,9 @@
 #    and/or other materials provided with the distribution.
 #
 
-from past.builtins import basestring
+# Python 2/3 compatible definition of basestring without past.builtins
+basestring = ("".__class__, u"".__class__, b"".__class__)
+
 import numpy as np
 import math
 

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -18,7 +18,6 @@
 
 import sys
 from itertools import chain
-from builtins import range
 from heapq import heappush, heappop
 import numpy as np
 

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -16,9 +16,6 @@
 #    and/or other materials provided with the distribution.
 #
 
-# Python 2/3 compatible definition of basestring without past.builtins
-basestring = ("".__class__, u"".__class__, b"".__class__)
-
 import sys
 from itertools import chain
 from builtins import range
@@ -32,7 +29,7 @@ from .image import Image, _Image
 from .bounds import _BoundsI
 from .wcs import PixelScale
 from .interpolatedimage import InterpolatedImage
-from .utilities import doc_inherit, OrderedWeakRef, rotate_xy, lazy_property
+from .utilities import doc_inherit, OrderedWeakRef, rotate_xy, lazy_property, basestring
 from .errors import GalSimError, GalSimValueError, GalSimRangeError, GalSimIncompatibleValuesError
 from .errors import GalSimFFTSizeError, galsim_warn
 

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -16,8 +16,10 @@
 #    and/or other materials provided with the distribution.
 #
 
+# Python 2/3 compatible definition of basestring without past.builtins
+basestring = ("".__class__, u"".__class__, b"".__class__)
+
 import sys
-from past.builtins import basestring
 from itertools import chain
 from builtins import range
 from heapq import heappush, heappop

--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -16,7 +16,6 @@
 #    and/or other materials provided with the distribution.
 #
 
-from builtins import range, zip
 import sys
 import numpy as np
 import multiprocessing

--- a/galsim/sed.py
+++ b/galsim/sed.py
@@ -16,9 +16,6 @@
 #    and/or other materials provided with the distribution.
 #
 
-# Python 2/3 compatible definition of basestring without past.builtins
-basestring = ("".__class__, u"".__class__, b"".__class__)
-
 import numpy as np
 from astropy import units
 from astropy import constants
@@ -29,7 +26,7 @@ from .table import LookupTable
 from . import utilities
 from . import integ
 from . import dcr
-from .utilities import WeakMethod, lazy_property, combine_wave_list
+from .utilities import WeakMethod, lazy_property, combine_wave_list, basestring
 from .errors import GalSimError, GalSimValueError, GalSimRangeError, GalSimSEDError
 from .errors import GalSimIncompatibleValuesError
 

--- a/galsim/sed.py
+++ b/galsim/sed.py
@@ -16,7 +16,9 @@
 #    and/or other materials provided with the distribution.
 #
 
-from past.builtins import basestring
+# Python 2/3 compatible definition of basestring without past.builtins
+basestring = ("".__class__, u"".__class__, b"".__class__)
+
 import numpy as np
 from astropy import units
 from astropy import constants

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -1422,17 +1422,14 @@ def math_eval(str, other_modules=()):
     Returns:
         Whatever the string evaluates to.
     """
-    # Python 2 and 3 have a different syntax for exec with globals() dict.
-    # The exec_ function lets us use the Python 3 syntax even in Python 2.
-    from future.utils import exec_
     gdict = globals().copy()
-    exec_('import galsim', gdict)
-    exec_('import numpy', gdict)
-    exec_('import numpy as np', gdict)
-    exec_('import math', gdict)
-    exec_('import coord', gdict)
+    exec('import galsim', gdict)
+    exec('import numpy', gdict)
+    exec('import numpy as np', gdict)
+    exec('import math', gdict)
+    exec('import coord', gdict)
     for m in other_modules:  # pragma: no cover  (We don't use this.)
-        exec_('import ' + m, gdict)
+        exec('import ' + m, gdict)
     return eval(str, gdict)
 
 def binomial(a, b, n):

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -17,7 +17,6 @@
 #
 import functools
 from contextlib import contextmanager
-from builtins import range, object
 import weakref
 import os
 import numpy as np

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -17,7 +17,6 @@
 #
 import functools
 from contextlib import contextmanager
-from future.utils import iteritems
 from builtins import range, object
 import weakref
 import os
@@ -250,7 +249,7 @@ class AttributeDict(object): # pragma: no cover
         self.__dict__.update(other.__dict__)
 
     def _write(self, output, prefix=""):
-        for k, v in iteritems(self.__dict__):
+        for k, v in self.__dict__.items():
             if isinstance(v, AttributeDict):
                 v._write(output, prefix="{0}{1}.".format(prefix, k))
             else:
@@ -1247,7 +1246,7 @@ def dol_to_lod(dol, N=None, scalar_string=True):
     # Loop through broadcast range
     for i in range(N):
         out = {}
-        for k, v in iteritems(dol):
+        for k, v in dol.items():
             if scalar_string and isinstance(v, str):
                 out[k] = v
                 continue
@@ -1407,7 +1406,7 @@ def functionize(f):
                 new_kwargs = dict([(k, v)
                                    if not hasattr(v, '__call__')
                                    else (k, v(*inner_args, **inner_kwargs))
-                                   for k, v in iteritems(kwargs)])
+                                   for k, v in kwargs.items()])
                 return f(*new_args, **new_kwargs)
             return fff
     return ff

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -26,6 +26,9 @@ from . import _galsim
 from .errors import GalSimError, GalSimValueError, GalSimIncompatibleValuesError, GalSimRangeError
 from .errors import galsim_warn
 
+# Python 2/3 compatible definition of basestring without past.builtins
+basestring = ("".__class__, u"".__class__, b"".__class__)
+
 
 def isinteger(value):
     """Check if a value is an integer type (including np.int64, long, etc.)

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -27,6 +27,7 @@ from .errors import GalSimError, GalSimValueError, GalSimIncompatibleValuesError
 from .errors import galsim_warn
 
 # Python 2/3 compatible definition of basestring without past.builtins
+# (Based on this SO answer: https://stackoverflow.com/a/33699705/1332281)
 basestring = ("".__class__, u"".__class__, b"".__class__)
 
 

--- a/galsim/wcs.py
+++ b/galsim/wcs.py
@@ -757,9 +757,8 @@ def readFromFitsHeader(header):
     origin = PositionI(xmin, ymin)
     wcs_name = header.get("GS_WCS", None)
     if wcs_name is not None:
-        from future.utils import exec_
         gdict = globals().copy()
-        exec_('import galsim', gdict)
+        exec('import galsim', gdict)
         wcs_type = eval('galsim.' + wcs_name, gdict)
         wcs = wcs_type._readHeader(header)
     else:

--- a/galsim/wfirst/wfirst_psfs.py
+++ b/galsim/wfirst/wfirst_psfs.py
@@ -16,7 +16,6 @@
 #    and/or other materials provided with the distribution.
 #
 
-from past.builtins import basestring
 import numpy as np
 import os
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@
 # prior to running pip install -r requirements.txt
 setuptools>=38
 numpy>=1.13
-future>=0.15
 astropy>=2.0
 pybind11>=2.2
 pip>=18.0

--- a/setup.py
+++ b/setup.py
@@ -966,7 +966,7 @@ ext=Extension("galsim._galsim",
               undef_macros = undef_macros)
 
 build_dep = ['setuptools>=38', 'pybind11>=2.2']
-run_dep = ['numpy', 'future', 'astropy', 'LSSTDESC.Coord']
+run_dep = ['numpy', 'astropy', 'LSSTDESC.Coord']
 test_dep = ['pytest', 'pytest-xdist', 'pytest-timeout', 'nose',
             'scipy', 'pyyaml', 'starlink-pyast', 'matplotlib']
 # Note: Even though we don't use nosetests, nose is required for some tests to work.

--- a/tests/test_des.py
+++ b/tests/test_des.py
@@ -333,6 +333,10 @@ def test_meds_config():
     config = galsim.config.CleanConfig(config)
     config['image']['offset'] = { 'type' : 'XY' , 'x' : offset_x, 'y' : offset_y }
     config['output']['badpix'] = {}
+    # These three are just added for coverage really.
+    config['output']['weight'] = {}
+    config['output']['psf'] = {}
+    config['output']['meds_get_offset'] = {}
     galsim.config.BuildFile(galsim.config.CopyConfig(config), logger=logger)
 
     # Scattered image is invalid with MEDS output


### PR DESCRIPTION
This is a bit of a "spring cleaning" PR.

I've come to realize that our python usage has very few bits that require the future module, so I'm inclined to remove it as a dependency.  Here are the places where we are currently using `future` and my proposed (via this PR) changes:

1. `basestring`: I found a cute way to define basestring that works in both 2 and 3: `basestring = ("".__class__, u"".__class__, b"".__class__)`.  This captures `str`, `unicode` and `bytes` properly on both.  I put this in utilities.py and import from there when we want it.
2. `exec_`: Turns out the python 3 version of `exec` works just fine in python 2.7.  I think the `future.exec_` workaround must have been for python 2.6, which we don't support anymore.  So I just switched exec_ -> exec, and it works fine.
3. `iteritems`, `itervalues`, `iterkeys`: These have only ever been an efficiency difference between python 2 and 3, and a minuscule one for all of our uses.  So I just switched them all to the regular `items`, `values`, `keys`.
4. `range`, `zip`: Similarly, the difference was just (slight) efficiency.  Just use the regular ones in both now.
5. `object`: I'm pretty sure this was already not needed.  I think `object` in 2.7 is already the python 3 version.
6. `int`: Our usage didn't care about the differences in functionality here, so I just use the native `int` in both and it's fine.
7. `input`: In python 2, this was called `raw_input`.  Easy to handle with a try/except NameError.  Just used in galsim_download_cosmos.py.
8. `super`: Python 2 doesn't have the no-argument version.  It's a little bit of extra typing, but I converted our uses of that to the more verbose one that works in both 2 and 3.  This was only being used in errors.py.