### PR TITLE
Add ability to draw chromatic objects in config processing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,10 +121,10 @@ before_install:
     - if [[ $TRAVIS_OS_NAME == "linux" ]]; then sudo -H apt-get -qq update; sudo -H apt-get install -y python-dev libfftw3-dev libeigen3-dev; fi
     # Shouldn't usually need this, but occasionally might.
     #- if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew update; fi
-    - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew install fftw eigen wget; fi
+    - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew install fftw eigen; fi
     - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew cask install gfortran; fi
     - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew upgrade wget; fi
-    - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew link --overwrite fftw eigen wget gcc; fi
+    - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew link --overwrite fftw eigen gcc; fi
 
     # Only need this for the mpeg tests, which we don't do on 2.7
     - if [[ $TRAVIS_OS_NAME == "linux" && $TRAVIS_PYTHON_VERSION > 3.5 ]]; then sudo -H apt-get install -y libav-tools; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,7 +120,7 @@ before_install:
     # Install the non-python dependencies: fftw, libav, eigen
     - if [[ $TRAVIS_OS_NAME == "linux" ]]; then sudo -H apt-get -qq update; sudo -H apt-get install -y python-dev libfftw3-dev libeigen3-dev; fi
     # Shouldn't usually need this, but occasionally might.
-    #- if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew update; fi
+    - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew update; fi
     - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew install fftw eigen; fi
     - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew cask install gfortran; fi
     - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew upgrade wget; fi

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ API Changes
 Config Updates
 --------------
 
+- Added ability to draw chromatic objects with config files. (#510)
 - Fixed a few issues with parsing truth catalog items and, in general, places
   where a Current item might be used before it was parsed. (#1083)
 - Added value-type-specific type names like Random_float, Random_Angle, etc.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,6 +46,7 @@ Config Updates
 New Features
 ------------
 
+- Added atRedshift method for ChromaticObject. (#510)
 - Added galsim.utilities.pickle_shared() context, which lets the shared
   portion of an AtmosphericScreen be included in the pickle.  This allows
   the pickles to be recovered after writing to disk and reading back in,

--- a/docs/config_image.rst
+++ b/docs/config_image.rst
@@ -205,8 +205,8 @@ We don't currently have any examples of custom noise types, but it may be helpfu
     :show-inheritance:
 
 
-WCS
----
+WCS Field
+---------
 
 The ``pixel_scale`` attribute mentioned above is the usual way to define the connection between
 pixel coordinates and sky coordinates.  However, one can define a more complicated relationship,
@@ -316,4 +316,48 @@ the ``[source]`` links):
 .. autoclass:: galsim.config.ListWCSBuilder
     :show-inheritance:
 
+Bandpass Field
+--------------
 
+If you want to draw chromatic objects, then you also need to define the `Bandpass` to use
+for the image in a ``image.bandpass`` field.  Currently, there is only one defined
+type to use for the Bandpass, but the code is written in a modular way to allow for
+other types, including custom Bandpass types.
+
+* 'FileBandpass' is the default type here, and you may omit the type name when using it.
+
+    * ``file_name`` = *str_value* (required)  The file to read in.
+    * ``wave_type`` = *str_value* (required)  The unit of the wavelengths in the file ('nm' or 'Ang' or variations on these -- cf. `Bandpass`)
+    * ``blue_limit`` = *float_value* (optional)  Hard cut off on the blue side.
+    * ``red_limit`` = *float value* (optional)  Hard cut off on the red side.
+    * ``zeropoint`` = *flaot_value* (optional)  The zero-point to use.
+    * ``thin`` = *float_value* (optional)  If given, call `Bandpass.thin` on the Bandpass after reading in from the file, using this for the ``rel_err``.
+
+You may also define your own custom Bandpass type in the usual way
+with an importable module where you define a custom Builder class and register it with GalSim.
+The class should be a subclass of `galsim.config.BandpassBuilder`.
+
+.. autoclass:: galsim.config.BandpassBuilder
+    :members:
+
+Then, as usual, you need to register this type using::
+
+    galsim.config.RegisterBandpassType('CustomBandpass', CustomBandpassBuilder())
+
+.. autofunction:: galsim.config.RegisterBandpassType
+
+and tell the config parser the name of the module to load at the start of processing.
+
+.. code-block:: yaml
+
+    modules:
+        - my_custom_bandpass
+
+Then you can use this as a valid bandpass type:
+
+.. code-block:: yaml
+
+    image:
+        bandpass:
+            type: CustomBandpass
+            ...

--- a/docs/config_values.rst
+++ b/docs/config_values.rst
@@ -796,6 +796,6 @@ Then you can use this as a valid value type:
 For examples of custom values, see:
 
 * :download:`log_normal.py <../examples/des/log_normal.py>`
-* :download:`hsm_shape.py <../examples/des/hsm_shape.py>`
+* :download:`hsm_shape_measure.py <../examples/des/hsm_shape_measure.py>`
 * :download:`excluded_random.py <../examples/des/excluded_random.py>`
 * :download:`great3_reject <../examples/great3/great3_reject.py>`

--- a/docs/config_values.rst
+++ b/docs/config_values.rst
@@ -554,6 +554,12 @@ Variables that GalSim will provide for you to use:
     * Available if ``image_pos`` or ``world_pos`` is explicitly given in the ``stamp`` field.
     * A `galsim.PositionD` instance
 
+* ``sky_pos`` = the position of the object in sky coordinates (RA, Dec)
+
+    * Available if ``sky_pos`` is explicitly given in the ``stamp`` field.
+    * Available if ``world_pos`` is defined (as per above) and the WCS is a CelestialWCS.
+    * A `galsim.CelestialCoord` instance
+
 * ``image_center`` = the center of the image in pixels.  This is the position on the image that corresponds to ``world_pos = (0,0)``.
 
     * A `galsim.PositionD` instance

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -499,18 +499,18 @@ Demo 12
 -------
 
 :download:`demo12.py <../examples/demo12.py>`
+:download:`demo12.yaml <../examples/demo12.yaml>`
 
-This demo introduces the chromatic objects module galsim.chromatic, which handles wavelength-
-dependent profiles.  Three uses of this module are demonstrated:
+This demo introduces wavelength-dependent profiles.  Three kinds of chromatic profiles are
+demonstrated:
 
-1. A chromatic object representing a De Vaucouleurs galaxy with an early-type SED at redshift 0.8 is
-   created.  The galaxy is then drawn using the six LSST filter throughput curves to demonstrate
-   that the galaxy is a g-band dropout.
-2. A two-component bulge+disk galaxy, in which the bulge and disk have different SEDs, is created
-   and then drawn using LSST filters.
-3. A wavelength-dependent PSF is created to represent atmospheric effects of differential chromatic
-   refraction, and the wavelength dependence of Kolmogorov-turbulence-induced seeing.  This PSF is
-   used to draw a single Sersic galaxy in the LSST filters.
+1. A chromatic object representing a DeVaucouleurs galaxy with an early-type SED at redshift 0.8.
+   This galaxy is drawn using the six LSST filters, which demonstrate that the galaxy is a
+   g-band dropout.
+2. A two-component bulge+disk galaxy, in which the bulge and disk have different SEDs.
+3. A wavelength-dependent atmospheric PSF, which includes the effect of differential chromatic
+   refraction and the wavelength dependence of Kolmogorov-turbulence-induced seeing.  This PSF
+   is convolved with a simple Exponential galaxy.
 
 **New features in the Python file**:
 
@@ -526,8 +526,12 @@ dependent profiles.  Three uses of this module are demonstrated:
 
 **New features in the YAML file**:
 
-This demo currently does not have a YAML version.  The config processing of chromatic objects
-has not been implemented yet.
+- sed : file_name, wave_type, flux_type, norm_flux_density, norm_wavelength,
+        norm_flux, norm_bandpass
+- bandpass : filename, wave_type, thin
+- gal : redshift
+- psf_type : ChromaticAtmosphere (base_profile, base_wavelength, latitude, HA)
+
 
 Demo 13
 -------

--- a/examples/check_yaml
+++ b/examples/check_yaml
@@ -58,6 +58,9 @@ time galsim -v2 demo10.yaml || exit
 time $python demo11.py || exit
 time galsim -v2 demo11.yaml || exit
 
+time $python demo12.py || exit
+time galsim -v2 demo12.yaml || exit
+
 echo 'Checking diffs: (No output means success)'
 
 # demo1:
@@ -114,3 +117,12 @@ $python check_diff.py output/power_spectrum.fits output_yaml/power_spectrum.fits
 # demo11:
 $python check_diff.py output/tabulated_power_spectrum.fits.fz output_yaml/tabulated_power_spectrum.fits.fz
 
+# demo12:
+for part in a b c
+do
+    for band in u g r i z y
+    do
+        file_name=demo12${part}_${band}.fits
+        $python check_diff.py output/$file_name output_yaml/$file_name
+    done
+done

--- a/examples/demo11.yaml
+++ b/examples/demo11.yaml
@@ -120,6 +120,10 @@ psf :
     # tell GalSim that the pixel scale is 0.2 arcsec to match the pixel scale we use below.
     scale : *pixel_scale
 
+    # Make sure the PSF has flux=1.  Most PSF types have this by default, but InterpolatedImage
+    # doesn't, so set it here.
+    flux: 1
+
 # Define the galaxy profile
 gal :
 

--- a/examples/demo12.py
+++ b/examples/demo12.py
@@ -21,24 +21,21 @@ Demo #12
 The twelfth script in our tutorial about using GalSim in python scripts: examples/demo*.py.
 (This file is designed to be viewed in a window 100 characters wide.)
 
-This script currently doesn't have an equivalent demo*.yaml or demo*.json file.  The API for catalog
-level chromatic objects has not been written yet.
+This script introduces wavelength-dependent profiles. Three kinds of chromatic profiles are
+demonstrated here:
 
-This script introduces the chromatic objects module galsim.chromatic, which handles wavelength-
-dependent profiles.  Three uses of this module are demonstrated:
+1) A chromatic object representing a DeVaucouleurs galaxy with an early-type SED at redshift 0.8.
+   The galaxy is drawn using the six LSST filters, which demonstrate that the galaxy is a g-band
+   dropout.
 
-1) A chromatic object representing a De Vaucouleurs galaxy with an early-type SED at redshift 0.8 is
-created.  The galaxy is then drawn using the six LSST filter throughput curves to demonstrate that
-the galaxy is a g-band dropout.
+2) A two-component bulge+disk galaxy, in which the bulge and disk have different SEDs.
 
