### PR TITLE
Rather than eigency, download eigen from internet if it's not already installed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ dist
 .pytest_cache
 .clang_complete
 pytest_session.txt
+downloaded_eigen

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,13 +118,16 @@ matrix:
 before_install:
     - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
     # Install the non-python dependencies: fftw, libav, eigen
-    - if [[ $TRAVIS_OS_NAME == "linux" ]]; then sudo -H apt-get -qq update; sudo -H apt-get install -y python-dev libfftw3-dev libeigen3-dev; fi
+    - if [[ $TRAVIS_OS_NAME == "linux" ]]; then sudo -H apt-get -qq update; sudo -H apt-get install -y python-dev libfftw3-dev; fi
+    # Don't install eigen on 3.7 so we test the ability of setup.py to install it for us.
+    - if [[ $TRAVIS_OS_NAME == "linux" && $TRAVIS_PYTHON_VERSION < 3.7 ]]; then sudo -H apt-get install -y libeigen3-dev; fi
     # Shouldn't usually need this, but occasionally might.
     - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew update; fi
-    - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew install fftw eigen; fi
+    - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew install fftw wget; fi
+    - if [[ $TRAVIS_OS_NAME == "osx" && $TRAVIS_PYTHON_VERSION < 3.7 ]]; then brew install eigen; fi
     - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew cask install gfortran; fi
     - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew upgrade wget; fi
-    - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew link --overwrite fftw eigen gcc; fi
+    - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew link --overwrite fftw gcc wget; fi
 
     # Only need this for the mpeg tests, which we don't do on 2.7
     - if [[ $TRAVIS_OS_NAME == "linux" && $TRAVIS_PYTHON_VERSION > 3.5 ]]; then sudo -H apt-get install -y libav-tools; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,7 @@ before_install:
     # Shouldn't usually need this, but occasionally might.
     - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew update; fi
     - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew install fftw wget; fi
-    - if [[ $TRAVIS_OS_NAME == "osx" && $TRAVIS_PYTHON_VERSION < 3.7 ]]; then brew install eigen; fi
+    - if [[ $TRAVIS_OS_NAME == "osx" && $TRAVIS_PYTHON_VERSION < 3.7 ]]; then brew install eigen; brew link --overwrite eigen; fi
     - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew cask install gfortran; fi
     - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew upgrade wget; fi
     - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew link --overwrite fftw gcc wget; fi

--- a/SConstruct
+++ b/SConstruct
@@ -2074,20 +2074,9 @@ def DoCppChecks(config):
     else:
         ok = config.CheckHeader('Eigen/Core',language='C++')
         if not ok:
-            # Try to get the correct include directory from eigency
-            try:
-                import eigency
-                print('Trying eigency installation: ',eigency.get_includes()[2])
-                config.env.Append(CPPPATH=eigency.get_includes()[2])
-                ok = config.CheckHeader('Eigen/Core',language='C++')
-            except ImportError:
-                pass
-        if not ok:
             ErrorExit(
                 'Eigen/Core not found',
-                'You should either specify the location of Eigen as EIGEN_DIR=... '
-                'or install eigency using: \n'
-                '    pip install git+git://github.com/wouterboomsma/eigency.git')
+                'You should specify the location of Eigen as EIGEN_DIR=... '
 
 
 def DoPyChecks(config):

--- a/docs/install_pip.rst
+++ b/docs/install_pip.rst
@@ -217,20 +217,19 @@ Installing Eigen
 
 GalSim uses Eigen for the C++-layer linear algebra calculations.  It is a
 header-only library, which means that nothing needs to be compiled to use it.
-You can download the header files yourself, but if you do not, then we use
-the pip-installable eigency module, which bundles the header files in their
-installed python directory.  So usually, this dependency should require no
-work on your part.
+You can download the header files yourself, but if you do not, then the
+installation script will download it for you automatically.  So usually,
+this dependency should require no work on your part.
 
