### PR TITLE
Test an equivalent to a simple version of fpack/funpack using galsim.fits functions.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -92,3 +92,5 @@ Bug Fixes
   of (r0, L0, lam). (#1058)
 - Fixed minor bug in repr of OpticalPSF class. (#1061)
 - Fixed bug in RandomKnots when multiplied by an SED. (#1064)
+- Fixed bug that galsim.fits.writeMulti didn't properly write the header
+  information in each hdu. (#1091)

--- a/galsim/fits.py
+++ b/galsim/fits.py
@@ -465,6 +465,19 @@ def writeMulti(image_list, file_name=None, dir=None, hdu_list=None, clobber=True
 
     The details of how the images are written to file depends on the arguments.
 
+    .. note::
+
+        This function along with `readMulti` can be used to effect the equivalent of a simple
+        version of fpack or funpack. To Rice compress a fits file, you can call::
+
+            fname = 'some_image_file.fits'
+            galsim.fits.writeMulti(galsim.fits.readMulti(fname, read_headers=True), fname+'.fz')
+
+        To uncompress::
+
+            fname = 'some_image_file.fits.fz'
+            galsim.fits.writeMulti(galsim.fits.readMulti(fname, read_headers=True), fname[:-3])
+
     Parameters:
         image_list:     A Python list of `Image` instances.  (For convenience, some items in this
                         list may be HDUs already.  Any `Image` will be converted into an
@@ -819,6 +832,19 @@ def readMulti(file_name=None, dir=None, hdu_list=None, compression='auto', read_
     scale will be set to 1.0.
 
     This function is called as ``im = galsim.fits.readMulti(...)``
+
+    .. note::
+
+        This function along with `writeMulti` can be used to effect the equivalent of a simple
+        version of fpack or funpack. To Rice compress a fits file, you can call::
+
+            fname = 'some_image_file.fits'
+            galsim.fits.writeMulti(galsim.fits.readMulti(fname, read_headers=True), fname+'.fz')
+
+        To uncompress::
+
+            fname = 'some_image_file.fits.fz'
+            galsim.fits.writeMulti(galsim.fits.readMulti(fname, read_headers=True), fname[:-3])
 
     Parameters:
         file_name:      The name of the file to read in.  [Either ``file_name`` or ``hdu_list`` is

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -3449,13 +3449,16 @@ def test_fpack():
     from astropy.io import fits
     file_name0 = os.path.join('des_data','DECam_00158414_01.fits.fz')
     hdulist = fits.open(file_name0)
-    hdulist.verify('silentfix')
+
     # Remove a few invalid header keys in the DECam fits file
-    # The I/O works if we don't, but it complicates the later tests.
+    # The I/O works if we don't, but they complicate the later tests.
+    # Easier to just get rid of them.
+    hdulist.verify('silentfix')
     for k in list(hdulist[1].header.keys()):
         if k.startswith('G-') or k.startswith('time_recorded'):
             print('remove header key ',k,hdulist[1].header[k])
             del hdulist[1].header[k]
+
     file_name1 = os.path.join('des_data','DECam_00158414_01_fix.fits.fz')
     hdulist.writeto(file_name1, overwrite=True)
 
@@ -3475,8 +3478,7 @@ def test_fpack():
     assert len(imlist1) == len(imlist3)
     for im1, im3 in zip(imlist1, imlist3):
         for key in im1.header.keys():
-            #if key in im3.header and key not in ['XTENSION','COMMENT','HISTORY','']:
-            if key in im3.header and key not in ['COMMENT','HISTORY','']:
+            if key in im3.header and key not in ['XTENSION','COMMENT','HISTORY','']:
                 if isinstance(im1.header[key], str):
                     assert im1.header[key] == im3.header[key]
                 else:

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -3459,7 +3459,7 @@ def test_fpack():
             print('remove header key ',k,hdulist[1].header[k])
             del hdulist[1].header[k]
 
-    file_name1 = os.path.join('des_data','DECam_00158414_01_fix.fits.fz')
+    file_name1 = os.path.join('output','DECam_00158414_01_fix.fits.fz')
     hdulist.writeto(file_name1, overwrite=True)
 
     file_name2 = os.path.join('output','DECam_00158414_01.fits')


### PR DESCRIPTION
I was having trouble getting fpack to work on a system, and I realized that GalSim already did what I needed using readMulti and writeMulti.

Except that it didn't quite work correctly.  I discovered that writeMulti didn't properly write the header information when there were non-trivial headers on the images, so the round trip lost the header values I needed from the original files.

So this PR fixes that, and also adds a note about how to effect at least a very simple version of fpack and funpack with galsim, and tests these operations that they preserve at least most of the header values.  (Some get changed by astropy's verify operations, so I skip those.)