-2) A two-component bulge+disk galaxy, in which the bulge and disk have different SEDs, is created
-and then drawn using LSST filters.
+3) A wavelength-dependent atmospheric PSF, which includes the effect of differential chromatic
+   refraction and the wavelength dependence of Kolmogorov-turbulence-induced seeing.  This PSF
+   convolved with a simple Exponential galaxy.
 
-3) A wavelength-dependent PSF is created to represent atmospheric effects of differential chromatic
-refraction, and the wavelength dependence of Kolmogorov-turbulence-induced seeing.  This PSF is used
-to draw a single Sersic galaxy in the LSST filters.
-
-For all cases, suggested parameters for viewing in ds9 are also included.
+In all three cases, six images are created, which correspond to each of the LSST filters:
+u, g, r, i, z, and Y.  We also provide suggested parameters for viewing in ds9.
 
 New features introduced in this demo:
 
@@ -77,7 +74,6 @@ def main(argv):
 
     # initialize (pseudo-)random number generator
     random_seed = 1234567
-    rng = galsim.BaseDeviate(random_seed)
 
     # read in SEDs
     SED_names = ['CWW_E_ext', 'CWW_Sbc_ext', 'CWW_Scd_ext', 'CWW_Im_ext']
@@ -143,11 +139,16 @@ def main(argv):
     logger.debug('Created final profile')
 
     # draw profile through LSST filters
-    gaussian_noise = galsim.GaussianNoise(rng, sigma=0.1)
-    for filter_name, filter_ in filters.items():
+    for i, filter_name in enumerate(filters):
+        filter_ = filters[filter_name]
         img = galsim.ImageF(64, 64, scale=pixel_scale)
         final.drawImage(filter_, image=img)
+
+        # To match the yaml, we need a new rng for each file
+        rng = galsim.BaseDeviate(random_seed+1+i)
+        gaussian_noise = galsim.GaussianNoise(rng, sigma=0.02)
         img.addNoise(gaussian_noise)
+
         logger.debug('Created {0}-band image'.format(filter_name))
         out_filename = os.path.join(outpath, 'demo12a_{0}.fits'.format(filter_name))
         galsim.fits.write(img, out_filename)
@@ -183,10 +184,13 @@ def main(argv):
     logger.debug('Created bulge+disk galaxy final profile')
 
     # draw profile through LSST filters
-    gaussian_noise = galsim.GaussianNoise(rng, sigma=0.02)
-    for filter_name, filter_ in filters.items():
+    for i, filter_name in enumerate(filters):
+        filter_ = filters[filter_name]
         img = galsim.ImageF(64, 64, scale=pixel_scale)
         bdfinal.drawImage(filter_, image=img)
+
+        rng = galsim.BaseDeviate(random_seed+1+i)
+        gaussian_noise = galsim.GaussianNoise(rng, sigma=0.02)
         img.addNoise(gaussian_noise)
         logger.debug('Created {0}-band image'.format(filter_name))
         out_filename = os.path.join(outpath, 'demo12b_{0}.fits'.format(filter_name))
@@ -257,10 +261,13 @@ def main(argv):
     logger.debug('Created chromatic PSF final profile')
 
     # Draw profile through LSST filters
-    gaussian_noise = galsim.GaussianNoise(rng, sigma=0.03)
-    for filter_name, filter_ in filters.items():
+    for i, filter_name in enumerate(filters):
+        filter_ = filters[filter_name]
         img = galsim.ImageF(64, 64, scale=pixel_scale)
         final.drawImage(filter_, image=img)
+
+        rng = galsim.BaseDeviate(random_seed+1+i)
+        gaussian_noise = galsim.GaussianNoise(rng, sigma=0.02)
         img.addNoise(gaussian_noise)
         logger.debug('Created {0}-band image'.format(filter_name))
         out_filename = os.path.join(outpath, 'demo12c_{0}.fits'.format(filter_name))

--- a/examples/demo12.py
+++ b/examples/demo12.py
@@ -32,7 +32,7 @@ demonstrated here:
 
 3) A wavelength-dependent atmospheric PSF, which includes the effect of differential chromatic
    refraction and the wavelength dependence of Kolmogorov-turbulence-induced seeing.  This PSF
-   convolved with a simple Exponential galaxy.
+   is convolved with a simple Exponential galaxy.
 
 In all three cases, six images are created, which correspond to each of the LSST filters:
 u, g, r, i, z, and Y.  We also provide suggested parameters for viewing in ds9.

