### PR TITLE
Update Roman PSF orientation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -80,6 +80,8 @@ New Features
 - Added FittedSIPWCS to fit a WCS from a list of image and celestial
   coordinates. (#1092)
 - Extended GSFitsWCS to support -SIP distortions for non-TAN WCSs. (#1092)
+- Added wcs option to Roman getPSF function to more easily get the right PSF
+  in world coordinates for a particular observation. (#1094)
 
 
 Performance Improvements

--- a/galsim/roman/roman_psfs.py
+++ b/galsim/roman/roman_psfs.py
@@ -90,7 +90,7 @@ def getPSF(SCA, bandpass,
     The PSF that is returned by default will be oriented with respect to the SCA coordinates,
     not world coordinates as is typical in GalSim.  The pupil plane has a fixed orientation
     with respect to the focal plane, so the PSF rotates with the telescope.  To obtain a
-    PSF in world coordinates, which can be convolved with galaxies (who are normally described
+    PSF in world coordinates, which can be convolved with galaxies (that are normally described
     in world coordinates), you may pass in a ``wcs`` parameter to this function.  This will
     project the PSF into world coordinates according to that WCS before returning it.  Otherwise,
     the return value is equivalent to using ``wcs=galim.PixelScale(galsim.roman.pixel_scale)``.

--- a/galsim/roman/roman_psfs.py
+++ b/galsim/roman/roman_psfs.py
@@ -87,7 +87,7 @@ def getPSF(SCA, bandpass,
         to recover any memory currently being used for this cache.  Of course, subsequent calls to
         `getPSF` will need to rebuild the aperture at that point.
 
-    The PSF that is returned be default will be oriented with respect to the image coordinates,
+    The PSF that is returned by default will be oriented with respect to the SCA coordinates,
     not world coordinates as is typical in GalSim.  The pupil plane has a fixed orientation
     with respect to the focal plane, so the PSF rotates with the telescope.  To obtain a
     PSF in world coordinates, which can be convolved with galaxies (who are normally described

--- a/galsim/table.py
+++ b/galsim/table.py
@@ -307,7 +307,7 @@ class LookupTable(object):
                                      # it from pandas.
         try:
             import pandas
-            from pandas.io.common import ParserError
+            from pandas.errors import ParserError
             data = pandas.read_csv(file_name, comment='#', delim_whitespace=True, header=None)
             data = data.values.transpose()
         except (ImportError, AttributeError, ParserError):


### PR DESCRIPTION
@troxel pointed out a subtlety with the Roman PSFs that we had been doing wrong in demo13 and which he also did wrong in his WFIRST sims.  Namely, the PSF that is returned by `galsim.roman.getPSF` is oriented with respect to the image coordinates, not world coordinates.  

While it is in arcsec (not pixels, so kind of in world coordinates), the pupil plane rotates with the camera, so observations with different PA values don't have the diffraction spikes rotate correctly as the telescope rotates.  This led to coadd images in Troxel's sims having very pronounced spikes, whereas we actually expect them to be washed out by the varying PA angles.

This PR fixes that by adding an optional `wcs` parameter to the `getPSF` function.  To get the PSF in world coordinates (as is standard everywhere else in GalSim), you need to provide the wcs of the image onto which you will be drawing it.  Otherwise, it will return the PSF oriented along the image directions as before.