-However, it might become useful to install Eigen separately from eigency
-e.g. if you want to upgrade to a newer version of Eigen than the one that is
-bundled with eigency.  (Eigen 3.2.8 is bundled with eigency 1.77.)  Therefore,
-this section describes several options for how to obtain and install Eigen.
+However, if you have a version of Eigen already installed on your system,
+you may want to use that.  If the right directory is in your path for
+include file (C_INCLUDE_PATH), it should find it.  If not, you may specify
+the right directory to use by setting the EIGEN_DIR environment variable.
 
-We require Eigen version >= 3.0.  Most tests have been done with Eigen 3.2.8
-or 3.3.4, but we have also tested on 3.0.4, so probably any 3.x version will
-work.  However, if you have trouble with another version, try upgrading to
-3.2.8 or later.
+We require Eigen version >= 3.0.  The version we download automatically is
+3.3.4, so that version is known to work.  We have also tested with versions
+3.2.8 and 3.0.4, so probably any 3.x version will work.  However, if you have
+trouble with another version, try upgrading to 3.3.4 or later.
 
 Note: Prior to version 2.0, GalSim used TMV for the linear algebra back end.
 This is still an option if you prefer (e.g. it may be faster for some use
@@ -341,31 +340,3 @@ If you use MacPorts, Eigen can be installed with::
 
 This will put it into the /opt/local/include directory on your system. GalSim
 knows to look here, so there is nothing additional you need to do.
-
-
-Using eigency
-^^^^^^^^^^^^^
-
-Eigency is a pip-installable module that bundles the Eigen header files, so it
-can also be used to install these files on your system.  Indeed, as mentioned
-above, we will use eigency automatically if Eigen is not found in one of the
-above locations.  So the above installations will take precendence, but
-eigency should work as a fall-back.
-
-Note: At the time of this writing, installation of eigency depends on having
-cython already installed.  I thought I fixed this with PR #26, but it was
-not quite complete.  There is now an open PR #27, which I believe will
-finish making pip install eigency work, even if you do not have cython
-installed.  But for now, you can do::
-
-    pip install cython
-    pip install eigency
-
-(in that order) to get it to work.  Alternatively, you can use my (MJ) version
-which is the source of PR #27.  This is pip installable as::
-
-    pip install rmjarvis.eigency
-
-
-
-

--- a/docs/install_pip.rst
+++ b/docs/install_pip.rst
@@ -223,7 +223,7 @@ this dependency should require no work on your part.
 
 However, if you have a version of Eigen already installed on your system,
 you may want to use that.  If the right directory is in your path for
-include file (C_INCLUDE_PATH), it should find it.  If not, you may specify
+include files (C_INCLUDE_PATH), it should find it.  If not, you may specify
 the right directory to use by setting the EIGEN_DIR environment variable.
 
 We require Eigen version >= 3.0.  The version we download automatically is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,2 @@
 [build-system]
-# Note: cython and eigency aren't always required, but if they turn out to be
-# necessary and they aren't specified here, then pip 10.x will fail.
-requires = ["setuptools>=38", "wheel", "pybind11>=2.2", "cython", "rmjarvis.eigency>=1.77"]
+requires = ["setuptools>=38", "wheel", "pybind11>=2.2"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,9 +10,3 @@ astropy>=2.0
 pybind11>=2.2
 pip>=18.0
 LSSTDESC.Coord>=1.2
-
-# Note: 1.77 was supposed to make this work, but it doesn't include a couple cpp files, so
-# it gives an error on installation.  Once the eigency people merge PR #27 and release another
-# version with that included, we can switch this back to the regular eigency package.
-# Until then, we can use rmjarvis.eigency, which includes the fix.
-rmjarvis.eigency>=1.77.1

--- a/setup.py
+++ b/setup.py
@@ -321,8 +321,8 @@ def find_eigen_dir(output=False):
 
     if output:
         print("Could not find Eigen in any of the standard locations.")
-        print("Will now try to download it from the internet.  This requires an internet")
-        print("connect, so will fail if you are currently offline.")
+        print("Will now try to download it from bitbucket.org. This requires an internet")
+        print("connection, so it will fail if you are currently offline.")
         print("If Eigen is installed in a non-standard location, and you want to use that")
         print("instead, you should make sure the right directory is either in your")
         print("C_INCLUDE_PATH or specified in an EIGEN_DIR environment variable.")
@@ -336,7 +336,7 @@ def find_eigen_dir(output=False):
         url = 'https://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2'
         if output:
             print("Downloading eigen from ",url)
-        u = urlopen('https://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2')
+        u = urlopen(url)
         fname = 'eigen.tar.bz2'
         block_sz = 32 * 1024
         with open(fname, 'wb') as f:
@@ -345,7 +345,7 @@ def find_eigen_dir(output=False):
                 f.write(buffer)
                 buffer = u.read(block_sz)
         if output:
-            print("Done. Unpacking tarball")
+            print("Downloaded %s.  Unpacking tarball."%fname)
         with tarfile.open(fname) as tar:
             tar.extractall(dir)
         os.remove(fname)

--- a/setup.py
+++ b/setup.py
@@ -303,6 +303,13 @@ def find_eigen_dir(output=False):
                 try_dirs.append(dir)
     if os.path.isdir('downloaded_eigen'):
         try_dirs.extend(glob.glob(os.path.join('downloaded_eigen','*')))
+    # eigency is a python package that bundles the Eigen header files, so if that's there,
+    # can use that.
+    try:
+        import eigency
+        try_dirs.append(eigency.get_includes()[2])
+    except ImportError:
+        pass
 
     if output: print("Looking for Eigen:")
     for dir in try_dirs:

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,12 @@ import types
 import subprocess
 import re
 import tempfile
+try:
+    from urllib2 import urlopen
+except ImportError:
+    from urllib.request import urlopen
+import tarfile
+import shutil
 
 try:
     from setuptools import setup, Extension, find_packages
@@ -322,12 +328,6 @@ def find_eigen_dir(output=False):
         print("C_INCLUDE_PATH or specified in an EIGEN_DIR environment variable.")
 
     try:
-        try:
-            from urllib2 import urlopen
-        except ImportError:
-            from urllib.request import urlopen
-        import tarfile
-        import shutil
         dir = 'downloaded_eigen'
         if os.path.isdir(dir):
             # If this exists, it was tried above and failed.  Something must be wrong with it.

--- a/setup.py
+++ b/setup.py
@@ -338,6 +338,7 @@ def find_eigen_dir(output=False):
         dir = 'downloaded_eigen'
         if os.path.isdir(dir):
             # If this exists, it was tried above and failed.  Something must be wrong with it.
+            print("Previous attempt to download eigen found. Deleting and trying again.")
             shutil.rmtree(dir)
         os.mkdir(dir)
         url = 'https://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2'

--- a/setup.py
+++ b/setup.py
@@ -318,8 +318,8 @@ def find_eigen_dir(output=False):
         print("Will now try to download it from the internet.  This requires an internet")
         print("connect, so will fail if you are currently offline.")
         print("If Eigen is installed in a non-standard location, and you want to use that")
-        print("instead, you should make sure the right directory is either in")
-        print("your C_INCLUDE_PATH or an EIGEN_DIR environment variable.")
+        print("instead, you should make sure the right directory is either in your")
+        print("C_INCLUDE_PATH or specified in an EIGEN_DIR environment variable.")
 
     try:
         try:


### PR DESCRIPTION
Since version 2.0 let us do `pip install galsim`, installation problems have been much reduced.  The only thing left that seems to be somewhat unreliable about the installation is Eigen.  Specifically my attempt to make it work automatically via eigency.

This doesn't always work, and lately has been hitting a bug in numpy, which they don't seem to have any plans to fix.  cf. #1076.  (See also #1035, and indeed all of the pip installation issues on the [FAQ](https://github.com/GalSim-developers/GalSim/wiki/Installation-FAQ-(pip,-setup.py)#2-installing-with-pip).)  There have been other bug reports people have sent separately, and I usually recommend `conda install eigen`, which works great, but requires conda, so doesn't work for everyone.

Anyway, this PR tries to fix this by getting rid of the eigency option and instead just download eigen from their website.  It's super quick and doesn't require any compiling, since Eigen is header-only.  So I think this will be much more reliable for the cases where people have had troubles with eigency.