--- a/examples/demo12.yaml
+++ b/examples/demo12.yaml
@@ -1,0 +1,216 @@
+# Copyright (c) 2012-2019 by the GalSim developers team on GitHub
+# https://github.com/GalSim-developers
+#
+# This file is part of GalSim: The modular galaxy image simulation toolkit.
+# https://github.com/GalSim-developers/GalSim
+#
+# GalSim is free software: redistribution and use in source and binary forms,
+# with or without modification, are permitted provided that the following
+# conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions, and the disclaimer given in the accompanying LICENSE
+#    file.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions, and the disclaimer given in the documentation
+#    and/or other materials provided with the distribution.
+#
+#
+# Demo #12
+#
+# The twelfth YAML configuration file in our tutorial about using Galsim config files.
+# (This file is designed to be viewed in a window 100 characters wide.)
+#
+# This script introduces wavelength-dependent profiles. Three kinds of chromatic profiles are
+# demonstrated here:
+# 
+# 1) A chromatic object representing a DeVaucouleurs galaxy with an early-type SED at redshift 0.8.
+#    This galaxy is drawn using the six LSST filters, which demonstrate that the galaxy is a
+#    g-band dropout.
+# 
+# 2) A two-component bulge + disk galaxy, in which the bulge and disk have different SEDs.
+# 
+# 3) A wavelength-dependent atmospheric PSF, which includes the effect of differential chromatic
+#    refraction and the wavelength dependence of Kolmogorov-turbulence-induced seeing.  This PSF
+#    convolved with a simple Exponential galaxy.
+# 
+# In all three cases, six images are created, which correspond to each of the LSST filters:
+# u, g, r, i, z, and y.
+# 
+# New features introduced in this demo:
+# 
+# - sed : file_name, wave_type, flux_type
+# - bandpass : filename, wave_type
+# - gal : redshift
+# - psf_type : ChromaticAtmosphere (base_profile, base_wavelength, latitude, HA)
+
+
+
+eval_variables:
+    # It will be convenient to have the single-character filter name to use in Eval items.
+    sfilter:
+        type: List
+        items: [ u, g, r, i, z, y ]
+        index_key: file_num
+
+# Define some other information about the images
+image:
+    type: Single
+
+    size: 64
+
+    noise:
+        type: Gaussian
+        sigma: 0.02
+
+    pixel_scale: 0.2  # arcsec (LSST)
+
+    random_seed: 1234567
+
+    bandpass:
+        file_name:
+            type: FormattedStr
+            format: "LSST_%s.dat"
+            items:
+                - $filter
+        wave_type: nm   # Wavelength in these files is in nm.
+        thin: 1.e-4
+
+output:
+
+    nfiles: 6
+    dir: output_yaml
+    file_name:
+        type: FormattedStr
+        format: "demo12a_%s.fits"
+        items:
+            - $filter
+
+--- 
+
+# 1) A chromatic object representing a DeVaucouleurs galaxy with an early-type SED at redshift 0.8.
+#    This galaxy is drawn using the six LSST filters, which demonstrate that the galaxy is a
+#    g-band dropout.
+
+gal:
+    type: DeVaucouleurs
+    half_light_radius: 0.5
+
+    sed:
+        file_name: CWW_E_ext.sed
+        wave_type: Ang
+        flux_type: flambda
+        norm_flux_density: 1.0
+        norm_wavelength: 500
+
+    redshift: 0.8
+
+    shear:
+        type: G1G2
+        g1: 0.5
+        g2: 0.3
+
+    dilate: 1.05
+
+    shift:
+        type: XY
+        x: 0
+        y: 0.1
+
+psf:
+    type: Moffat
+    fwhm: 0.6
+    beta: 2.5
+
+---
+
+# 2) A two-component bulge + disk galaxy, in which the bulge and disk have different SEDs.
+
+gal:
+    type: Sum
+    items:
+        -
+            type: DeVaucouleurs
+            half_light_radius: 0.5
+            sed: 
+                file_name: CWW_E_ext.sed
+                wave_type: Ang
+                flux_type: flambda
+                norm_flux_density: 1.0
+                norm_wavelength: 500
+            shear:
+                type: G1G2
+                g1: 0.12
+                g2: 0.07
+            scale_flux: 0.8
+        -
+            type: Exponential
+            half_light_radius: 2.0
+            sed:
+                file_name: CWW_Im_ext.sed
+                wave_type: Ang
+                flux_type: flambda
+                norm_flux_density: 1.0
+                norm_wavelength: 500
+            shear:
+                type: G1G2
+                g1: 0.4
+                g2: 0.2
+            scale_flux: 4
+
+    redshift: 0.8
+    scale_flux: 1.1
+
+psf:
+    type: Moffat
+    fwhm: 0.6
+    beta: 2.5
+
+output:
+    file_name:
+        format: "demo12b_%s.fits"
+
+
+---
+
+# 3) A wavelength-dependent atmospheric PSF, which includes the effect of differential chromatic
+#    refraction and the wavelength dependence of Kolmogorov-turbulence-induced seeing.  This PSF
+#    convolved with a simple Sersic galaxy.
+
+psf:
+    type: ChromaticAtmosphere
+    base_profile:
+        type: Moffat
+        fwhm: 0.5
+        beta: 2.5
+    base_wavelength: 500
+    latitude: 19.8207 deg
+    HA: -1.0 hour
+
+gal:
+    type: Exponential
+    half_light_radius: 0.5
+
+    sed:
+        file_name: CWW_Im_ext.sed
+        wave_type: Ang
+        flux_type: flambda
+        norm_flux: 50
+        norm_bandpass:
+            file_name: LSST_g.dat
+            wave_type: nm
+            thin: 1.e-4
+    shear:
+        type: G1G2
+        g1: 0.5
+        g2: 0.3
+
+stamp:
+    sky_pos:
+        type: RADec
+        ra: 14:03:13 hours
+        dec: 54:20:57 degrees
+
+output:
+    file_name:
+        format: "demo12c_%s.fits"

--- a/examples/demo12.yaml
+++ b/examples/demo12.yaml
@@ -32,18 +32,18 @@
 # 
 # 3) A wavelength-dependent atmospheric PSF, which includes the effect of differential chromatic
 #    refraction and the wavelength dependence of Kolmogorov-turbulence-induced seeing.  This PSF
-#    convolved with a simple Exponential galaxy.
+#    is convolved with a simple Exponential galaxy.
 # 
 # In all three cases, six images are created, which correspond to each of the LSST filters:
 # u, g, r, i, z, and y.
 # 
 # New features introduced in this demo:
 # 
-# - sed : file_name, wave_type, flux_type
-# - bandpass : filename, wave_type
+# - sed : file_name, wave_type, flux_type, norm_flux_density, norm_wavelength,
+#         norm_flux, norm_bandpass
+# - bandpass : filename, wave_type, thin
 # - gal : redshift
 # - psf_type : ChromaticAtmosphere (base_profile, base_wavelength, latitude, HA)
-
 
 
 eval_variables:

--- a/examples/demo12.yaml
+++ b/examples/demo12.yaml
@@ -23,22 +23,31 @@
 #
 # This script introduces wavelength-dependent profiles. Three kinds of chromatic profiles are
 # demonstrated here:
-# 
+#
 # 1) A chromatic object representing a DeVaucouleurs galaxy with an early-type SED at redshift 0.8.
 #    This galaxy is drawn using the six LSST filters, which demonstrate that the galaxy is a
 #    g-band dropout.
-# 
+#
 # 2) A two-component bulge + disk galaxy, in which the bulge and disk have different SEDs.
-# 
+#
 # 3) A wavelength-dependent atmospheric PSF, which includes the effect of differential chromatic
 #    refraction and the wavelength dependence of Kolmogorov-turbulence-induced seeing.  This PSF
 #    is convolved with a simple Exponential galaxy.
-# 
+#
 # In all three cases, six images are created, which correspond to each of the LSST filters:
 # u, g, r, i, z, and y.
-# 
+#
+# After running this script, you can use the following ds9 commands to view the outputs
+# in various ways:
+#
+# 1) ds9 output_yaml/demo12a_*.fits -match scale -zoom 2 -match frame image
+# 2) ds9 -rgb -blue -scale limits -0.2 0.8 output_yaml/demo12b_r.fits
+#             -green -scale limits -0.25 1.0 output_yaml/demo12b_i.fits
+#             -red -scale limits -0.25 1.0 output_yaml/demo12b_z.fits -zoom 2
+# 3) ds9 output_yaml/demo12c_*.fits -match scale -zoom 2 -match frame image -blink
+#
 # New features introduced in this demo:
-# 
+#
 # - sed : file_name, wave_type, flux_type, norm_flux_density, norm_wavelength,
 #         norm_flux, norm_bandpass
 # - bandpass : filename, wave_type, thin
@@ -86,7 +95,7 @@ output:
         items:
             - $filter
 
---- 
+---
 
 # 1) A chromatic object representing a DeVaucouleurs galaxy with an early-type SED at redshift 0.8.
 #    This galaxy is drawn using the six LSST filters, which demonstrate that the galaxy is a
@@ -132,7 +141,7 @@ gal:
         -
             type: DeVaucouleurs
             half_light_radius: 0.5
-            sed: 
+            sed:
                 file_name: CWW_E_ext.sed
                 wave_type: Ang
                 flux_type: flambda

--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -2966,11 +2966,6 @@ class ChromaticOpticalPSF(ChromaticObject):
                 lam=wave, diam=self.diam,
                 aberrations=self.aberrations*(self.lam/wave), scale_unit=self.scale_unit,
                 gsparams=self.gsparams, **self.kwargs)
-        if '_force_stepk' not in self.kwargs:
-            # These don't change much, and figuring out good stepk and maxk values are very slow.
-            # So once we've done this once, just keep using those values.
-            self.kwargs['_force_stepk'] = ret.stepk
-            self.kwargs['_force_maxk'] = ret.maxk
         return ret
 
 

--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -2992,6 +2992,10 @@ class ChromaticAiry(ChromaticObject):
                         gsparams.  See `galsim.Airy` docstring for a complete description of these
                         options.
     """
+    _req_params = { 'lam' : float }
+    _opt_params = { 'scale_unit' : str }
+    _single_params = [ {'diam' : float, 'lam_over_diam' : float} ]
+
     def __init__(self, lam, diam=None, lam_over_diam=None, scale_unit=None, gsparams=None,
                  **kwargs):
         from .angle import AngleUnit, arcsec, radians

--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -24,6 +24,7 @@ from .bandpass import Bandpass
 from .position import PositionD, PositionI
 from .utilities import lazy_property, doc_inherit
 from .gsparams import GSParams
+from .phase_psf import OpticalPSF
 from . import utilities
 from . import integ
 from .errors import GalSimError, GalSimRangeError, GalSimSEDError, GalSimValueError
@@ -2855,6 +2856,10 @@ class ChromaticOpticalPSF(ChromaticObject):
                         related to struts, obscuration, oversampling, etc.  See OpticalPSF
                         docstring for a complete list of options.
     """
+    _req_params = { 'lam' : float }
+    _opt_params = { k:v for k,v in OpticalPSF._opt_params.items() if k != 'diam' }
+    _single_params = [ {'diam' : float, 'lam_over_diam' : float} ]
+
     def __init__(self, lam, diam=None, lam_over_diam=None, aberrations=None,
                  scale_unit=None, gsparams=None, **kwargs):
         from .angle import AngleUnit, arcsec, radians
@@ -2954,7 +2959,6 @@ class ChromaticOpticalPSF(ChromaticObject):
         Parameters:
              wave:  Wavelength in nanometers.
         """
-        from .phase_psf import OpticalPSF
         # We need to rescale the stored lam/diam by the ratio of input wavelength to stored fiducial
         # wavelength.  Likewise, the aberrations were in units of wavelength for the fiducial
         # wavelength, so we have to convert to units of waves for *this* wavelength.

--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -2962,6 +2962,11 @@ class ChromaticOpticalPSF(ChromaticObject):
                 lam=wave, diam=self.diam,
                 aberrations=self.aberrations*(self.lam/wave), scale_unit=self.scale_unit,
                 gsparams=self.gsparams, **self.kwargs)
+        if '_force_stepk' not in self.kwargs:
+            # These don't change much, and figuring out good stepk and maxk values are very slow.
+            # So once we've done this once, just keep using those values.
+            self.kwargs['_force_stepk'] = ret.stepk
+            self.kwargs['_force_maxk'] = ret.maxk
         return ret
 
 

--- a/galsim/config/__init__.py
+++ b/galsim/config/__init__.py
@@ -26,6 +26,8 @@ from .image import *
 from .stamp import *
 from .noise import *
 from .wcs import *
+from .bandpass import *
+from .sed import *
 from .gsobject import *
 from .value import *
 from .value_eval import eval_base_variables

--- a/galsim/config/bandpass.py
+++ b/galsim/config/bandpass.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2012-2019 by the GalSim developers team on GitHub
+# https://github.com/GalSim-developers
+#
+# This file is part of GalSim: The modular galaxy image simulation toolkit.
+# https://github.com/GalSim-developers/GalSim
+#
+# GalSim is free software: redistribution and use in source and binary forms,
+# with or without modification, are permitted provided that the following
+# conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions, and the disclaimer given in the accompanying LICENSE
+#    file.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions, and the disclaimer given in the documentation
+#    and/or other materials provided with the distribution.
+#
+
+import logging
+
+from .util import LoggerWrapper
+from .value import ParseValue, GetAllParams, GetIndex
+from .input import RegisterInputConnectedType
+from ..errors import GalSimConfigError, GalSimConfigValueError
+from ..bandpass import Bandpass
+from ..utilities import basestring
+
+# This module-level dict will store all the registered Bandpass types.
+# See the RegisterBandpassType function at the end of this file.
+# The keys are the (string) names of the Bandpass types, and the values will be builders that know
+# how to build the Bandpass object.
+valid_bandpass_types = {}
+
+def BuildBandpass(config, key, base, logger=None):
+    """Read the Bandpass parameters from config[key] and return a constructed Bandpass object.
+
+    Parameters:
+        config:     A dict with the configuration information.
+        key:        The key name in config indicating which object to build.
+        base:       The base dict of the configuration.
+        logger:     Optionally, provide a logger for logging debug statements. [default: None]
+
+    Returns:
+        (bandpass, safe) where bandpass is a Bandpass instance, and safe is whether it is safe to
+                         reuse.
+    """
+    logger = LoggerWrapper(logger)
+    logger.debug('obj %d: Start BuildBandpass key = %s',base.get('obj_num',0),key)
+
+    param = config[key]
+
+    # Check for direct value, else get the bandpass type
+    if isinstance(param, Bandpass):
+        return param, True
+    elif isinstance(param, basestring) and (param[0] == '$' or param[0] == '@'):
+        return ParseValue(config, key, base, None)
+    elif isinstance(param, dict):
+        bandpass_type = param.get('type', 'FileBandpass')
+    else:
+        raise GalSimConfigError("%s must be either a Bandpass or a dict"%key)
+
+    # For these two, just do the usual ParseValue function.
+    if bandpass_type in ('Eval', 'Current'):
+        return ParseValue(config, key, base, None)
+
+    # Check if we can use the current cached object
+    index, index_key = GetIndex(param, base)
+    if 'current' in param:
+        cbandpass, csafe, cvalue_type, cindex, cindex_key = param['current']
+        if cindex == index:
+            logger.debug('obj %d: The Bandpass object is already current', base.get('obj_num',0))
+            logger.debug('obj %d: index_key = %s, index = %d',base.get('obj_num',0),
+                         cindex_key, cindex)
+            return cbandpass, csafe
+
+    if bandpass_type not in valid_bandpass_types:
+        raise GalSimConfigValueError("Invalid bandpass.type.", bandpass_type, valid_bandpass_types)
+    logger.debug('obj %d: Building bandpass type %s', base.get('obj_num',0), bandpass_type)
+    builder = valid_bandpass_types[bandpass_type]
+    bandpass, safe = builder.buildBandpass(param, base, logger)
+    logger.debug('obj %d: bandpass = %s', base.get('obj_num',0), bandpass)
+
+    param['current'] = bandpass, safe, Bandpass, index, index_key
+
+    return bandpass, safe
+
+
+class BandpassBuilder(object):
+    """A base class for building Bandpass objects.
+
+    The base class defines the call signatures of the methods that any derived class should follow.
+    """
+    def buildBandpass(self, config, base, logger):
+        """Build the Bandpass based on the specifications in the config dict.
+
+        Note: Sub-classes must override this function with a real implementation.
+
+        Parameters:
+            config:     The configuration dict for the bandpass type.
+            base:       The base configuration dict.
+            logger:     If provided, a logger for logging debug statements.
+
+        Returns:
+            the constructed Bandpass object.
+        """
+        raise NotImplementedError("The %s class has not overridden buildBandpass"%self.__class__)
+
+
+class FileBandpassBuilder(BandpassBuilder):
+    """A class for loading a Bandpass from a file
+
+    FileBandpass expected the following parameters:
+
+        file_name (str)     The file to load (required)
+        wave_type(str)      The units (nm or Ang) of the wavelengths in the file (required)
+        thin (floatl)       A relative error to use for thinning the file (default: None)
+        blue_limit (float)  A cutoff wavelength on the blue side (default: None)
+        red_limit (float)   A cutoff wavelength on the red side (default: None)
+        zeropoint (float)   A zeropoint to use (default: None)
+    """
+    def buildBandpass(self, config, base, logger):
+        """Build the Bandpass based on the specifications in the config dict.
+
+        Parameters:
+            config:     The configuration dict for the bandpass type.
+            base:       The base configuration dict.
+            logger:     If provided, a logger for logging debug statements.
+
+        Returns:
+            the constructed Bandpass object.
+        """
+        logger = LoggerWrapper(logger)
+
+        req = {'file_name': str, 'wave_type': str}
+        opt = {'thin' : float, 'blue_limit' : float, 'red_limit' : float, 'zeropoint': float }
+
+        kwargs, safe = GetAllParams(config, base, req=req, opt=opt)
+
+        file_name = kwargs.pop('file_name')
+        thin = kwargs.pop('thin', None)
+
+        logger.info("Reading Bandpass file: %s",file_name)
+        bandpass = Bandpass(file_name, **kwargs)
+        if thin:
+            bandpass = bandpass.thin(thin)
+
+        return bandpass, safe
+
+def RegisterBandpassType(bandpass_type, builder, input_type=None):
+    """Register a bandpass type for use by the config apparatus.
+
+    Parameters:
+        bandpass_type:  The name of the type in the config dict.
+        builder:        A builder object to use for building the Bandpass object.  It should
+                        be an instance of a subclass of BandpassBuilder.
+        input_type:     If the Bandpass builder utilises an input object, give the key name of the
+                        input type here.  (If it uses more than one, this may be a list.)
+                        [default: None]
+    """
+    valid_bandpass_types[bandpass_type] = builder
+    RegisterInputConnectedType(input_type, bandpass_type)
+
+RegisterBandpassType('FileBandpass', FileBandpassBuilder())

--- a/galsim/config/extra_truth.py
+++ b/galsim/config/extra_truth.py
@@ -16,6 +16,7 @@
 #    and/or other materials provided with the distribution.
 #
 
+import sys
 import numpy as np
 from .extra import ExtraOutputBuilder, RegisterExtraOutput
 from .value import ParseValue, GetCurrentValue
@@ -45,12 +46,15 @@ class TruthBuilder(ExtraOutputBuilder):
 
         # Warn if the config dict isn't an OrderedDict.
         cols = config['columns']
-        if logger and not hasattr(cols, '__reversed__') and not config.get('_warned',False):
+        if (sys.version_info < (3,6) and logger and not hasattr(cols, '__reversed__')
+                and not config.get('_warned',False)):
             # If config doesn't have a __reversed__ attribute, then it's not an OrderedDict.
             # Probably it's just a regular dict.  So warn the user that the columns are in
             # arbitrary order.
             # (This was the simplest difference I could find between dict and OrderedDict that
             #  seemed relevant.)
+            # And note that starting in 3.6, the regular dict is ordered, so don't bother
+            # with this check.
             logger.warning('The config dict is not an OrderedDict.  The columns in the output '
                            'truth catalog will be in arbitrary order.')
             config['_warned'] = True

--- a/galsim/config/gsobject.py
+++ b/galsim/config/gsobject.py
@@ -440,7 +440,7 @@ def _BuildChromaticAtmosphere(config, base, ignore, gsparams, logger):
     from .util import CleanConfig
 
     req = {'base_wavelength' : float}
-    opt = {'sale_unit' : str,
+    opt = {
            'alpha' : float,
            'zenith_angle' : Angle,
            'parallactic_angle' : Angle,

--- a/galsim/config/gsobject.py
+++ b/galsim/config/gsobject.py
@@ -460,7 +460,11 @@ def _BuildChromaticAtmosphere(config, base, ignore, gsparams, logger):
     safe = safe and safe1
 
     if 'zenith_angle' not in kwargs:
-        kwargs['obj_coord'] = base['world_pos']
+        sky_pos = base.get('sky_pos', None)
+        if sky_pos is None:
+            raise GalSimConfigError("Using zenith_angle with type=ChromaticAtmosphere requires "
+                                    "that sky_pos be available to use as the object coord.")
+        kwargs['obj_coord'] = sky_pos
         safe = False
 
     psf = ChromaticAtmosphere(base_profile, **kwargs)

--- a/galsim/config/gsobject.py
+++ b/galsim/config/gsobject.py
@@ -432,6 +432,40 @@ def _BuildOpticalPSF(config, base, ignore, gsparams, logger):
 
     return OpticalPSF(**kwargs), safe
 
+def _BuildChromaticAtmosphere(config, base, ignore, gsparams, logger):
+    """Build a ChromaticAtmosphere.
+    """
+    from ..chromatic import ChromaticAtmosphere
+    from ..celestial import CelestialCoord
+    from .util import CleanConfig
+
+    req = {'base_wavelength' : float}
+    opt = {'sale_unit' : str,
+           'alpha' : float,
+           'zenith_angle' : Angle,
+           'parallactic_angle' : Angle,
+           'zenith_coord' : CelestialCoord,
+           'HA' : Angle,
+           'latitude' : Angle,
+           'pressure' : float,
+           'temperature' : float,
+           'H2O_pressure' : float,
+          }
+    ignore = ['base_profile'] + ignore
+    kwargs, safe = GetAllParams(config, base, req=req, opt=opt, ignore=ignore)
+
+    if 'base_profile' not in config:
+        raise GalSimConfigError("Attribute base_profile is required for type=ChromaticAtmosphere")
+    base_profile, safe1 = BuildGSObject(config, 'base_profile', base, gsparams, logger)
+    safe = safe and safe1
+
+    if 'zenith_angle' not in kwargs:
+        kwargs['obj_coord'] = base['world_pos']
+        safe = False
+
+    psf = ChromaticAtmosphere(base_profile, **kwargs)
+    return psf, safe
+
 
 #
 # Now the functions for performing transformations
@@ -549,4 +583,4 @@ RegisterObjectType('Convolve', _BuildConvolve)
 RegisterObjectType('Convolution', _BuildConvolve)
 RegisterObjectType('List', _BuildList)
 RegisterObjectType('OpticalPSF', _BuildOpticalPSF)
-
+RegisterObjectType('ChromaticAtmosphere', _BuildChromaticAtmosphere)

--- a/galsim/config/image.py
+++ b/galsim/config/image.py
@@ -24,6 +24,7 @@ from .input import SetupInput, SetupInputsForImage
 from .extra import SetupExtraOutputsForImage, ProcessExtraOutputsForImage
 from .value import ParseValue, GetAllParams
 from .wcs import BuildWCS
+from .bandpass import BuildBandpass
 from .stamp import BuildStamp, MakeStampTasks
 from ..errors import GalSimConfigError, GalSimConfigValueError
 from ..position import PositionI, PositionD
@@ -212,11 +213,22 @@ def SetupConfigImageSize(config, xsize, ysize, logger=None):
     else:
         config['world_center'] = wcs.toWorld(config['image_center'])
 
+def SetupConfigBandpass(config, logger=None):
+    """If thre is a 'bandpass' field in config['image'], load it.
+
+    Parameters:
+        config:     The configuration dict.
+        logger:     If given, a logger object to log progress. [default: None]
+    """
+    image = config['image']
+    if 'bandpass' in image:
+        config['bandpass'] = BuildBandpass(image, 'bandpass', config, logger)[0]
+
 
 # Ignore these when parsing the parameters for specific Image types:
 from .stamp import stamp_image_keys
 image_ignore = [ 'random_seed', 'noise', 'pixel_scale', 'wcs', 'sky_level', 'sky_level_pixel',
-                 'world_center', 'index_convention', 'nproc'] + stamp_image_keys
+                 'world_center', 'index_convention', 'nproc', 'bandpass'] + stamp_image_keys
 
 def BuildImage(config, image_num=0, obj_num=0, logger=None):
     """
@@ -251,6 +263,9 @@ def BuildImage(config, image_num=0, obj_num=0, logger=None):
     logger.debug('image %d: image_size = %d, %d',image_num,xsize,ysize)
     logger.debug('image %d: image_origin = %s',image_num,config['image_origin'])
     logger.debug('image %d: image_center = %s',image_num,config['image_center'])
+
+    # If there is a bandpass field, load it into config['bandpass']
+    SetupConfigBandpass(config, logger)
 
     # Sometimes an input field needs to do something special at the start of an image.
     SetupInputsForImage(config, logger)

--- a/galsim/config/input.py
+++ b/galsim/config/input.py
@@ -293,10 +293,18 @@ def SetupInputsForImage(config, logger=None):
                     input_obj = input_objs[i]
                     loader.setupImage(input_obj, field, config, logger)
 
+def GetNumInputObj(input_type, base):
+    """Get the number of input objects of the given type
+
+    Parameters:
+        input_type: The type of input object to count
+        base:       The base config dict
+    """
+    return len(base['_input_objs'][input_type])
 
 # A helper function for getting the input object needed for generating a value or building
 # a gsobject.
-def GetInputObj(input_type, config, base, param_name):
+def GetInputObj(input_type, config, base, param_name, num=0):
     """Get the input object needed for generating a particular value
 
     Parameters:
@@ -310,14 +318,12 @@ def GetInputObj(input_type, config, base, param_name):
         raise GalSimConfigError(
             "No input %s available for type = %s"%(input_type,param_name))
 
-    if 'num' in config:
+    if num == 0 and 'num' in config:
         num = ParseValue(config, 'num', base, int)[0]
-    else:
-        num = 0
 
     if num < 0:
         raise GalSimConfigValueError("Invalid num < 0 supplied for %s."%param_name, num)
-    if num >= len(base['_input_objs'][input_type]):
+    if num >= GetNumInputObj(input_type, base):
         raise GalSimConfigValueError("Invalid num supplied for %s (too large)"%param_name, num)
 
     return base['_input_objs'][input_type][num]

--- a/galsim/config/sed.py
+++ b/galsim/config/sed.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2012-2019 by the GalSim developers team on GitHub
+# https://github.com/GalSim-developers
+#
+# This file is part of GalSim: The modular galaxy image simulation toolkit.
+# https://github.com/GalSim-developers/GalSim
+#
+# GalSim is free software: redistribution and use in source and binary forms,
+# with or without modification, are permitted provided that the following
+# conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions, and the disclaimer given in the accompanying LICENSE
+#    file.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions, and the disclaimer given in the documentation
+#    and/or other materials provided with the distribution.
+#
+
+import logging
+
+from .util import LoggerWrapper
+from .value import ParseValue, GetAllParams, GetIndex
+from .input import RegisterInputConnectedType
+from ..errors import GalSimConfigError, GalSimConfigValueError
+from ..sed import SED
+from ..bandpass import Bandpass
+from ..utilities import basestring
+
+# This module-level dict will store all the registered SED types.
+# See the RegisterSEDType function at the end of this file.
+# The keys are the (string) names of the SED types, and the values will be builders that know
+# how to build the SED object.
+valid_sed_types = {}
+
+def BuildSED(config, key, base, logger=None):
+    """Read the SED parameters from config[key] and return a constructed SED object.
+
+    Parameters:
+        config:     A dict with the configuration information.
+        key:        The key name in config indicating which object to build.
+        base:       The base dict of the configuration.
+        logger:     Optionally, provide a logger for logging debug statements. [default: None]
+
+    Returns:
+        (sed, safe) where sed is an SED instance, and safe is whether it is safe to reuse.
+    """
+    logger = LoggerWrapper(logger)
+    logger.debug('obj %d: Start BuildSED key = %s',base.get('obj_num',0),key)
+
+    param = config[key]
+
+    # Check for direct value, else get the SED type
+    if isinstance(param, SED):
+        return param, True
+    elif isinstance(param, basestring) and (param[0] == '$' or param[0] == '@'):
+        return ParseValue(config, key, base, None)
+    elif isinstance(param, dict):
+        sed_type = param.get('type','FileSED')
+    else:
+        raise GalSimConfigError("%s must be either an SED or a dict"%key)
+
+    # For these two, just do the usual ParseValue function.
+    if sed_type in ('Eval', 'Current'):
+        return ParseValue(config, key, base, None)
+
+    # Check if we can use the current cached object
+    index, index_key = GetIndex(param, base)
+    if 'current' in param:
+        csed, csafe, cvalue_type, cindex, cindex_key = param['current']
+        if cindex == index:
+            logger.debug('obj %d: The SED object is already current', base.get('obj_num',0))
+            logger.debug('obj %d: index_key = %s, index = %d',base.get('obj_num',0),
+                         cindex_key, cindex)
+            return csed, csafe
+
+    if sed_type not in valid_sed_types:
+        raise GalSimConfigValueError("Invalid sed.type.", sed_type, valid_sed_types)
+    logger.debug('obj %d: Building sed type %s', base.get('obj_num',0), sed_type)
+    builder = valid_sed_types[sed_type]
+    sed, safe = builder.buildSED(param, base, logger)
+    logger.debug('obj %d: sed = %s', base.get('obj_num',0), sed)
+
+    param['current'] = sed, safe, SED, index, index_key
+
+    return sed, safe
+
+
+class SEDBuilder(object):
+    """A base class for building SED objects.
+
+    The base class defines the call signatures of the methods that any derived class should follow.
+    """
+    def buildSED(self, config, base, logger):
+        """Build the SED based on the specifications in the config dict.
+
+        Note: Sub-classes must override this function with a real implementation.
+
+        Parameters:
+            config:     The configuration dict for the SED type.
+            base:       The base configuration dict.
+            logger:     If provided, a logger for logging debug statements.
+
+        Returns:
+            the constructed SED object.
+        """
+        raise NotImplementedError("The %s class has not overridden buildSED"%self.__class__)
+
+
+class FileSEDBuilder(SEDBuilder):
+    """A class for loading an SED from a file
+
+    FileSED expected the following parameters:
+
+        file_name (required)    The file to load
+        wave_type(required)     The units (nm or Ang) of the wavelengths in the file
+        flux_type (required)    Which kind of flux values are in the file
+                                Allowed values: flambda, fnu, fphotons, 1
+    """
+    def buildSED(self, config, base, logger):
+        """Build the SED based on the specifications in the config dict.
+
+        Parameters:
+            config:     The configuration dict for the SED type.
+            base:       The base configuration dict.
+            logger:     If provided, a logger for logging debug statements.
+
+        Returns:
+            the constructed SED object.
+        """
+        from .bandpass import BuildBandpass
+        logger = LoggerWrapper(logger)
+
+        req = {'file_name': str, 'wave_type': str, 'flux_type': str}
+        opt = {'norm_flux_density': float, 'norm_wavelength': float,
+               'norm_flux': float, 'redshift': float}
+        ignore = ['norm_bandpass']
+
+        kwargs, safe = GetAllParams(config, base, req=req, opt=opt, ignore=ignore)
+
+        file_name = kwargs.pop('file_name')
+
+        norm_flux_density = kwargs.pop('norm_flux_density', None)
+        norm_wavelength = kwargs.pop('norm_wavelength', None)
+        norm_flux = kwargs.pop('norm_flux', None)
+        redshift = kwargs.pop('redshift', 0.)
+
+        logger.info("Reading SED file: %s",file_name)
+        sed = SED(file_name, **kwargs)
+        if norm_flux_density:
+            sed = sed.withFluxDensity(norm_flux_density, wavelength=norm_wavelength)
+        elif norm_flux:
+            bandpass, safe1 = BuildBandpass(config, 'norm_bandpass', base, logger)
+            sed = sed.withFlux(norm_flux, bandpass=bandpass)
+            safe = safe and safe1
+        sed = sed.atRedshift(redshift)
+
+        return sed, safe
+
+def RegisterSEDType(sed_type, builder, input_type=None):
+    """Register a SED type for use by the config apparatus.
+
+    Parameters:
+        sed_type:       The name of the type in the config dict.
+        builder:        A builder object to use for building the SED object.  It should
+                        be an instance of a subclass of SEDBuilder.
+        input_type:     If the SED builder utilises an input object, give the key name of the
+                        input type here.  (If it uses more than one, this may be a list.)
+                        [default: None]
+    """
+    valid_sed_types[sed_type] = builder
+    RegisterInputConnectedType(input_type, sed_type)
+
+RegisterSEDType('FileSED', FileSEDBuilder())

--- a/galsim/config/stamp.py
+++ b/galsim/config/stamp.py
@@ -694,9 +694,14 @@ class StampBuilder(object):
         elif world_pos is not None and image_pos is None:
             image_pos = wcs.toImage(world_pos)
 
+        if 'sky_pos' in config:
+            base['sky_pos'] = ParseValue(config, 'sky_pos', base, CelestialCoord)[0]
+        elif isinstance(world_pos, CelestialCoord):
+            base['sky_pos'] = world_pos
+
         # Wherever we use the world position, we expect a Euclidean position, not a
         # CelestialCoord.  So if it is the latter, project it onto a tangent plane at the
-        # image center.
+        # image center. (sky_pos is available as a CelestialCoord when we need that.)
         if isinstance(world_pos, CelestialCoord):
             # Then project this position relative to the image center.
             world_center = base.get('world_center', wcs.toWorld(base['image_center']))
@@ -731,10 +736,6 @@ class StampBuilder(object):
         base['stamp_offset'] = stamp_offset
         base['image_pos'] = image_pos
         base['world_pos'] = world_pos
-        if 'sky_pos' in config:
-            base['sky_pos'] = ParseValue(config, 'sky_pos', base, CelestialCoord)[0]
-        elif isinstance(world_pos, CelestialCoord):
-            base['sky_pos'] = world_pos
 
         if xsize:
             logger.debug('obj %d: xsize,ysize = %s,%s',base['obj_num'],xsize,ysize)

--- a/galsim/config/stamp.py
+++ b/galsim/config/stamp.py
@@ -221,7 +221,7 @@ def SetupConfigStampSize(config, xsize, ysize, image_pos, world_pos, logger=None
 
 
 # Ignore these when parsing the parameters for specific stamp types:
-stamp_ignore = ['xsize', 'ysize', 'size', 'image_pos', 'world_pos',
+stamp_ignore = ['xsize', 'ysize', 'size', 'image_pos', 'world_pos', 'sky_pos',
                 'offset', 'retry_failures', 'gsparams', 'draw_method',
                 'n_photons', 'max_extra_noise', 'poisson_flux',
                 'skip', 'reject', 'min_flux_frac', 'min_snr', 'max_snr',
@@ -731,6 +731,10 @@ class StampBuilder(object):
         base['stamp_offset'] = stamp_offset
         base['image_pos'] = image_pos
         base['world_pos'] = world_pos
+        if 'sky_pos' in config:
+            base['sky_pos'] = ParseValue(config, 'sky_pos', base, CelestialCoord)[0]
+        elif isinstance(world_pos, CelestialCoord):
+            base['sky_pos'] = world_pos
 
         if xsize:
             logger.debug('obj %d: xsize,ysize = %s,%s',base['obj_num'],xsize,ysize)

--- a/galsim/config/stamp.py
+++ b/galsim/config/stamp.py
@@ -37,6 +37,8 @@ from ..celestial import CelestialCoord
 from ..angle import arcsec
 from ..gsobject import GSObject
 from ..convolve import Convolve
+from ..chromatic import ChromaticObject
+from ..bandpass import Bandpass
 
 # This file handles the building of postage stamps to place onto a larger image.
 # There is only one type of stamp currently, called Basic, which builds a galaxy from
@@ -488,9 +490,14 @@ def DrawBasic(prof, image, method, offset, config, base, logger, **kwargs):
         max_extra_noise *= noise_var
         kwargs['max_extra_noise'] = max_extra_noise
 
+    if isinstance(prof, ChromaticObject) and 'bandpass' not in base:
+        raise GalSimConfigError("Drawing chromatic object requires specifying bandpass")
+    kwargs['bandpass'] = base.get('bandpass',None)
+
     if logger.isEnabledFor(logging.DEBUG):
-        # Don't output the full image array.  Use str(image) for that kwarg.
-        alt_kwargs = dict([(k,str(kwargs[k]) if isinstance(kwargs[k],Image) else kwargs[k])
+        # Don't output the full image array.  Use str(image) for that kwarg.  And Bandpass.
+        alt_kwargs = dict([(k, str(kwargs[k]) if isinstance(kwargs[k],(Image,Bandpass))
+                               else kwargs[k])
                            for k in kwargs])
         logger.debug('obj %d: drawImage kwargs = %s',base.get('obj_num',0), alt_kwargs)
         logger.debug('obj %d: prof = %s',base.get('obj_num',0),prof)
@@ -499,6 +506,7 @@ def DrawBasic(prof, image, method, offset, config, base, logger, **kwargs):
     except Exception as e:
         logger.debug('obj %d: prof = %r', base.get('obj_num',0), prof)
         raise
+    logger.debug('obj %d: added_flux = %s',base.get('obj_num',0), image.added_flux)
     return image
 
 def ParseWorldPos(config, param_name, base, logger):

--- a/galsim/config/value.py
+++ b/galsim/config/value.py
@@ -24,7 +24,7 @@ from .util import PropagateIndexKeyRNGNum, GetIndex, ParseExtendedKey
 
 from ..errors import GalSimConfigError, GalSimConfigValueError
 from ..gsobject import GSObject
-from ..angle import Angle, AngleUnit, radians, degrees
+from ..angle import Angle, AngleUnit, radians, degrees, hours
 from ..position import PositionD
 from ..celestial import CelestialCoord
 from ..shear import Shear
@@ -429,9 +429,14 @@ def _GetAngleValue(param):
     """
     try :
         value, unit = param.rsplit(None,1)
-        value = float(value)
         unit = AngleUnit.from_name(unit)
-        return Angle(value, unit)
+        if unit is hours and ':' in value:
+            return Angle.from_hms(value)
+        elif unit is degrees and ':' in value:
+            return Angle.from_dms(value)
+        else:
+            value = float(value)
+            return Angle(value, unit)
     except (ValueError, TypeError, AttributeError) as e:
         raise GalSimConfigError("Unable to parse %s as an Angle. Caught %s"%(param,e))
 

--- a/galsim/config/value_eval.py
+++ b/galsim/config/value_eval.py
@@ -58,7 +58,7 @@ def _type_by_letter(key):
 eval_base_variables = [ 'image_pos', 'world_pos', 'image_center', 'image_origin', 'image_bounds',
                         'image_xsize', 'image_ysize', 'stamp_xsize', 'stamp_ysize', 'pixel_scale',
                         'wcs', 'rng', 'file_num', 'image_num', 'obj_num', 'start_obj_num',
-                        'world_center', ]
+                        'world_center', 'sky_pos', ]
 
 from .value import standard_ignore
 eval_ignore = ['str','_fn'] + standard_ignore

--- a/galsim/config/wcs.py
+++ b/galsim/config/wcs.py
@@ -28,6 +28,7 @@ from ..fitswcs import TanWCS, FitsWCS
 from ..angle import Angle, AngleUnit
 from ..position import PositionD
 from ..celestial import CelestialCoord
+from ..utilities import basestring
 
 # This file handles the construction of wcs types in config['image']['wcs'].
 
@@ -66,14 +67,12 @@ def BuildWCS(config, key, base, logger=None):
     # Check for direct value, else get the wcs type
     if isinstance(param, BaseWCS):
         return param
-    elif param == str(param) and (param[0] == '$' or param[0] == '@'):
+    elif isinstance(param, basestring) and (param[0] == '$' or param[0] == '@'):
         return ParseValue(config, key, base, None)[0]
-    elif not isinstance(param, dict):
-        raise GalSimConfigError("wcs must be either a BaseWCS or a dict")
-    elif 'type' in param:
-        wcs_type = param['type']
+    elif isinstance(param, dict):
+        wcs_type = param.get('type', 'PixelScale')
     else:
-        wcs_type = 'PixelScale'
+        raise GalSimConfigError("wcs must be either a BaseWCS or a dict")
 
     # For these two, just do the usual ParseValue function.
     if wcs_type in ('Eval', 'Current'):

--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -419,6 +419,8 @@ class GSObject(object):
     def dimensionless(self): return True
     @property
     def wave_list(self): return np.array([], dtype=float)
+    @property
+    def redshift(self): return getattr(self, '_redshift', 0.)
 
     # Also need this method to duck-type as a ChromaticObject
     def evaluateAtWavelength(self, wave):
@@ -1044,6 +1046,21 @@ class GSObject(object):
         from .transform import _Transform
         new_obj = _Transform(self, offset=offset)
         return new_obj
+
+    def atRedshift(self, redshift):
+        """Create a version of the current object with a different redshift.
+
+        For regular GSObjects, this method doesn't do anything aside from setting a ``redshift``
+        attribute with the given value.  But this allows duck typing with ChromaticObjects
+        where this function will adjust the SED appropriately.
+
+        Returns:
+            the object with the new redshift
+        """
+        from copy import copy
+        ret = copy(self)
+        ret._redshift = redshift
+        return ret
 
     # Make sure the image is defined with the right size and wcs for drawImage()
     def _setup_image(self, image, nx, ny, bounds, add_to_image, dtype, center, odd=False):

--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -1238,7 +1238,7 @@ class GSObject(object):
                   center=None, use_true_center=True, offset=None,
                   n_photons=0., rng=None, max_extra_noise=0.,
                   poisson_flux=None, sensor=None, surface_ops=(), n_subsample=3, maxN=None,
-                  save_photons=False, setup_only=False):
+                  save_photons=False, bandpass=None, setup_only=False):
         """Draws an `Image` of the object.
 
         The drawImage() method is used to draw an `Image` of the current object using one of several
@@ -1570,6 +1570,9 @@ class GSObject(object):
                             [default: None, which means no limit]
             save_photons:   If True, save the `PhotonArray` as ``image.photons``. Only valid if
                             method is 'phot' or sensor is not None.  [default: False]
+            bandpass:       This parameter is ignored, but is allowed to enable duck typing
+                            eqivalence between this method and the ChromaticObject.drawImage
+                            method. [default: None]
             setup_only:     Don't actually draw anything on the image.  Just make sure the image
                             is set up correctly.  This is used internally by GalSim, but there
                             may be cases where the user will want the same functionality.
@@ -2361,7 +2364,7 @@ class GSObject(object):
         raise NotImplementedError("%s does not implement shoot"%self.__class__.__name__)
 
     def drawKImage(self, image=None, nx=None, ny=None, bounds=None, scale=None,
-                   add_to_image=False, recenter=True, setup_only=False):
+                   add_to_image=False, recenter=True, bandpass=None, setup_only=False):
         """Draws the k-space (complex) `Image` of the object, with bounds optionally set by input
         `Image` instance.
 
@@ -2399,6 +2402,13 @@ class GSObject(object):
                             bounds. [default: False]
             recenter:       Whether to recenter the image to put k = 0 at the center (True) or to
                             trust the provided bounds (False).  [default: True]
+            bandpass:       This parameter is ignored, but is allowed to enable duck typing
+                            eqivalence between this method and the ChromaticObject.drawImage
+                            method. [default: None]
+            setup_only:     Don't actually draw anything on the image.  Just make sure the image
+                            is set up correctly.  This is used internally by GalSim, but there
+                            may be cases where the user will want the same functionality.
+                            [default: False]
 
         Returns:
             an `Image` instance (created if necessary)

--- a/galsim/main.py
+++ b/galsim/main.py
@@ -24,7 +24,7 @@ from __future__ import print_function
 import sys
 import os
 import logging
-import pprint
+import json
 import argparse
 
 from ._version import __version__ as version
@@ -191,7 +191,7 @@ def process_config(all_config, args, logger):
         if args.profile:
             config['profile'] = True
 
-        logger.debug("Process config dict: \n%s", pprint.pformat(config))
+        logger.debug("Process config dict: \n%s", json.dumps(config, indent=4))
 
         # Process the configuration
         Process(config, logger, njobs=args.njobs, job=args.job, new_params=new_params,

--- a/galsim/real.py
+++ b/galsim/real.py
@@ -993,6 +993,17 @@ class ChromaticRealGalaxy(ChromaticSum):
                                 them.  [default: None]
 
     """
+    _req_params = {}
+    # TODO: SEDs isn't implemented yet in config parser.
+    _opt_params = { "k_interpolant" : str ,
+                    "maxk" : float,
+                    "pad_factor" : float,
+                    "noise_pad_size" : float,
+                    "area_norm" : float
+                  }
+    _single_params = [ { "index" : int , "id" : str , "random" : bool } ]
+    _takes_rng = True
+
     def __init__(self, real_galaxy_catalogs, index=None, id=None, random=False, rng=None,
                  gsparams=None, logger=None, **kwargs):
         from .random import BaseDeviate, UniformDeviate

--- a/galsim/roman/roman_psfs.py
+++ b/galsim/roman/roman_psfs.py
@@ -43,7 +43,7 @@ def getPSF(SCA, bandpass,
 
     This routine carries out linear interpolation of the aberrations within a given SCA, based on
     the Roman (then WFIRST) Cycle 7 specification of the aberrations as a function of focal plane
-    position, more specifically from `Roman_Phase-A_SRR_WFC_Zernike_and_Field_Data_170727.xlsm`
+    position, more specifically from ``Roman_Phase-A_SRR_WFC_Zernike_and_Field_Data_170727.xlsm``
     downloaded from https://roman.gsfc.nasa.gov/science/Roman_Reference_Information.html.  Phase
     B updates that became available in mid-2019 have not yet been incorporated into this module.
     (Note: the files at that url still use the old WFIRST name.  We have renamed them to use the

--- a/galsim/sed.py
+++ b/galsim/sed.py
@@ -466,12 +466,9 @@ class SED(object):
 
     def _mul_sed(self, other):
         """Equivalent to self * other when other is an SED, but no sanity checks."""
-        if self.spectral:
-            redshift = self.redshift
-        elif other.spectral:
-            redshift = other.redshift
-        else:
-            redshift = 0.0
+        # There should only be one SED with a non-trivial redshift, so adding them
+        # should always give us the right net redshift to use.
+        redshift = self.redshift + other.redshift
 
         fast = self.fast and other.fast
 
@@ -755,6 +752,8 @@ class SED(object):
         Returns:
             the redshifted `SED`.
         """
+        if redshift == self.redshift:
+            return self
         if redshift <= -1:
             raise GalSimRangeError("Invalid redshift", redshift, -1.)
         zfactor = (1.0 + redshift) / (1.0 + self.redshift)

--- a/galsim/transform.py
+++ b/galsim/transform.py
@@ -89,8 +89,8 @@ def Transform(obj, jac=(1.,0.,0.,1.), offset=PositionD(0.,0.), flux_ratio=1., gs
             return ChromaticConvolution( [first] + [o for o in obj.obj_list[1:]] )
 
         else:
-            return ChromaticTransformation(obj, jac, offset, flux_ratio, gsparams,
-                                           propagate_gsparams)
+            return ChromaticTransformation(obj, jac, offset, flux_ratio, gsparams=gsparams,
+                                           propagate_gsparams=propagate_gsparams)
     else:
         return Transformation(obj, jac, offset, flux_ratio, gsparams, propagate_gsparams)
 

--- a/tests/test_config_gsobject.py
+++ b/tests/test_config_gsobject.py
@@ -1971,3 +1971,4 @@ if __name__ == "__main__":
     test_list()
     test_repeat()
     test_usertype()
+    test_sed()

--- a/tests/test_config_image.py
+++ b/tests/test_config_image.py
@@ -1897,7 +1897,8 @@ def test_index_key():
         psf_shear = galsim.Shear(e=e, beta=beta)
         kolm = kolm.shear(psf_shear)
         airy = galsim.Airy(lam=700, diam=4)
-        psf = galsim.Convolve(kolm, airy).withFlux(1.0)
+        psf = galsim.Convolve(kolm, airy)
+        assert np.isclose(psf.flux, 1.0, rtol=1.e-15)
         print('fwhm, shear = ',fwhm,psf_shear._g)
         ellip_e1 = file_rng() * 0.4 - 0.2
 

--- a/tests/test_config_image.py
+++ b/tests/test_config_image.py
@@ -2507,6 +2507,7 @@ if __name__ == "__main__":
     test_tiled()
     test_njobs()
     test_wcs()
+    test_bandpass()
     test_index_key()
     test_multirng()
     test_template()

--- a/tests/test_config_image.py
+++ b/tests/test_config_image.py
@@ -2486,7 +2486,20 @@ def test_chromatic():
     del config['sky_pos']
     with assert_raises(galsim.GalSimConfigError):
         galsim.config.BuildImage(config)
-    config['sky_pos'] = sky_pos
+
+    config['psf'] =  {
+        'type': 'ChromaticAiry',
+        'lam' : 550,
+        'diam' : 6.5,
+    }
+    galsim.config.RemoveCurrent(config)
+    print(config)
+    image = galsim.config.BuildImage(config)
+
+    psf4 = galsim.ChromaticAiry(lam=550, diam=6.5)
+    final = galsim.Convolve(gal, psf4)
+    image4 = final.drawImage(nx=64, ny=64, scale=0.2, bandpass=bandpass)
+    np.testing.assert_allclose(image.array, image4.array)
 
     del config['image']['bandpass']
     del config['bandpass']

--- a/tests/test_config_output.py
+++ b/tests/test_config_output.py
@@ -1034,8 +1034,8 @@ def test_extra_truth():
     np.testing.assert_almost_equal(cat.data['shape.g1'], meas_g1)
     np.testing.assert_almost_equal(cat.data['shape.g2'], meas_g2)
 
-    # Note: Starting in python 3.8, dict is equivalent to OrderedDict
-    if sys.version_info < (3,8):
+    # Note: Starting in python 3.6, dict is equivalent to OrderedDict
+    if sys.version_info < (3,6):
         # Check that a warning is properly logged when columns are not an ordered dict.
         # These need to be done with BuildFile, not Process, so original isn't copied.
         # 1. When it is an OrderedDict, no warning.

--- a/tests/test_config_value.py
+++ b/tests/test_config_value.py
@@ -1071,9 +1071,9 @@ def test_angle_value():
         'str1' : '0.73 radians',
         'str2' : '240 degrees',
         'str3' : '1.2 rad',
-        'str4' : '45 deg',
+        'str4' : '45:12:55.1 deg',
         'str5' : '6 hrs',
-        'str6' : '21 hour',
+        'str6' : '21:31:05.3 hour',
         'str7' : '-240 arcmin',
         'str8' : '1800 arcsec',
         'cat1' : { 'type' : 'Radians' ,
@@ -1129,13 +1129,13 @@ def test_angle_value():
     np.testing.assert_almost_equal(str3.rad, 1.2)
 
     str4 = galsim.config.ParseValue(config,'str4',config, galsim.Angle)[0]
-    np.testing.assert_almost_equal(str4.rad, math.pi/4)
+    np.testing.assert_almost_equal(str4.rad, galsim.Angle.from_dms('45:12:55.1').rad)
 
     str5 = galsim.config.ParseValue(config,'str5',config, galsim.Angle)[0]
     np.testing.assert_almost_equal(str5.rad, math.pi/2)
 
     str6 = galsim.config.ParseValue(config,'str6',config, galsim.Angle)[0]
-    np.testing.assert_almost_equal(str6.rad, 7*math.pi/4)
+    np.testing.assert_almost_equal(str6.rad, galsim.Angle.from_hms('21:31:05.3').rad)
 
     str7 = galsim.config.ParseValue(config,'str7',config, galsim.Angle)[0]
     np.testing.assert_almost_equal(str7 / galsim.degrees, -4)


### PR DESCRIPTION
This PR addresses Issue #510 to implement drawing chromatic objects via the config layer.  Mostly, I targeted implementing demo12 as a YAML config file, which certainly gets most of the interesting chromatic functionality.

This required adding SED, Bandpass, and ChormaticAtmosphere to the config processing.  Only minor updates related to the random number sequence were required in demo12.py to get them to match up.