### PR TITLE
Remove the _nobjects_only mechanism from input objects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -59,6 +59,11 @@ Config Updates
   the case that the longer one might not be parsed properly. (#1083)
 - Added ``photon_ops`` and ``sensor`` as options in the stamp processing.
   (#1093)
+- Removed the ``_nobjects_only`` mechanism from input objects.  If this
+  pattern was useful for a custom input type, you should switch to using lazy
+  properties to delay the loading of data other than what is needed for
+  determining the number of objects.  See `Catalog` for an example of how
+  to do this.
 
 
 New Features

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,9 @@ API Changes
 - Deprecated the ``surface_ops`` parameter to `GSObject.drawImage`, switching
   to the name ``photon_ops``, since these don't have to be something that
   happens at the surface of the sensor. (#1093)
+- Added logger option to some config functions and methods. If you are using
+  custom Image or Output types, you may need to add a ``logger=None`` optional
+  parameter to some method signatures.
 
 
 Config Updates

--- a/SConstruct
+++ b/SConstruct
@@ -2076,7 +2076,7 @@ def DoCppChecks(config):
         if not ok:
             ErrorExit(
                 'Eigen/Core not found',
-                'You should specify the location of Eigen as EIGEN_DIR=... '
+                'You should specify the location of Eigen as EIGEN_DIR=... ')
 
 
 def DoPyChecks(config):

--- a/devel/time_wcs.py
+++ b/devel/time_wcs.py
@@ -1,4 +1,5 @@
 import time
+import timeit
 import numpy as np
 import galsim
 import astropy.io.fits as fits
@@ -14,18 +15,24 @@ for fn in fns:
     x = rng.uniform(0, header['NAXIS1'], size=size)
     y = rng.uniform(0, header['NAXIS2'], size=size)
 
+    wcs = galsim.GSFitsWCS(header=header)
+    ra, dec = wcs.xyToradec(x, y, units='rad')
+
     print()
     print(fn)
     print(f"PV?  {'PV1_1' in header}")
     print(f"SIP?  {'A_ORDER' in header}")
 
-    wcs = galsim.GSFitsWCS(header=header)
-    t0 = time.time()
-    ra, dec = wcs.xyToradec(x, y, units='rad')
-    t1 = time.time()
-    print(f"xyToradec {t1-t0:.3f}")
+    t = min(timeit.repeat(lambda: wcs.xyToradec(x,y,units='rad'), number=3))
+    print(f"xyToradec {t:.3f}")
+    #t0 = time.time()
+    #ra, dec = wcs.xyToradec(x, y, units='rad')
+    #t1 = time.time()
+    #print(f"xyToradec {t1-t0:.3f}")
 
-    t0 = time.time()
-    x1, y1 = wcs.radecToxy(ra, dec, units='rad')
-    t1 = time.time()
-    print(f"radecToxy {t1-t0:.3f}")
+    t = min(timeit.repeat(lambda: wcs.radecToxy(ra,dec,units='rad'), number=3))
+    print(f"radecToxy {t:.3f}")
+    #t0 = time.time()
+    #x1, y1 = wcs.radecToxy(ra, dec, units='rad')
+    #t1 = time.time()
+    #print(f"radecToxy {t1-t0:.3f}")

--- a/galsim/__init__.py
+++ b/galsim/__init__.py
@@ -109,7 +109,7 @@ if not os.path.exists(lib_file): # pragma: no cover
 # Import things from other files we want to be in the galsim namespace
 
 # First some basic building blocks that don't usually depend on anything else
-from .position import Position, PositionI, PositionD
+from .position import Position, PositionI, PositionD, _PositionI, _PositionD
 from .bounds import Bounds, BoundsI, BoundsD, _BoundsI, _BoundsD
 from .shear import Shear, _Shear
 from .angle import Angle, AngleUnit, _Angle, radians, hours, degrees, arcmin, arcsec

--- a/galsim/__init__.py
+++ b/galsim/__init__.py
@@ -195,7 +195,7 @@ from .nfw_halo import NFWHalo, Cosmology
 # Detector effects
 from .sensor import Sensor, SiliconSensor
 from . import detectors  # Everything here is a method of Image, so nothing to import by name.
-from .utilities import set_omp_threads  # This one we bring into the main scope.
+from .utilities import set_omp_threads, get_omp_threads  # These we bring into the main scope.
 
 # Deprecated functionality
 from . import deprecated

--- a/galsim/bounds.py
+++ b/galsim/bounds.py
@@ -449,7 +449,7 @@ class BoundsI(Bounds):
 
 def _BoundsD(xmin, xmax, ymin, ymax):
     """Equivalent to `BoundsD` constructor, but skips some sanity checks and argument parsing.
-    This requires that the four values already be int types.
+    This requires that the four values be float types.
     """
     ret = BoundsD.__new__(BoundsD)
     ret._isdefined = True
@@ -462,7 +462,7 @@ def _BoundsD(xmin, xmax, ymin, ymax):
 
 def _BoundsI(xmin, xmax, ymin, ymax):
     """Equivalent to `BoundsI` constructor, but skips some sanity checks and argument parsing.
-    This requires that the four values already be int types.
+    This requires that the four values be int types.
     """
     ret = BoundsI.__new__(BoundsI)
     ret._isdefined = True

--- a/galsim/bounds.py
+++ b/galsim/bounds.py
@@ -19,7 +19,7 @@
 import math
 
 from . import _galsim
-from .position import Position, PositionI, PositionD
+from .position import Position, PositionI, PositionD, _PositionD, _PositionI
 from .errors import GalSimUndefinedBoundsError
 
 class Bounds(object):
@@ -195,7 +195,7 @@ class Bounds(object):
         """
         if not self.isDefined():
             raise GalSimUndefinedBoundsError("true_center is invalid for an undefined Bounds")
-        return PositionD((self.xmax + self.xmin)/2., (self.ymax + self.ymin)/2.)
+        return _PositionD((self.xmax + self.xmin)/2., (self.ymax + self.ymin)/2.)
 
     def includes(self, *args):
         """Test whether a supplied ``(x,y)`` pair, `Position`, or `Bounds` lie within a defined
@@ -388,7 +388,7 @@ class BoundsD(Bounds):
 
     @property
     def _center(self):
-        return PositionD( (self.xmax + self.xmin)/2., (self.ymax + self.ymin)/2. )
+        return _PositionD( (self.xmax + self.xmin)/2., (self.ymax + self.ymin)/2. )
 
 
 class BoundsI(Bounds):
@@ -443,8 +443,8 @@ class BoundsI(Bounds):
         # e.g. (1,10,1,10) -> (6,6)
         #      (-10,-1,-10,-1) -> (-5,-5)
         # Just up and to the right of the true center in both cases.
-        return PositionI( self.xmin + (self.xmax - self.xmin + 1)//2,
-                          self.ymin + (self.ymax - self.ymin + 1)//2 )
+        return _PositionI( self.xmin + (self.xmax - self.xmin + 1)//2,
+                           self.ymin + (self.ymax - self.ymin + 1)//2 )
 
 
 def _BoundsD(xmin, xmax, ymin, ymax):

--- a/galsim/box.py
+++ b/galsim/box.py
@@ -23,7 +23,6 @@ from . import _galsim
 from .gsobject import GSObject
 from .gsparams import GSParams
 from .utilities import lazy_property, doc_inherit
-from .position import PositionD
 from .errors import convert_cpp_errors
 
 

--- a/galsim/catalog.py
+++ b/galsim/catalog.py
@@ -103,7 +103,6 @@ class Catalog(object):
     def readAscii(self):
         """Read in an input catalog from an ASCII file.
         """
-        print('readAscii: ',self.file_name)
         if self.comments is not None and len(self.comments) > 1:
             raise GalSimValueError('Invalid comments character', self.comments)
 
@@ -124,7 +123,6 @@ class Catalog(object):
         # Note: we leave the data as str, rather than convert to float, so that if
         # we have any str fields, they don't give an error here.  They'll only give an
         # error if one tries to convert them to float at some point.
-        print('finishReadAscii: ',self.file_name)
         self._data = np.loadtxt(self.file_name, comments=self.comments, dtype=bytes, ndmin=2)
         # Convert the bytes to str.  For Py2, this is a no op.
         self._data = self._data.astype(str)

--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -21,7 +21,7 @@ import numpy as np
 from .gsobject import GSObject
 from .sed import SED
 from .bandpass import Bandpass
-from .position import PositionD, PositionI
+from .position import Position, PositionD, _PositionD
 from .utilities import lazy_property, doc_inherit
 from .gsparams import GSParams
 from .phase_psf import OpticalPSF
@@ -702,7 +702,7 @@ class ChromaticObject(object):
             flux = np.trapz(bp * fluxes, w)
             xcentroid = np.trapz(bp * fluxes * xcentroids, w) / flux
             ycentroid = np.trapz(bp * fluxes * ycentroids, w) / flux
-            return PositionD(xcentroid, ycentroid)
+            return _PositionD(xcentroid, ycentroid)
         else:
             flux_integrand = lambda w: self.evaluateAtWavelength(w).flux * bandpass(w)
             def xcentroid_integrand(w):
@@ -718,7 +718,7 @@ class ChromaticObject(object):
             ycentroid = 1./flux * integ.int1d(ycentroid_integrand,
                                               bandpass.blue_limit,
                                               bandpass.red_limit)
-            return PositionD(xcentroid, ycentroid)
+            return _PositionD(xcentroid, ycentroid)
 
     def calculateFlux(self, bandpass):
         """Return the flux (photons/cm^2/s) of the `ChromaticObject` through a `Bandpass` bandpass.
@@ -1044,7 +1044,7 @@ class ChromaticObject(object):
                     # Then it's a function returning a tuple or list or array.
                     # Just make sure it is actually an array to make our life easier later.
                     offset = lambda w: np.asarray(args[0](w))
-            elif isinstance(args[0], PositionD) or isinstance(args[0], PositionI):
+            elif isinstance(args[0], Position):
                 offset = np.asarray( (args[0].x, args[0].y) )
             else:
                 # Let python raise the appropriate exception if this isn't valid.
@@ -1553,7 +1553,7 @@ class ChromaticTransformation(ChromaticObject):
     """
     def __init__(self, obj, jac=np.identity(2), offset=(0.,0.), flux_ratio=1., redshift=None,
                  gsparams=None, propagate_gsparams=True):
-        if isinstance(offset, PositionD) or isinstance(offset, PositionI):
+        if isinstance(offset, Position):
             offset = (offset.x, offset.y)
         if not hasattr(jac,'__call__'):
             jac = np.asarray(jac).reshape(2,2)
@@ -1701,7 +1701,7 @@ class ChromaticTransformation(ChromaticObject):
         if hasattr(self._offset, '__call__'):
             offset = self._offset
         else:
-            offset = PositionD(*(self._offset.tolist()))
+            offset = _PositionD(*(self._offset.tolist()))
         return ('galsim.ChromaticTransformation(%r, jac=%r, offset=%r, flux_ratio=%r, '
                 'redshift=%r, gsparams=%r, propagate_gsparams=%r)')%(
             self.original, jac, offset, self._flux_ratio, self.redshift,
@@ -1732,7 +1732,7 @@ class ChromaticTransformation(ChromaticObject):
             offset = self._offset(wave)
         else:
             offset = self._offset
-        offset = PositionD(*offset)
+        offset = _PositionD(*offset)
         flux_ratio = self._flux_ratio(wave)
         return jac, offset, flux_ratio
 

--- a/galsim/config/image.py
+++ b/galsim/config/image.py
@@ -83,7 +83,7 @@ def BuildImages(nimages, config, image_num=0, obj_num=0, logger=None):
     for k in range(nimages):
         kwargs = { 'image_num' : image_num, 'obj_num' : obj_num }
         jobs.append(kwargs)
-        obj_num += GetNObjForImage(config, image_num)
+        obj_num += GetNObjForImage(config, image_num, logger=logger)
         image_num += 1
 
     def done_func(logger, proc, k, image, t):
@@ -304,7 +304,7 @@ def BuildImage(config, image_num=0, obj_num=0, logger=None):
     return image
 
 
-def GetNObjForImage(config, image_num):
+def GetNObjForImage(config, image_num, logger=None):
     """
     Get the number of objects that will be made for the image number image_num based on
     the information in the config dict.
@@ -312,6 +312,7 @@ def GetNObjForImage(config, image_num):
     Parameters:
         config:         The configuration dict.
         image_num:      The current image number.
+        logger:         If given, a logger object to log progress.
 
     Returns:
         the number of objects
@@ -321,7 +322,7 @@ def GetNObjForImage(config, image_num):
     if image_type not in valid_image_types:
         raise GalSimConfigValueError("Invalid image.type.", image_type,
                                      list(valid_image_types.keys()))
-    return valid_image_types[image_type].getNObj(image,config,image_num)
+    return valid_image_types[image_type].getNObj(image,config,image_num,logger=logger)
 
 
 def FlattenNoiseVariance(config, full_image, stamps, current_vars, logger):
@@ -560,7 +561,7 @@ class ImageBuilder(object):
         """
         pass
 
-    def getNObj(self, config, base, image_num):
+    def getNObj(self, config, base, image_num, logger=None):
         """Get the number of objects that will be built for this image.
 
         For Single, this is just 1, but other image types would figure this out from the
@@ -570,6 +571,7 @@ class ImageBuilder(object):
             config:     The configuration dict for the image field.
             base:       The base configuration dict.
             image_num:  The current image number.
+            logger:     If given, a logger object to log progress.
 
         Returns:
             the number of objects

--- a/galsim/config/image_scattered.py
+++ b/galsim/config/image_scattered.py
@@ -51,7 +51,7 @@ class ScatteredImageBuilder(ImageBuilder):
         logger.debug('image %d: Building Scattered: image, obj = %d,%d',
                      image_num,image_num,obj_num)
 
-        self.nobjects = self.getNObj(config, base, image_num)
+        self.nobjects = self.getNObj(config, base, image_num, logger=logger)
         logger.debug('image %d: nobj = %d',image_num,self.nobjects)
 
         # These are allowed for Scattered, but we don't use them here.
@@ -179,13 +179,14 @@ class ScatteredImageBuilder(ImageBuilder):
         AddNoise(base,image,current_var,logger)
 
 
-    def getNObj(self, config, base, image_num):
+    def getNObj(self, config, base, image_num, logger=None):
         """Get the number of objects that will be built for this image.
 
         Parameters:
             config:     The configuration dict for the image field.
             base:       The base configuration dict.
             image_num:  The current image number.
+            logger:     If given, a logger object to log progress.
 
         Returns:
             the number of objects
@@ -196,7 +197,7 @@ class ScatteredImageBuilder(ImageBuilder):
 
         # Allow nobjects to be automatic based on input catalog
         if 'nobjects' not in config:
-            nobj = ProcessInputNObjects(base)
+            nobj = ProcessInputNObjects(base, logger=logger)
             if nobj is None:
                 raise GalSimConfigError(
                     "Attribute nobjects is required for image.type = Scattered")

--- a/galsim/config/image_tiled.py
+++ b/galsim/config/image_tiled.py
@@ -218,13 +218,14 @@ class TiledImageBuilder(ImageBuilder):
             AddSky(base,image)
             AddNoise(base,image,current_var,logger)
 
-    def getNObj(self, config, base, image_num):
+    def getNObj(self, config, base, image_num, logger=None):
         """Get the number of objects that will be built for this image.
 
         Parameters:
             config:     The configuration dict for the image field.
             base:       The base configuration dict.
             image_num:  The current image number.
+            logger:     If given, a logger object to log progress.
 
         Returns:
             the number of objects

--- a/galsim/config/input.py
+++ b/galsim/config/input.py
@@ -22,7 +22,7 @@ import os
 import logging
 
 from .value import RegisterValueType
-from .util import LoggerWrapper, RemoveCurrent, GetRNG, GetLoggerProxy, get_cls_params
+from .util import LoggerWrapper, RemoveCurrent, GetRNG, get_cls_params
 from .value import ParseValue, CheckAllParams, GetAllParams, SetDefaultIndex, _GetBoolValue
 from ..errors import GalSimConfigError, GalSimConfigValueError
 from ..catalog import Catalog, Dict
@@ -424,7 +424,7 @@ class InputLoader(object):
             kwargs['rng'] = rng
             safe = False
         if self.takes_logger:
-            kwargs['logger'] = GetLoggerProxy(logger)
+            kwargs['logger'] = logger
         return kwargs, safe
 
     def setupImage(self, input_obj, config, base, logger):

--- a/galsim/config/input.py
+++ b/galsim/config/input.py
@@ -184,7 +184,7 @@ def LoadInputObj(config, key, num=0, safe_only=False, logger=None):
     nfields = len(fields) if isinstance(fields, list) else 1
 
     if key not in all_input_objs:
-        all_input_objs[key] = [ None for num in range(nfields) ]
+        all_input_objs[key] = [None] * nfields
 
     loader = valid_input_types[key]
     field = fields[num] if isinstance(fields, list) else fields
@@ -331,6 +331,7 @@ def GetInputObj(input_type, config, base, param_name, num=0):
         base:       The base config dict
         param_name: The type of value that we are trying to construct (only used for
                     error messages).
+        num:        Which number in the list of this key, if needed. [default: 0]
     """
     if '_input_objs' not in base or input_type not in base['_input_objs']:
         raise GalSimConfigError(

--- a/galsim/config/input.py
+++ b/galsim/config/input.py
@@ -22,7 +22,7 @@ import os
 import logging
 
 from .value import RegisterValueType
-from .util import LoggerWrapper, RemoveCurrent, GetRNG, get_cls_params
+from .util import LoggerWrapper, RemoveCurrent, GetRNG, GetLoggerProxy, get_cls_params
 from .value import ParseValue, CheckAllParams, GetAllParams, SetDefaultIndex, _GetBoolValue
 from ..errors import GalSimConfigError, GalSimConfigValueError
 from ..catalog import Catalog, Dict
@@ -225,6 +225,10 @@ def LoadInputObj(config, key, num=0, safe_only=False, logger=None):
     logger.debug('file %d: %s kwargs = %s',file_num,key,kwargs)
     if '_input_manager' in config:
         tag = key + str(num)
+        if 'logger' in kwargs:
+            # Loggers can't be pickled. (At least prior to py3.7.  Maybe they fixed this?)
+            # So if we have a logger, switch it for a proxy instead.
+            kwargs['logger'] = GetLoggerProxy(kwargs['logger'])
         input_obj = getattr(config['_input_manager'],tag)(**kwargs)
     else:
         input_obj = loader.init_func(**kwargs)

--- a/galsim/config/output_datacube.py
+++ b/galsim/config/output_datacube.py
@@ -52,7 +52,7 @@ class DataCubeBuilder(OutputBuilder):
             a list of the images built
         """
         import time
-        nimages = self.getNImages(config, base, file_num)
+        nimages = self.getNImages(config, base, file_num, logger=logger)
 
         # The above call sets up a default nimages if appropriate.  Now, check that there are no
         # invalid parameters in the config dict.
@@ -80,19 +80,20 @@ class DataCubeBuilder(OutputBuilder):
         images = [ image0 ]
 
         if nimages > 1:
-            obj_num += GetNObjForImage(base, image_num)
+            obj_num += GetNObjForImage(base, image_num, logger=logger)
             images += BuildImages(nimages-1, base, logger=logger,
                                   image_num=image_num+1, obj_num=obj_num)
 
         return images
 
-    def getNImages(self, config, base, file_num):
+    def getNImages(self, config, base, file_num, logger=None):
         """Returns the number of images to be built.
 
         Parameters:
             config:         The configuration dict for the output field.
             base:           The base configuration dict.
             file_num:       The current file number.
+            logger:         If given, a logger object to log progress.
 
         Returns:
             the number of images to build.

--- a/galsim/config/output_multifits.py
+++ b/galsim/config/output_multifits.py
@@ -45,7 +45,7 @@ class MultiFitsBuilder(OutputBuilder):
         Returns:
             a list of the images built
         """
-        nimages = self.getNImages(config, base, file_num)
+        nimages = self.getNImages(config, base, file_num, logger=logger)
 
         # The above call sets up a default nimages if appropriate.  Now, check that there are no
         # invalid parameters in the config dict.
@@ -55,7 +55,7 @@ class MultiFitsBuilder(OutputBuilder):
 
         return BuildImages(nimages, base, image_num, obj_num, logger=logger)
 
-    def getNImages(self, config, base, file_num):
+    def getNImages(self, config, base, file_num, logger=None):
         """
         Get the number of images for a MultiFits file type.
 
@@ -63,6 +63,7 @@ class MultiFitsBuilder(OutputBuilder):
             config:         The configuration dict for the output field.
             base:           The base configuration dict.
             file_num:       The current file number.
+            logger:         If given, a logger object to log progress.
 
         Returns:
             the number of images

--- a/galsim/config/process.py
+++ b/galsim/config/process.py
@@ -243,7 +243,7 @@ def Process(config, logger=None, njobs=1, job=1, new_params=None, except_abort=F
 
     # Determine how many files we will be processing in total.
     # Usually, this is just output.nfiles, but different output types may define this differently.
-    nfiles = GetNFiles(config)
+    nfiles = GetNFiles(config, logger=logger)
     logger.debug('nfiles = %d',nfiles)
 
     if njobs > 1:

--- a/galsim/config/stamp.py
+++ b/galsim/config/stamp.py
@@ -77,7 +77,7 @@ def BuildStamps(nobjects, config, obj_num=0,
         logger:         If given, a logger object to log progress. [default: None]
 
     Returns:
-        the tuple (images, current_vars).  Both are lists.
+        the tuple (images, current_vars).  Both are themselves tuples.
     """
     logger = LoggerWrapper(logger)
     logger.debug('image %d: BuildStamps nobjects = %d: obj = %d',
@@ -85,7 +85,7 @@ def BuildStamps(nobjects, config, obj_num=0,
 
     if nobjects == 0:
         logger.error("No stamps were built, since nstamps == 0.")
-        return [], []
+        return (), ()
 
     # Figure out how many processes we will use for building the stamps:
     if nobjects > 1 and 'image' in config and 'nproc' in config['image']:

--- a/galsim/config/stamp.py
+++ b/galsim/config/stamp.py
@@ -373,7 +373,7 @@ def BuildStamp(config, obj_num=0, xsize=0, ysize=0, do_noise=True, logger=None):
         except SkipThisObject as e:
             if e.msg != '':
                 logger.debug('obj %d: Caught SkipThisObject: e = %s',obj_num,e.msg)
-            logger.info('Skipping object %d',obj_num)
+            logger.info('Skipping object %d %s', obj_num, e.msg)
             # If xsize, ysize != 0, then this makes a blank stamp for this object.
             # Otherwise, it's just None here.
             im = builder.makeStamp(stamp, config, xsize, ysize, logger)

--- a/galsim/config/util.py
+++ b/galsim/config/util.py
@@ -284,36 +284,40 @@ class LoggerWrapper(object):
             self.logger = logger.logger
         else:
             self.logger = logger
+        # When multiprocessing, it is faster to check if the level is enabled locally, rather than
+        # communicating over the pipe to ask the base logger if it isEnabledFor a given level.
+        # If the logger is None, use more than the top logging level (CRITICAL).
+        self.level = self.logger.getEffectiveLevel() if self.logger else logging.CRITICAL+1
+
+    def getEffectiveLevel(self):
+        return self.level
 
     def __bool__(self):
         return self.logger is not None
     __nonzero__ = __bool__
 
     def debug(self, *args, **kwargs):
-        if self.logger and self.logger.isEnabledFor(logging.DEBUG):
+        if self.logger and self.isEnabledFor(logging.DEBUG):
             self.logger.debug(*args, **kwargs)
 
     def info(self, *args, **kwargs):
-        if self.logger and self.logger.isEnabledFor(logging.INFO):
+        if self.logger and self.isEnabledFor(logging.INFO):
             self.logger.info(*args, **kwargs)
 
     def warning(self, *args, **kwargs):
-        if self.logger and self.logger.isEnabledFor(logging.WARNING):
+        if self.logger and self.isEnabledFor(logging.WARNING):
             self.logger.warning(*args, **kwargs)
 
     def error(self, *args, **kwargs):
-        if self.logger and self.logger.isEnabledFor(logging.ERROR):
+        if self.logger and self.isEnabledFor(logging.ERROR):
             self.logger.error(*args, **kwargs)
 
-    def log(self, lvl, *args, **kwargs):
-        if self.logger and self.logger.isEnabledFor(lvl):
-            self.logger.log(lvl, *args, **kwargs)
+    def log(self, level, *args, **kwargs):
+        if self.logger and self.isEnabledFor(level):
+            self.logger.log(level, *args, **kwargs)
 
-    def isEnabledFor(self, *args, **kwargs):
-        if self.logger:
-            return self.logger.isEnabledFor(*args,**kwargs)
-        else:
-            return False
+    def isEnabledFor(self, level):
+        return level >= self.level
 
 
 def UpdateNProc(nproc, ntot, config, logger=None):

--- a/galsim/config/util.py
+++ b/galsim/config/util.py
@@ -222,7 +222,9 @@ def CopyConfig(config):
     def recursive_copy(d):
         # copy the given dict, skipping any current leading underscore fields.
         if isinstance(d, dict):
-            return {k:recursive_copy(v) for k,v in d.items() if not k.startswith('_')}
+            # Use type(d) rather than dict comprehension, since in python 2.7, 3.5, this may
+            # be an OrderedDict, and we want to preserve that.
+            return type(d)([(k,recursive_copy(v)) for k,v in d.items() if not k.startswith('_')])
         elif isinstance(d, list):
             return [recursive_copy(v) for v in d]
         else:

--- a/galsim/config/util.py
+++ b/galsim/config/util.py
@@ -743,8 +743,8 @@ def MultiProcess(nproc, config, job_func, tasks, item, logger=None,
         # Send the tasks to the task_queue.
         ntasks = len(tasks)
         if ntasks > max_queue_size:
-            logger.warning("len(tasks) = %d is more than max_queue_size = %d",
-                           len(tasks),max_queue_size)
+            logger.info("len(tasks) = %d is more than max_queue_size = %d",
+                        len(tasks),max_queue_size)
             njoin = (ntasks-1) // max_queue_size + 1
             new_size = (ntasks-1) // njoin + 1
             tasks = [
@@ -752,7 +752,7 @@ def MultiProcess(nproc, config, job_func, tasks, item, logger=None,
                 for k in range(new_size)
             ]
             ntasks = len(tasks)
-            logger.warning("joined in groups of %d: new len(tasks) = %d",njoin,ntasks)
+            logger.info("Joined in groups of %d: new len(tasks) = %d",njoin,ntasks)
         task_queue = Queue(ntasks)
         for task in tasks:
             task_queue.put(task)

--- a/galsim/correlatednoise.py
+++ b/galsim/correlatednoise.py
@@ -550,11 +550,11 @@ class BaseCorrelatedNoise(object):
 
         This is the variance of values in an image filled with noise according to this model.
         """
-        from .position import PositionD
+        from .position import _PositionD
         # Test whether we can simply return the zero-lag correlation function value, which gives the
         # variance of an image of noise generated according to this model
         if self._profile.is_analytic_x:
-            variance = self._profile.xValue(PositionD(0., 0.))
+            variance = self._profile.xValue(_PositionD(0., 0.))
         else:
             # If the profile has changed since last time (or if we have never been here before),
             # clear out the stored values.

--- a/galsim/deltafunction.py
+++ b/galsim/deltafunction.py
@@ -22,7 +22,6 @@ import math
 from . import _galsim
 from .gsobject import GSObject
 from .gsparams import GSParams
-from .position import PositionD
 from .utilities import doc_inherit
 from .errors import convert_cpp_errors
 

--- a/galsim/des/des_meds.py
+++ b/galsim/des/des_meds.py
@@ -529,7 +529,7 @@ class MEDSBuilder(OutputBuilder):
         """
         WriteMEDS(data, file_name)
 
-    def getNImages(self, config, base, file_num):
+    def getNImages(self, config, base, file_num, logger=None):
         # This gets called before starting work on the file, so we can use this opportunity
         # to make sure that weight and psf processing are turned on.
         # We just add these as empty dicts, so there is no hdu or file_name parameter, which

--- a/galsim/exponential.py
+++ b/galsim/exponential.py
@@ -23,7 +23,6 @@ from . import _galsim
 from .gsobject import GSObject
 from .gsparams import GSParams
 from .utilities import lazy_property, doc_inherit
-from .position import PositionD
 from .errors import GalSimIncompatibleValuesError, convert_cpp_errors
 
 

--- a/galsim/fitswcs.py
+++ b/galsim/fitswcs.py
@@ -1333,23 +1333,19 @@ class GSFitsWCS(CelestialWCS):
             assert x.shape == y.shape
             return ra, dec
 
-    def _invert_ab(self, u, v, ab, x=None, y=None, abp=None):
+    def _invert_ab(self, u, v, ab, abp=None):
         # This is used both for inverting (u,v) = PV (u',v')
         # and for inverting (x,y) = AB (x',y')
         # Here (and in C++) the notation is (u,v) = AB(x,y), even though both (u,v) and (x,y)
         # in this context are either in CCD coordinates (normally called x,y) or tangent plane
         # coordinates (normally called u,v).
-        # The provided x and y are optional initial guesses, if absent, use u and v.
         # abp is an optional set of coefficients to make a good guess for x,y
-        if x is None:
-            x = u.copy()
-        if y is None:
-            y = v.copy()
 
         uu = np.ascontiguousarray(u)  # Don't overwrite the give u,v, since we need it at the end
         vv = np.ascontiguousarray(v)  # to check it we were provided scalars or arrays.
-        x = np.ascontiguousarray(x)
-        y = np.ascontiguousarray(y)
+
+        x = np.atleast_1d(u.copy())    # Start with x,y = u,v.
+        y = np.atleast_1d(v.copy())    # This may be updated below if abp is provided.
 
         with convert_cpp_errors():
             nab = ab.shape[1]

--- a/galsim/fitswcs.py
+++ b/galsim/fitswcs.py
@@ -1341,7 +1341,7 @@ class GSFitsWCS(CelestialWCS):
         # coordinates (normally called u,v).
         # abp is an optional set of coefficients to make a good guess for x,y
 
-        uu = np.ascontiguousarray(u)  # Don't overwrite the give u,v, since we need it at the end
+        uu = np.ascontiguousarray(u)  # Don't overwrite the given u,v, since we need it at the end
         vv = np.ascontiguousarray(v)  # to check it we were provided scalars or arrays.
 
         x = np.atleast_1d(u.copy())    # Start with x,y = u,v.

--- a/galsim/fitswcs.py
+++ b/galsim/fitswcs.py
@@ -1288,7 +1288,8 @@ class GSFitsWCS(CelestialWCS):
     def _apply_cd(self, x, y):
         # Do this in C++ layer for speed.
         with convert_cpp_errors():
-            _galsim.ApplyCD(len(x), x.ctypes.data, y.ctypes.data, self.cd.ctypes.data)
+            nx = len(x.ravel())
+            _galsim.ApplyCD(nx, x.ctypes.data, y.ctypes.data, self.cd.ctypes.data)
         return x, y
 
     def _uv(self, x, y):
@@ -1350,8 +1351,9 @@ class GSFitsWCS(CelestialWCS):
         with convert_cpp_errors():
             nab = ab.shape[1]
             nabp = abp.shape[1] if abp is not None else 0
-            _galsim.InvertAB(len(x), nab, uu.ctypes.data, vv.ctypes.data, ab.ctypes.data,
-                             x.ctypes.data, y.ctypes.data, self._doiter,
+            nx = len(x.ravel())
+            _galsim.InvertAB(nx, nab, uu.ctypes.data, vv.ctypes.data, ab.ctypes.data,
+                             x.ravel().ctypes.data, y.ravel().ctypes.data, self._doiter,
                              nabp, abp.ctypes.data if abp is not None else 0)
 
         # Return the right type for u,v

--- a/galsim/fitswcs.py
+++ b/galsim/fitswcs.py
@@ -1531,7 +1531,7 @@ class GSFitsWCS(CelestialWCS):
                 for j in range(order+1):
                     bpij = self.abp[1,i,j]
                     if i==0 and j==1: bpij -= 1
-                    if bij != 0.:
+                    if bpij != 0.:
                         header["BP_"+str(i)+"_"+str(j)] = bpij
         return header
 

--- a/galsim/fitswcs.py
+++ b/galsim/fitswcs.py
@@ -20,7 +20,7 @@ import warnings
 import numpy as np
 
 from .wcs import CelestialWCS
-from .position import PositionD, PositionI
+from .position import PositionD, _PositionD
 from .angle import radians, arcsec, degrees, AngleUnit
 from . import _galsim
 from . import fits
@@ -259,7 +259,7 @@ class AstropyWCS(CelestialWCS):
     def _readHeader(header):
         x0 = header.get("GS_X0",0.)
         y0 = header.get("GS_Y0",0.)
-        return AstropyWCS(header=header, origin=PositionD(x0,y0))
+        return AstropyWCS(header=header, origin=_PositionD(x0,y0))
 
     def copy(self):
         ret = AstropyWCS.__new__(AstropyWCS)
@@ -541,7 +541,7 @@ class PyAstWCS(CelestialWCS):
     def _readHeader(header):
         x0 = header.get("GS_X0",0.)
         y0 = header.get("GS_Y0",0.)
-        return PyAstWCS(header=header, origin=PositionD(x0,y0))
+        return PyAstWCS(header=header, origin=_PositionD(x0,y0))
 
     def copy(self):
         ret = PyAstWCS.__new__(PyAstWCS)
@@ -815,7 +815,7 @@ class WcsToolsWCS(CelestialWCS): # pragma: no cover
         file = header["GS_FILE"]
         x0 = header["GS_X0"]
         y0 = header["GS_Y0"]
-        return WcsToolsWCS(file, origin=PositionD(x0,y0))
+        return WcsToolsWCS(file, origin=_PositionD(x0,y0))
 
     def copy(self):
         # The copy module version of copying the dict works fine here.
@@ -951,7 +951,7 @@ class GSFitsWCS(CelestialWCS):
     def origin(self):
         """The origin in image coordinates of the WCS function.
         """
-        return PositionD(0.,0.)
+        return _PositionD(0.,0.)
 
     def _read_header(self, header):
         from .angle import AngleUnit

--- a/galsim/fitswcs.py
+++ b/galsim/fitswcs.py
@@ -1278,14 +1278,11 @@ class GSFitsWCS(CelestialWCS):
             pv2 = np.dot(xm.T , np.dot(pv, ym))
             return pv2
 
-    def _apply_pv(self, u, v):
-        u1 = horner2d(u, v, self.pv[0], triangle=True)
-        v1 = horner2d(u, v, self.pv[1], triangle=True)
-        return u1, v1
-
-    def _apply_ab(self, x, y):
-        x1 = horner2d(x, y, self.ab[0], triangle=True)
-        y1 = horner2d(x, y, self.ab[1], triangle=True)
+    def _apply_ab(self, x, y, ab):
+        # Note: this is used for both pv and ab, since the action is the same.
+        # They just occur at two different places in the calculation.
+        x1 = horner2d(x, y, ab[0], triangle=True)
+        y1 = horner2d(x, y, ab[1], triangle=True)
         return x1, y1
 
     def _apply_cd(self, x, y):
@@ -1305,14 +1302,14 @@ class GSFitsWCS(CelestialWCS):
         y -= self.crpix[1]
 
         if self.ab is not None:
-            x, y = self._apply_ab(x, y)
+            x, y = self._apply_ab(x, y, self.ab)
 
         # This converts to (u,v) in the tangent plane
         # Expanding this out is a bit faster than using np.dot for 2x2 matrix.
         u, v = self._apply_cd(x, y)
 
         if self.pv is not None:
-            u, v = self._apply_pv(u, v)
+            u, v = self._apply_ab(u, v, self.pv)
 
         # Convert (u,v) from degrees to radians
         # Also, the FITS standard defines u,v backwards relative to our standard.

--- a/galsim/gaussian.py
+++ b/galsim/gaussian.py
@@ -23,7 +23,6 @@ from . import _galsim
 from .gsobject import GSObject
 from .gsparams import GSParams
 from .utilities import lazy_property, doc_inherit
-from .position import PositionD
 from .errors import GalSimIncompatibleValuesError, convert_cpp_errors
 
 

--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -913,8 +913,7 @@ class GSObject(object):
             the sheared object.
         """
         from .transform import _Transform
-        new_obj = _Transform(self, shear.getMatrix())
-        return new_obj
+        return _Transform(self, shear.getMatrix())
 
     def lens(self, g1, g2, mu):
         """Create a version of the current object with both a lensing shear and magnification
@@ -937,7 +936,33 @@ class GSObject(object):
         Returns:
             the lensed object.
         """
-        return self.shear(g1=g1, g2=g2).magnify(mu)
+        from .transform import Transform
+        from .shear import Shear
+        shear = Shear(g1=g1, g2=g2)
+        return Transform(self, shear.getMatrix() * math.sqrt(mu))
+
+    def _lens(self, g1, g2, mu):
+        """Equivalent to `GSObject.lens`, but without the overhead of some of the sanity checks.
+
+        This is only valid for `GSObject`.  For a `ChromaticObject`, you must use the regular
+        `GSObject.lens` method.
+
+        Also, it won't propagate any noise attribute.
+
+        Parameters:
+            g1:         First component of lensing (reduced) shear to apply to the object.
+            g2:         Second component of lensing (reduced) shear to apply to the object.
+            mu:         Lensing magnification to apply to the object.  This is the factor by which
+                        the solid angle subtended by the object is magnified, preserving surface
+                        brightness.
+
+        Returns:
+            the lensed object.
+        """
+        from .shear import _Shear
+        from .transform import _Transform
+        shear = _Shear(g1 + 1j*g2)
+        return _Transform(self, shear.getMatrix() * math.sqrt(mu))
 
     def rotate(self, theta):
         """Rotate this object by an `Angle` ``theta``.

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -20,7 +20,7 @@ from __future__ import division
 import numpy as np
 
 from . import _galsim
-from .position import PositionI, PositionD
+from .position import PositionI, _PositionD
 from .bounds import BoundsI, BoundsD
 from .wcs import BaseWCS, PixelScale, JacobianWCS
 from . import utilities
@@ -833,7 +833,7 @@ class Image(object):
             # Set the origin so that corresponding image positions correspond to the same world_pos
             x0 = (self.wcs.origin.x - self.xmin + 0.5) / nx + 0.5
             y0 = (self.wcs.origin.y - self.ymin + 0.5) / ny + 0.5
-            target_wcs = target_wcs.shiftOrigin(PositionD(x0,y0), self.wcs.world_origin)
+            target_wcs = target_wcs.shiftOrigin(_PositionD(x0,y0), self.wcs.world_origin)
 
         target_bounds = BoundsI(1, nbins_x, 1, nbins_y)
 
@@ -887,7 +887,7 @@ class Image(object):
             # Set the origin so that corresponding image positions correspond to the same world_pos
             x0 = (self.wcs.origin.x - self.xmin + 0.5) * nx + 0.5
             y0 = (self.wcs.origin.y - self.ymin + 0.5) * ny + 0.5
-            target_wcs = target_wcs.shiftOrigin(PositionD(x0,y0), self.wcs.world_origin)
+            target_wcs = target_wcs.shiftOrigin(_PositionD(x0,y0), self.wcs.world_origin)
 
         target_bounds = BoundsI(1, npix_x, 1, npix_y)
 

--- a/galsim/inclined.py
+++ b/galsim/inclined.py
@@ -24,7 +24,6 @@ from .gsparams import GSParams
 from .utilities import lazy_property, doc_inherit
 from .exponential import Exponential
 from .angle import Angle
-from .position import PositionD
 from .errors import GalSimRangeError, GalSimIncompatibleValuesError, convert_cpp_errors
 
 

--- a/galsim/interpolatedimage.py
+++ b/galsim/interpolatedimage.py
@@ -23,7 +23,7 @@ from .gsobject import GSObject
 from .gsparams import GSParams
 from .image import Image
 from .bounds import _BoundsI
-from .position import PositionD
+from .position import PositionD, _PositionD
 from .interpolant import Quintic, Interpolant, SincInterpolant
 from .utilities import convert_interpolant, lazy_property, doc_inherit, basestring
 from .random import BaseDeviate
@@ -376,7 +376,7 @@ class InterpolatedImage(GSObject):
 
         # Apply the offset
         prof = self
-        if self._offset != PositionD(0,0):
+        if self._offset != _PositionD(0,0):
             prof = prof._shift(-self._offset)  # Opposite direction of what drawImage does.
 
         # If the user specified a flux, then set to that flux value.

--- a/galsim/kolmogorov.py
+++ b/galsim/kolmogorov.py
@@ -23,7 +23,6 @@ from . import _galsim
 from .gsobject import GSObject
 from .gsparams import GSParams
 from .utilities import lazy_property, doc_inherit
-from .position import PositionD
 from .errors import GalSimIncompatibleValuesError, convert_cpp_errors
 
 

--- a/galsim/moffat.py
+++ b/galsim/moffat.py
@@ -23,7 +23,6 @@ from . import _galsim
 from .gsobject import GSObject
 from .gsparams import GSParams
 from .utilities import lazy_property, doc_inherit
-from .position import PositionD
 from .errors import GalSimRangeError, GalSimIncompatibleValuesError, convert_cpp_errors
 
 

--- a/galsim/position.py
+++ b/galsim/position.py
@@ -131,7 +131,7 @@ class Position(object):
         elif isinstance(other, self.__class__):
             return self.__class__(self.x - other.x, self.y - other.y)
         else:
-            return PositionD(self.x - other.x, self.y - other.y)
+            return _PositionD(self.x - other.x, self.y - other.y)
 
     def __repr__(self):
         return "galsim.%s(x=%r, y=%r)"%(self.__class__.__name__, self.x, self.y)
@@ -166,7 +166,7 @@ class PositionD(Position):
     def round(self):
         """Return the rounded-off PositionI version of this position.
         """
-        return PositionI(int(round(self.x)), int(round(self.y)))
+        return _PositionI(int(round(self.x)), int(round(self.y)))
 
     def _check_scalar(self, other, op):
         try:

--- a/galsim/position.py
+++ b/galsim/position.py
@@ -204,3 +204,22 @@ class PositionI(Position):
         except (TypeError, ValueError):
             pass
         raise TypeError("Can only %s a PositionI by integer values"%op)
+
+def _PositionD(x, y):
+    """Equivalent to `PositionD` constructor, but skips some sanity checks and argument parsing.
+    This requires that x,y are floats.
+    """
+    ret = PositionD.__new__(PositionD)
+    ret.x = float(x)
+    ret.y = float(y)
+    return ret
+
+
+def _PositionI(x, y):
+    """Equivalent to `PositionI` constructor, but skips some sanity checks and argument parsing.
+    This requires that the four values already be int types.
+    """
+    ret = PositionI.__new__(PositionI)
+    ret.x = int(x)
+    ret.y = int(y)
+    return ret

--- a/galsim/position.py
+++ b/galsim/position.py
@@ -217,7 +217,7 @@ def _PositionD(x, y):
 
 def _PositionI(x, y):
     """Equivalent to `PositionI` constructor, but skips some sanity checks and argument parsing.
-    This requires that the four values already be int types.
+    This requires that x,y are ints.
     """
     ret = PositionI.__new__(PositionI)
     ret.x = int(x)

--- a/galsim/random.py
+++ b/galsim/random.py
@@ -144,8 +144,7 @@ class BaseDeviate(object):
         ret = BaseDeviate.__new__(self.__class__)
         ret.__dict__.update(self.__dict__)
         with convert_cpp_errors():
-            rng = _galsim.BaseDeviateImpl(self.serialize())
-            ret._rng = self._rng_type(rng, *ret._rng_args)
+            ret._rng = self._rng.duplicate()
         return ret
 
     def __copy__(self):

--- a/galsim/real.py
+++ b/galsim/real.py
@@ -630,8 +630,9 @@ class RealGalaxyCatalog(object):
         # fail since we use uniform deviates in the range 0 to 1.
         try:
             weight = self.cat.field('weight')
-        except KeyError:
-            return None
+        except KeyError:  # pragma: no cover
+            raise OSError("You still have the old COSMOS catalog.  Run the program "
+                          "`galsim_download_cosmos -s %s` to upgrade."%(self.sample))
         else:
             return weight/np.max(weight)
 
@@ -639,8 +640,9 @@ class RealGalaxyCatalog(object):
     def stamp_flux(self):
         try:
             return self.cat.field('stamp_flux')
-        except KeyError:
-            return None
+        except KeyError:  # pragma: no cover
+            raise OSError("You still have the old COSMOS catalog.  Run the program "
+                          "`galsim_download_cosmos -s %s` to upgrade."%(self.sample))
 
     def __del__(self):
         # Make sure to clean up pyfits open files if people forget to call close()

--- a/galsim/scene.py
+++ b/galsim/scene.py
@@ -266,9 +266,6 @@ class COSMOSCatalog(object):
             # subtraction or deblending errors.  Some of these are eliminated by other cuts when
             # using exclusion_level='marginal'.
             if self.real_cat is not None:
-                if self.real_cat.stamp_flux is None: # pragma: no cover
-                    raise OSError("You still have the old COSMOS catalog.  Run the program "
-                                  "`galsim_download_cosmos -s %s` to upgrade."%(self.use_sample))
                 mask &= self.real_cat.stamp_flux > 0
 
         if exclusion_level in ('bad_fits', 'marginal'):
@@ -531,7 +528,7 @@ class COSMOSCatalog(object):
         if rng is None:
             rng = BaseDeviate()
 
-        if self.real_cat is not None and self.real_cat.weight is not None:
+        if self.real_cat is not None:
             use_weights = self.real_cat.weight[self.orig_index]
         else:
             galsim_warn("Selecting random object without correcting for catalog-level "

--- a/galsim/second_kick.py
+++ b/galsim/second_kick.py
@@ -21,7 +21,6 @@ from . import _galsim
 from .gsobject import GSObject
 from .gsparams import GSParams
 from .utilities import lazy_property, doc_inherit
-from .position import PositionD
 from .angle import arcsec, AngleUnit, radians
 from .deltafunction import DeltaFunction
 from .errors import convert_cpp_errors

--- a/galsim/sed.py
+++ b/galsim/sed.py
@@ -760,7 +760,7 @@ class SED(object):
         blue_limit = self.blue_limit * zfactor
         red_limit = self.red_limit * zfactor
 
-        return SED(self._orig_spec, self.wave_type, self.flux_type, redshift, self.fast,
+        return SED(self._spec, self.wave_type, self.flux_type, redshift, self.fast,
                    _wave_list=wave_list, _blue_limit=blue_limit, _red_limit=red_limit)
 
     def calculateFlux(self, bandpass):

--- a/galsim/shapelet.py
+++ b/galsim/shapelet.py
@@ -275,7 +275,7 @@ class Shapelet(GSObject):
         if not center:
             center = image.true_center
         # convert from PositionI if necessary
-        center = PositionD(center.x,center.y)
+        center = PositionD(center)
 
         if not normalization.lower() in ("flux", "f", "surface brightness", "sb"):
             raise GalSimValueError("Invalid normalization requested.", normalization,

--- a/galsim/spergel.py
+++ b/galsim/spergel.py
@@ -23,7 +23,6 @@ from . import _galsim
 from .gsobject import GSObject
 from .gsparams import GSParams
 from .utilities import lazy_property, doc_inherit
-from .position import PositionD
 from .errors import GalSimRangeError, GalSimIncompatibleValuesError, convert_cpp_errors
 
 

--- a/galsim/table.py
+++ b/galsim/table.py
@@ -307,7 +307,7 @@ class LookupTable(object):
                                      # it from pandas.
         try:
             import pandas
-            from pandas.io.common import ParserError
+            from pandas.errors import ParserError
             data = pandas.read_csv(file_name, comment='#', delim_whitespace=True, header=None)
             data = data.values.transpose()
         except (ImportError, AttributeError, ParserError):

--- a/galsim/table.py
+++ b/galsim/table.py
@@ -20,7 +20,6 @@ import numbers
 
 from . import _galsim
 from .utilities import lazy_property, convert_interpolant, find_out_of_bounds_position
-from .position import PositionD
 from .bounds import BoundsD
 from .errors import GalSimRangeError, GalSimBoundsError, GalSimValueError
 from .errors import GalSimIncompatibleValuesError, convert_cpp_errors, galsim_warn

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -1881,3 +1881,10 @@ def set_omp_threads(num_threads, logger=None):
             logger.warning("Unable to use multiple threads, since OpenMP is not enabled.")
 
     return num_threads
+
+def get_omp_threads():
+    """Get the current number of OpenMP threads to be used in the C++ layer.
+
+    :returns: num_threads
+    """
+    return _galsim.GetOMPThreads()

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -158,7 +158,7 @@ def parse_pos_args(args, kwargs, name1, name2, integer=False, others=[]):
     Returns:
         a `Position` instance, possibly also with other values if ``others`` is given.
     """
-    from .position import PositionD, PositionI
+    from .position import PositionD, PositionI, _PositionD, _PositionI
     def canindex(arg):
         try: arg[0], arg[1]
         except (TypeError, IndexError): return False
@@ -208,9 +208,9 @@ def parse_pos_args(args, kwargs, name1, name2, integer=False, others=[]):
         raise TypeError("Received unexpected keyword arguments: %s",kwargs)
 
     if integer:
-        pos = PositionI(int(x),int(y))
+        pos = _PositionI(int(x),int(y))
     else:
-        pos = PositionD(float(x),float(y))
+        pos = _PositionD(float(x),float(y))
     if other_vals:
         return (pos,) + tuple(other_vals)
     else:
@@ -814,7 +814,7 @@ def deInterleaveImage(image, N, conserve_flux=False,suppress_warnings=False):
         `interleaveImages`.
     """
     from .image import Image
-    from .position import PositionD
+    from .position import _PositionD
     from .wcs import JacobianWCS, PixelScale
     if isinstance(N,int):
         n1,n2 = N,N
@@ -840,7 +840,7 @@ def deInterleaveImage(image, N, conserve_flux=False,suppress_warnings=False):
             # DX[i'] = -(i+0.5)/n+0.5 = -i/n + 0.5*(n-1)/n
             #    i  = -n DX[i'] + 0.5*(n-1)
             dx,dy = -(i+0.5)/n1+0.5,-(j+0.5)/n2+0.5
-            offset = PositionD(dx,dy)
+            offset = _PositionD(dx,dy)
             img_arr = image.array[j::n2,i::n1].copy()
             img = Image(img_arr)
             if conserve_flux is True:
@@ -1493,9 +1493,9 @@ def unweighted_moments(image, origin=None):
     Returns:
         Dict with entries for [M0, Mx, My, Mxx, Myy, Mxy]
     """
-    from .position import PositionD
+    from .position import _PositionD
     if origin is None:
-        origin = PositionD(0,0)
+        origin = _PositionD(0,0)
     a = image.array.astype(float)
     offset = image.origin - origin
     xgrid, ygrid = np.meshgrid(np.arange(image.array.shape[1]) + offset.x,
@@ -1829,20 +1829,20 @@ def find_out_of_bounds_position(x, y, bounds, grid=False):
     Returns:
         a `PositionD` from x and y that is out-of-bounds of bounds.
     """
-    from .position import PositionD
+    from .position import _PositionD
     if grid:
         # It's enough to check corners for grid input
         for x_ in (np.min(x), np.max(x)):
             for y_ in (np.min(y), np.max(y)):
                 if (x_ < bounds.xmin or x_ > bounds.xmax or
                     y_ < bounds.ymin or y_ > bounds.ymax):
-                    return PositionD(x_, y_)
+                    return _PositionD(x_, y_)
     else:
         # Faster to check all points than to iterate through them one-by-one?
         w = np.where((x < bounds.xmin) | (x > bounds.xmax) |
                      (y < bounds.ymin) | (y > bounds.ymax))
         if len(w[0]) > 0:
-            return PositionD(x[w[0][0]], y[w[0][0]])
+            return _PositionD(x[w[0][0]], y[w[0][0]])
     raise GalSimError("No out-of-bounds position")
 
 def set_omp_threads(num_threads, logger=None):

--- a/galsim/vonkarman.py
+++ b/galsim/vonkarman.py
@@ -22,7 +22,7 @@ from . import _galsim
 from .gsobject import GSObject
 from .gsparams import GSParams
 from .utilities import lazy_property, doc_inherit
-from .position import PositionD
+from .position import _PositionD
 from .angle import arcsec, AngleUnit
 from .errors import GalSimError, convert_cpp_errors, galsim_warn
 from .errors import GalSimIncompatibleValuesError
@@ -290,7 +290,7 @@ class VonKarman(GSObject):
 
     @property
     def _max_sb(self):
-        return self._sbvk.xValue(PositionD(0,0)._p)
+        return self._sbvk.xValue(_PositionD(0,0)._p)
 
     @doc_inherit
     def _xValue(self, pos):

--- a/include/galsim/Random.h
+++ b/include/galsim/Random.h
@@ -118,8 +118,7 @@ namespace galsim {
          *
          * Both this and the returned duplicate will produce identical sequences of values.
          */
-        BaseDeviate duplicate()
-        { return BaseDeviate(serialize().c_str()); }
+        BaseDeviate duplicate();
 
         /**
          * @brief Return a string that can act as the repr in python
@@ -235,6 +234,9 @@ namespace galsim {
          * if this is not possible.
          */
         void seedurandom();
+
+    private:
+        BaseDeviate();  // Private no-action constructor used by duplicate().
     };
 
     /**
@@ -269,7 +271,7 @@ namespace galsim {
          * Both this and the returned duplicate will produce identical sequences of values.
          */
         UniformDeviate duplicate()
-        { return UniformDeviate(serialize().c_str()); }
+        { return UniformDeviate(BaseDeviate::duplicate()); }
 
         /**
          * @brief Draw a new random number from the distribution
@@ -338,7 +340,7 @@ namespace galsim {
          * Both this and the returned duplicate will produce identical sequences of values.
          */
         GaussianDeviate duplicate()
-        { return GaussianDeviate(serialize().c_str(), getMean(), getSigma()); }
+        { return GaussianDeviate(BaseDeviate::duplicate(), getMean(), getSigma()); }
 
         /**
          * @brief Draw a new random number from the distribution
@@ -448,7 +450,7 @@ namespace galsim {
          * Both this and the returned duplicate will produce identical sequences of values.
          */
         BinomialDeviate duplicate()
-        { return BinomialDeviate(serialize().c_str(), getN(), getP()); }
+        { return BinomialDeviate(BaseDeviate::duplicate(), getN(), getP()); }
 
         /**
          * @brief Draw a new random number from the distribution
@@ -550,7 +552,7 @@ namespace galsim {
          * Both this and the returned duplicate will produce identical sequences of values.
          */
         PoissonDeviate duplicate()
-        { return PoissonDeviate(serialize().c_str(), getMean()); }
+        { return PoissonDeviate(BaseDeviate::duplicate(), getMean()); }
 
         /**
          * @brief Report current distribution mean
@@ -642,7 +644,7 @@ namespace galsim {
          * Both this and the returned duplicate will produce identical sequences of values.
          */
         WeibullDeviate duplicate()
-        { return WeibullDeviate(serialize().c_str(), getA(), getB()); }
+        { return WeibullDeviate(BaseDeviate::duplicate(), getA(), getB()); }
 
         /**
          * @brief Draw a new random number from the distribution.
@@ -745,7 +747,7 @@ namespace galsim {
          * Both this and the returned duplicate will produce identical sequences of values.
          */
         GammaDeviate duplicate()
-        { return GammaDeviate(serialize().c_str(), getK(), getTheta()); }
+        { return GammaDeviate(BaseDeviate::duplicate(), getK(), getTheta()); }
 
         /**
          * @brief Draw a new random number from the distribution.
@@ -848,7 +850,7 @@ namespace galsim {
          * Both this and the returned duplicate will produce identical sequences of values.
          */
         Chi2Deviate duplicate()
-        { return Chi2Deviate(serialize().c_str(), getN()); }
+        { return Chi2Deviate(BaseDeviate::duplicate(), getN()); }
 
         /**
          * @brief Draw a new random number from the distribution.

--- a/include/galsim/Silicon.h
+++ b/include/galsim/Silicon.h
@@ -81,6 +81,7 @@ namespace galsim
     };
 
     int SetOMPThreads(int num_threads);
+    int GetOMPThreads();
 
 }
 

--- a/include/galsim/WCS.h
+++ b/include/galsim/WCS.h
@@ -22,8 +22,8 @@
 namespace galsim {
 
     void ApplyCD(int n, double* x, double* y, const double* cd);
-    void InvertAB(int n, int nab, const double* x, const double* y, const double* ab,
-                  double* xx, double* yy, bool doiter, int nabp, const double* abp);
+    void InvertAB(int n, int nab, const double* u, const double* v, const double* ab,
+                  double* x, double* y, bool doiter, int nabp, const double* abp);
 
 }
 

--- a/include/galsim/WCS.h
+++ b/include/galsim/WCS.h
@@ -22,6 +22,8 @@
 namespace galsim {
 
     void ApplyCD(int n, double* x, double* y, const double* cd);
+    void InvertAB(int n, int nab, const double* x, const double* y, const double* ab,
+                  double* xx, double* yy, bool doiter, int nabp, const double* abp);
 
 }
 

--- a/include/galsim/math/Horner.h
+++ b/include/galsim/math/Horner.h
@@ -26,7 +26,7 @@ namespace math {
     // Use Horner's method to evaluate polynomial
     // result[i] = coef[0] + coef[1]*x[i] + coef[2]*x[i]**2 + ...
     // The result array should already be allocated and have the same size as x.
-    void Horner(double* x, const int nx, double* coef, const int nc, double* result);
+    void Horner(const double* x, const int nx, const double* coef, const int nc, double* result);
 
     // 2D version of Horner's method
     // result[i] = coef[0,0] + coef[0,1]*y[i] + coef[0,2]*y[i]**2 + ...
@@ -35,8 +35,8 @@ namespace math {
     //             + ...
     // The result array should already be allocated and have the same size as x and y.
     // This also requires a temporary array of the same size as well.
-    void Horner2D(double* x, double* y, const int nx,
-                  double* coef, const int ncx, const int ncy,
+    void Horner2D(const double* x, const double* y, const int nx,
+                  const double* coef, const int ncx, const int ncy,
                   double* result, double* temp);
 
 } }

--- a/pysrc/Random.cpp
+++ b/pysrc/Random.cpp
@@ -52,6 +52,7 @@ namespace galsim {
             .def(py::init<long>())
             .def(py::init<const BaseDeviate&>())
             .def(py::init<const char*>())
+            .def("duplicate", &BaseDeviate::duplicate)
             .def("seed", (void (BaseDeviate::*) (long) )&BaseDeviate::seed)
             .def("reset", (void (BaseDeviate::*) (const BaseDeviate&) )&BaseDeviate::reset)
             .def("clearCache", &BaseDeviate::clearCache)
@@ -64,38 +65,45 @@ namespace galsim {
         py::class_<UniformDeviate, BP_BASES(BaseDeviate)>(
             GALSIM_COMMA "UniformDeviateImpl" BP_NOINIT)
             .def(py::init<const BaseDeviate&>())
+            .def("duplicate", &UniformDeviate::duplicate)
             .def("generate1", &UniformDeviate::generate1);
 
         py::class_<GaussianDeviate, BP_BASES(BaseDeviate)>(
             GALSIM_COMMA "GaussianDeviateImpl" BP_NOINIT)
             .def(py::init<const BaseDeviate&, double, double>())
+            .def("duplicate", &GaussianDeviate::duplicate)
             .def("generate1", &GaussianDeviate::generate1)
             .def("generate_from_variance", &GenerateFromVariance);
 
         py::class_<BinomialDeviate, BP_BASES(BaseDeviate)>(
             GALSIM_COMMA "BinomialDeviateImpl" BP_NOINIT)
             .def(py::init<const BaseDeviate&, int, double>())
+            .def("duplicate", &BinomialDeviate::duplicate)
             .def("generate1", &BinomialDeviate::generate1);
 
         py::class_<PoissonDeviate, BP_BASES(BaseDeviate)>(
             GALSIM_COMMA "PoissonDeviateImpl" BP_NOINIT)
             .def(py::init<const BaseDeviate&, double>())
+            .def("duplicate", &PoissonDeviate::duplicate)
             .def("generate1", &PoissonDeviate::generate1)
             .def("generate_from_expectation", &GenerateFromExpectation);
 
         py::class_<WeibullDeviate, BP_BASES(BaseDeviate)>(
             GALSIM_COMMA "WeibullDeviateImpl" BP_NOINIT)
             .def(py::init<const BaseDeviate&, double, double>())
+            .def("duplicate", &WeibullDeviate::duplicate)
             .def("generate1", &WeibullDeviate::generate1);
 
         py::class_<GammaDeviate, BP_BASES(BaseDeviate)>(
             GALSIM_COMMA "GammaDeviateImpl" BP_NOINIT)
             .def(py::init<const BaseDeviate&, double, double>())
+            .def("duplicate", &GammaDeviate::duplicate)
             .def("generate1", &GammaDeviate::generate1);
 
         py::class_<Chi2Deviate, BP_BASES(BaseDeviate)>(
             GALSIM_COMMA "Chi2DeviateImpl" BP_NOINIT)
             .def(py::init<const BaseDeviate&, double>())
+            .def("duplicate", &Chi2Deviate::duplicate)
             .def("generate1", &Chi2Deviate::generate1);
     }
 

--- a/pysrc/Silicon.cpp
+++ b/pysrc/Silicon.cpp
@@ -55,6 +55,7 @@ namespace galsim {
         WrapTemplates<float>(pySilicon);
 
         GALSIM_DOT def("SetOMPThreads", &SetOMPThreads);
+        GALSIM_DOT def("GetOMPThreads", &GetOMPThreads);
     }
 
 } // namespace galsim

--- a/pysrc/WCS.cpp
+++ b/pysrc/WCS.cpp
@@ -24,15 +24,29 @@ namespace galsim {
 
     void CallApplyCD(int n, size_t x_data, size_t y_data, size_t cd_data)
     {
-        double* xar = reinterpret_cast<double*>(x_data);
-        double* yar = reinterpret_cast<double*>(y_data);
-        const double* cdar = reinterpret_cast<const double*>(cd_data);
-        ApplyCD(n, xar, yar, cdar);
+        double* x = reinterpret_cast<double*>(x_data);
+        double* y = reinterpret_cast<double*>(y_data);
+        const double* cd = reinterpret_cast<const double*>(cd_data);
+        ApplyCD(n, x, y, cd);
+    }
+
+    void CallInvertAB(int n, int nab, size_t x_data, size_t y_data, size_t ab_data,
+                      size_t xx_data, size_t yy_data, bool doiter,
+                      int nabp, size_t abp_data)
+    {
+        const double* x = reinterpret_cast<const double*>(x_data);
+        const double* y = reinterpret_cast<const double*>(y_data);
+        const double* ab = reinterpret_cast<const double*>(ab_data);
+        const double* abp = reinterpret_cast<const double*>(abp_data);
+        double* xx = reinterpret_cast<double*>(xx_data);
+        double* yy = reinterpret_cast<double*>(yy_data);
+        InvertAB(n, nab, x, y, ab, xx, yy, doiter, nabp, abp);
     }
 
     void pyExportWCS(PY_MODULE& _galsim)
     {
         GALSIM_DOT def("ApplyCD", &CallApplyCD);
+        GALSIM_DOT def("InvertAB", &CallInvertAB);
     }
 
 } // namespace galsim

--- a/pysrc/WCS.cpp
+++ b/pysrc/WCS.cpp
@@ -30,17 +30,17 @@ namespace galsim {
         ApplyCD(n, x, y, cd);
     }
 
-    void CallInvertAB(int n, int nab, size_t x_data, size_t y_data, size_t ab_data,
-                      size_t xx_data, size_t yy_data, bool doiter,
+    void CallInvertAB(int n, int nab, size_t u_data, size_t v_data, size_t ab_data,
+                      size_t x_data, size_t y_data, bool doiter,
                       int nabp, size_t abp_data)
     {
-        const double* x = reinterpret_cast<const double*>(x_data);
-        const double* y = reinterpret_cast<const double*>(y_data);
+        const double* u = reinterpret_cast<const double*>(u_data);
+        const double* v = reinterpret_cast<const double*>(v_data);
         const double* ab = reinterpret_cast<const double*>(ab_data);
         const double* abp = reinterpret_cast<const double*>(abp_data);
-        double* xx = reinterpret_cast<double*>(xx_data);
-        double* yy = reinterpret_cast<double*>(yy_data);
-        InvertAB(n, nab, x, y, ab, xx, yy, doiter, nabp, abp);
+        double* x = reinterpret_cast<double*>(x_data);
+        double* y = reinterpret_cast<double*>(y_data);
+        InvertAB(n, nab, u, v, ab, x, y, doiter, nabp, abp);
     }
 
     void pyExportWCS(PY_MODULE& _galsim)

--- a/setup.py
+++ b/setup.py
@@ -348,8 +348,7 @@ def find_eigen_dir(output=False):
         # so it thinks we're a web browser.
         # cf. https://stackoverflow.com/questions/42863240/how-to-get-round-the-http-error-403-forbidden-with-urllib-request-using-python
         page=urllib2.Request(url,headers={'User-Agent': 'Mozilla/5.0'})
-        infile=urllib2.urlopen(page).read()
-        data = infile.decode('ISO-8859-1')
+        data=urllib2.urlopen(page).read()
         fname = 'eigen.tar.bz2'
         with open(fname, 'wb') as f:
             f.write(data)

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,9 @@ import subprocess
 import re
 import tempfile
 try:
-    from urllib2 import urlopen
+    import urllib2
 except ImportError:
-    from urllib.request import urlopen
+    import urllib.request as urllib2
 import tarfile
 import shutil
 
@@ -344,14 +344,14 @@ def find_eigen_dir(output=False):
         url = 'https://gitlab.com/libeigen/eigen/-/archive/3.3.4/eigen-3.3.4.tar.bz2'
         if output:
             print("Downloading eigen from ",url)
-        u = urlopen(url)
-        fname = 'eigen.tar.bz2'
-        block_sz = 32 * 1024
+        # Unfortunately, gitlab doesn't allow direct downloads. We need to spoof the request
+        # so it thinks we're a web browser.
+        # cf. https://stackoverflow.com/questions/42863240/how-to-get-round-the-http-error-403-forbidden-with-urllib-request-using-python
+        page=urllib2.Request(url,headers={'User-Agent': 'Mozilla/5.0'})
+        infile=urllib2.urlopen(page).read()
+        data = infile.decode('ISO-8859-1')
         with open(fname, 'wb') as f:
-            buffer = u.read(block_sz)
-            while buffer:
-                f.write(buffer)
-                buffer = u.read(block_sz)
+            f.write(data)
         if output:
             print("Downloaded %s.  Unpacking tarball."%fname)
         with tarfile.open(fname) as tar:

--- a/setup.py
+++ b/setup.py
@@ -328,7 +328,7 @@ def find_eigen_dir(output=False):
 
     if output:
         print("Could not find Eigen in any of the standard locations.")
-        print("Will now try to download it from bitbucket.org. This requires an internet")
+        print("Will now try to download it from gitlab.com. This requires an internet")
         print("connection, so it will fail if you are currently offline.")
         print("If Eigen is installed in a non-standard location, and you want to use that")
         print("instead, you should make sure the right directory is either in your")
@@ -341,7 +341,7 @@ def find_eigen_dir(output=False):
             print("Previous attempt to download eigen found. Deleting and trying again.")
             shutil.rmtree(dir)
         os.mkdir(dir)
-        url = 'https://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2'
+        url = 'https://gitlab.com/libeigen/eigen/-/archive/3.3.4/eigen-3.3.4.tar.bz2'
         if output:
             print("Downloading eigen from ",url)
         u = urlopen(url)

--- a/setup.py
+++ b/setup.py
@@ -350,6 +350,7 @@ def find_eigen_dir(output=False):
         page=urllib2.Request(url,headers={'User-Agent': 'Mozilla/5.0'})
         infile=urllib2.urlopen(page).read()
         data = infile.decode('ISO-8859-1')
+        fname = 'eigen.tar.bz2'
         with open(fname, 'wb') as f:
             f.write(data)
         if output:

--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -60,9 +60,14 @@ namespace galsim {
         // Note that this class could be templated with the type of Boost.Random generator that
         // you want to use instead of mt19937
         typedef boost::mt19937 rng_type;
+
         BaseDeviateImpl() : _rng(new rng_type) {}
         shared_ptr<rng_type> _rng;
     };
+
+    BaseDeviate::BaseDeviate() :
+        _impl(new BaseDeviateImpl())
+    {}
 
     BaseDeviate::BaseDeviate(long lseed) :
         _impl(new BaseDeviateImpl())
@@ -92,6 +97,21 @@ namespace galsim {
         std::ostringstream oss;
         oss << *_impl->_rng;
         return oss.str();
+    }
+
+    BaseDeviate BaseDeviate::duplicate()
+    {
+#if 0
+        // This is the bespoke, but slow, way to do this.
+        return BaseDeviate(serialize().c_str());
+#else
+        // This is a hack, but it seems to work.  And it's around 100x faster. (!)
+        // cf. https://stackoverflow.com/a/16310375/1332281
+        // Although in this context, a direct copy is simpler than their suggestion.
+        BaseDeviate ret;
+        std::memcpy(ret._impl->_rng.get(), _impl->_rng.get(), sizeof(*_impl->_rng));
+        return ret;
+#endif
     }
 
     void BaseDeviate::seedurandom()

--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 #include <sstream>
 #include <unistd.h>
+#include <cstring>  // For memcpy
 #include "Random.h"
 
 #include "galsim/IgnoreWarnings.h"

--- a/src/Silicon.cpp
+++ b/src/Silicon.cpp
@@ -793,6 +793,15 @@ namespace galsim {
 #endif
     }
 
+    int GetOMPThreads()
+    {
+#ifdef _OPENMP
+        return omp_get_max_threads();
+#else
+        return 1;
+#endif
+    }
+
     template bool Silicon::insidePixel(int ix, int iy, double x, double y, double zconv,
                                        ImageView<double> target, bool*) const;
     template bool Silicon::insidePixel(int ix, int iy, double x, double y, double zconv,

--- a/src/WCS.cpp
+++ b/src/WCS.cpp
@@ -17,7 +17,11 @@
  *    and/or other materials provided with the distribution.
  */
 
+//#define DEBUGLOGGING
+
+#include "Std.h"
 #include "WCS.h"
+#include "math/Horner.h"
 
 namespace galsim {
 
@@ -37,4 +41,211 @@ namespace galsim {
             *y++ = v;
         }
     }
+
+    void InvertAB(int n, int nab, const double* u, const double* v, const double* ab,
+                  double* x, double* y, bool doiter, int nabp, const double* abp)
+    {
+        // Find (x,y) such that:
+        //   u = Horner2D(x,y,A) = [1 x x^2 x^3 ...] A [1 y y^2 y^3 ...]T
+        //   v = Horner2D(x,y,B) = [1 x x^2 x^3 ...] B [1 y y^2 y^3 ...]T
+        // A = ab[0], B = ab[1] (in python)
+        //
+        // Use Newton's method.
+        // du/dx = [0 1 2x 3x^2 ...] A [1 y y^2 y^3 ...]T
+        // du/dy = [1 x x^2 x^3 ...] A [0 1 2y 3y^2 ...]T
+        // dv/dx = [0 1 2x 3x^2 ...] B [1 y y^2 y^3 ...]T
+        // dv/dy = [1 x x^2 x^3 ...] B [0 1 2y 3y^2 ...]T
+        //
+        // Rather than adjust the x,y vectors to compute these, we can adjust A,B so that
+        // we can continue to use the regular x,y for the Horner2D call.
+        // A_dudx = [  A10   A11   A12 ... ]
+        //          [ 2A20  2A21  2A22 ... ]
+        //          [ 3A30  3A31  3A32 ... ]
+        //          [ ...                  ]
+        // And, since A is initially upper-left triangular, the last column is all 0's.
+        // So we can truncate it by 1 in both directions.  If nab = 4, we obtain
+        // A_dudx = [  A10   A11   A12 ]
+        //          [ 2A20  2A21    0  ]
+        //          [ 3A30    0     0  ]
+        // Similarly,
+        // A_dudy = [ A01  2A02  3A03 ... ]
+        //          [ A11  2A12  3A13 ... ]
+        //          [ A21  2A22  3A23 ... ]
+        //          [ ...                 ]
+        // The dv matrices are equivalent for B.
+        //
+        // Once we compute J = [ du/dx  du/dy ]
+        //                     [ dv/dx  dv/dy ]
+        //
+        // the Newton step is: [ dx ] = J^-1 [ du ]
+        //                     [ dy ]        [ dv ]
+        // x <- x + dx
+        // y <- y + dy
+        //
+        // Here is Josh's implementation of all this in Python, which we will reimplement
+        // in C++ below.  (With some adjustmet of variable names to match the above notation.)
+        /*
+        # Assemble horner2d coefs for derivatives
+        dudxcoef = (np.arange(nab)[:,None]*ab[0])[1:,:-1]
+        dudycoef = (np.arange(nab)*ab[0])[:-1,1:]
+        dvdxcoef = (np.arange(nab)[:,None]*ab[1])[1:,:-1]
+        dvdycoef = (np.arange(nab)*ab[1])[:-1,1:]
+
+        # Usually converges in ~3 iterations.
+        for iter in range(10):  # pragma: no branch
+            # Want Jac^-1 . du
+            # du
+            du = horner2d(x, y, ab[0], triangle=True) - u
+            dv = horner2d(x, y, ab[1], triangle=True) - v
+            # J
+            dudx = horner2d(x, y, dudxcoef, triangle=True)
+            dudy = horner2d(x, y, dudycoef, triangle=True)
+            dvdx = horner2d(x, y, dvdxcoef, triangle=True)
+            dvdy = horner2d(x, y, dvdycoef, triangle=True)
+            # J^-1 . du
+            det = dudx*dvdy - dudy*dvdx
+            duu = -(du*dvdy - dv*dudy)/det
+            dvv = -(-du*dvdx + dv*dudx)/det
+
+            x += dx
+            y += dy
+            # Do at least 3 iterations before spending the time to check for
+            # convergence.
+            if iter >= 2 and np.max(np.abs(np.array([dx, dy]))) < 1e-12:
+                break
+        else:  # pragma: no cover
+            raise GalSimError("Unable to solve for image_pos.")
+        */
+        using math::Horner2D;
+        dbg<<"Start InvertAB\n";
+        xdbg<<"u = "<<u[0]<<std::endl;
+        xdbg<<"v = "<<v[0]<<std::endl;
+        xdbg<<"x = "<<x[0]<<std::endl;
+        xdbg<<"y = "<<y[0]<<std::endl;
+        dbg<<"n = "<<n<<std::endl;
+        dbg<<"nab = "<<nab<<std::endl;
+
+        // Do the iteration in batches of at most 256, so we can allocate on the stack
+        // and we can keep everything in L1 cache.
+        int nblock = std::min(n, 256);
+        xdbg<<"nblock = "<<nblock<<std::endl;
+
+        double temp[nblock];
+        if (abp) {
+            dbg<<"Using abp\n";
+            const double* Ap = abp;
+            const double* Bp = abp + nabp*nabp;
+            int nn = n;
+            const double* uu = u;   // Need copies here, so we have the originals for later.
+            const double* vv = v;
+            double* xx = x;
+            double* yy = y;
+            while (nn) {
+                int n1 = std::min(nn, 256);
+                xdbg<<"nn = "<<nn<<"  "<<n1<<std::endl;
+                xdbg<<"uu = "<<uu[0]<<std::endl;
+                xdbg<<"vv = "<<vv[0]<<std::endl;
+                xdbg<<"xx = "<<xx[0]<<std::endl;
+                xdbg<<"yy = "<<yy[0]<<std::endl;
+                Horner2D(uu, vv, n1, Ap, nabp, nabp, xx, temp);  // x = Horner2D(u, v, Ap)
+                Horner2D(uu, vv, n1, Bp, nabp, nabp, yy, temp);  // y = Horner2D(u, v, Bp)
+                xdbg<<"xx => "<<xx[0]<<std::endl;
+                xdbg<<"yy => "<<yy[0]<<std::endl;
+                xx += n1;
+                yy += n1;
+                uu += n1;
+                vv += n1;
+                nn -= n1;
+            }
+            if (!doiter) return;
+        }
+
+        const double* A = ab;
+        const double* B = ab + nab*nab;
+        double A_dudx[(nab-1)*(nab-1)];
+        double A_dudy[(nab-1)*(nab-1)];
+        double B_dvdx[(nab-1)*(nab-1)];
+        double B_dvdy[(nab-1)*(nab-1)];
+        for (int i=1; i<nab; ++i) {
+            for (int j=1; j<nab; ++j) {
+                int k = (i-1)*(nab-1) + (j-1);
+                A_dudx[k] = A[i*nab+(j-1)] * i;
+                A_dudy[k] = A[(i-1)*nab+j] * j;
+                B_dvdx[k] = B[i*nab+(j-1)] * i;
+                B_dvdy[k] = B[(i-1)*nab+j] * j;
+            }
+        }
+#ifdef DEBUGLOGGING
+        xdbg<<"A_dudx = ";
+        for (int k=0; k<(nab-1)*(nab-1); ++k) xdbg<<A_dudx[k]<<" ";
+        xdbg<<"\nA_dudy = ";
+        for (int k=0; k<(nab-1)*(nab-1); ++k) xdbg<<A_dudy[k]<<" ";
+        xdbg<<"\nB_dvdx = ";
+        for (int k=0; k<(nab-1)*(nab-1); ++k) xdbg<<B_dvdx[k]<<" ";
+        xdbg<<"\nB_dvdy = ";
+        for (int k=0; k<(nab-1)*(nab-1); ++k) xdbg<<B_dvdy[k]<<" ";
+        xdbg<<std::endl;
+#endif
+
+        // More temporary arrays
+        double du[nblock];
+        double dv[nblock];
+        double dudx[nblock];
+        double dudy[nblock];
+        double dvdx[nblock];
+        double dvdy[nblock];
+
+        const int MAX_ITER = 10;
+
+        while (n) {
+            dbg<<"n = "<<n<<std::endl;
+            int n1 = std::min(n, 256);
+            for (int iter=0; iter<10; ++iter) {
+                Horner2D(x, y, n1, A, nab, nab, du, temp);  // u' = Horner2D(x, y, A)
+                for(int m=0; m<n1; ++m) du[m] -= u[m];      // du = u' - u
+                Horner2D(x, y, n1, B, nab, nab, dv, temp);  // v' = Horner2D(x, y, B)
+                for(int m=0; m<n1; ++m) dv[m] -= v[m];      // dv = v' - v
+                xdbg<<"du,dv = "<<du[0]<<", "<<dv[0]<<std::endl;
+
+                Horner2D(x, y, n1, A_dudx, nab-1, nab-1, dudx, temp);  // -> dudx
+                Horner2D(x, y, n1, A_dudy, nab-1, nab-1, dudy, temp);  // -> dudy
+                Horner2D(x, y, n1, B_dvdx, nab-1, nab-1, dvdx, temp);  // -> dvdx
+                Horner2D(x, y, n1, B_dvdy, nab-1, nab-1, dvdy, temp);  // -> dvdy
+                xdbg<<"dudx = "<<dudx[0]<<std::endl;
+                xdbg<<"dudy = "<<dudy[0]<<std::endl;
+                xdbg<<"dvdx = "<<dvdx[0]<<std::endl;
+                xdbg<<"dvdy = "<<dvdy[0]<<std::endl;
+
+                // Newton step [dx dy] = -J^-1 [du dv]
+                double max_step = 0.;
+                for(int m=0; m<n1; ++m) {
+                    double det = dudx[m] * dvdy[m] - dudy[m] * dvdx[m];
+                    double dx = -(dvdy[m] * du[m] - dudy[m] * dv[m]) / det;
+                    double dy = -(-dvdx[m] * du[m] + dudx[m] * dv[m]) / det;
+                    if (m == 0) {
+                        xdbg<<"dx,dy = "<<dx<<", "<<dy<<std::endl;
+                    }
+                    x[m] += dx;
+                    y[m] += dy;
+                    double abs_step = std::max(std::abs(dx), std::abs(dy));
+                    if (abs_step > max_step) {
+                        dbg<<"abs_step at m = "<<m<<" = "<<abs_step<<std::endl;
+                        max_step = abs_step;
+                    }
+                }
+                dbg<<"iter "<<iter<<": max step = "<<max_step<<std::endl;
+                if (max_step < 1.e-12) break;
+
+                if (iter == MAX_ITER-1) {
+                    throw std::runtime_error("Unable to solve for image_pos (max iter reached)");
+                }
+            }
+            x += n1;
+            y += n1;
+            u += n1;
+            v += n1;
+            n -= n1;
+        }
+    }
+
 }

--- a/src/math/Horner.cpp
+++ b/src/math/Horner.cpp
@@ -25,7 +25,7 @@
 namespace galsim {
 namespace math {
 
-    void HornerStep(double* x, int n, double c, double* r)
+    void HornerStep(const double* x, int n, const double c, double* r)
     {
 #ifdef __SSE2__
         for (; n && (!IsAligned(r) || !IsAligned(x)); --n, ++r, ++x)
@@ -38,7 +38,7 @@ namespace math {
         if (n2) {
             __m128d cx = _mm_set1_pd(c);
             __m128d* rx = reinterpret_cast<__m128d*>(r);
-            __m128d* xx = reinterpret_cast<__m128d*>(x);
+            const __m128d* xx = reinterpret_cast<const __m128d*>(x);
             do {
                 *rx = _mm_add_pd(_mm_mul_pd(*rx, *xx), cx);
                 ++rx;
@@ -56,7 +56,7 @@ namespace math {
 #endif
     }
 
-    void HornerBlock(double* x, int nx, double* coef, double* c, double* result)
+    void HornerBlock(const double* x, int nx, const double* coef, const double* c, double* result)
     {
         // Repeatedly multiply by x and add next coefficient
         double* r = result;
@@ -67,10 +67,10 @@ namespace math {
         // In the last step, we will have added the constant term, and we're done.
     }
 
-    void Horner(double* x, int nx, double* coef, const int nc, double* result)
+    void Horner(const double* x, int nx, const double* coef, const int nc, double* result)
     {
         // Start at highest power
-        double* c = coef + nc-1;
+        const double* c = coef + nc-1;
         // Ignore any trailing zeros
         while (*c == 0. && c > coef) --c;
 
@@ -82,7 +82,7 @@ namespace math {
         HornerBlock(x, nx, coef, c, result);
     }
 
-    void HornerStep2(double* x, int n, double* t, double* r)
+    void HornerStep2(const double* x, int n, const double* t, double* r)
     {
 #ifdef __SSE2__
         for (; n && (!IsAligned(r) || !IsAligned(x) || !IsAligned(t)); --n, ++r, ++x, ++t)
@@ -94,8 +94,8 @@ namespace math {
 
         if (n2) {
             __m128d* rx = reinterpret_cast<__m128d*>(r);
-            __m128d* xx = reinterpret_cast<__m128d*>(x);
-            __m128d* tx = reinterpret_cast<__m128d*>(t);
+            const __m128d* xx = reinterpret_cast<const __m128d*>(x);
+            const __m128d* tx = reinterpret_cast<const __m128d*>(t);
             do {
                 *rx = _mm_add_pd(_mm_mul_pd(*rx, *xx), *tx);
                 ++rx;
@@ -115,8 +115,8 @@ namespace math {
 #endif
     }
 
-    void HornerBlock2(double* x, double* y, int nx, double* coef, double* c, const int ncy,
-                      double* result, double* temp)
+    void HornerBlock2(const double* x, const double* y, int nx, const double* coef,
+                      const double* c, const int ncy, double* result, double* temp)
     {
         Horner(y, nx, c, ncy, result);
         while((c -= ncy) >= coef) {
@@ -125,11 +125,11 @@ namespace math {
         }
     }
 
-    void Horner2D(double* x, double* y, int nx,
-                  double* coef, const int ncx, const int ncy,
+    void Horner2D(const double* x, const double* y, int nx,
+                  const double* coef, const int ncx, const int ncy,
                   double* result, double* temp)
     {
-        double* c = coef + (ncx-1) * ncy;
+        const double* c = coef + (ncx-1) * ncy;
 
         // Better for caching to do this in blocks of 64 rather than all at once.
         const int BLOCK_SIZE = 64;

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -44,15 +44,6 @@ def test_ascii_catalog():
     assert len(cat2) == cat2.nobjects == cat2.getNObjects() == cat.nobjects
     assert cat2.ncols == cat.ncols
 
-    # Special _nobjects_only option sets nobjects, but doesn't finish setting up object.
-    cat3 = galsim.Catalog('catalog.txt', 'config_input', _nobjects_only=True)
-    assert cat3 == cat
-    assert len(cat3) == cat3.nobjects == cat3.getNObjects() == cat.nobjects
-    with assert_raises(AttributeError):
-        assert cat3.ncols
-    with assert_raises(AttributeError):
-        assert cat3.get(1,11)
-
     cat2 = galsim.Catalog('catalog2.txt', 'config_input', comments='%')
     assert cat2.nobjects == cat.nobjects
     np.testing.assert_array_equal(cat2.data, cat.data)
@@ -64,9 +55,6 @@ def test_ascii_catalog():
     np.testing.assert_array_equal(cat3.data, cat.data)
     assert cat3 != cat
     do_pickle(cat3)
-
-    cat3n = galsim.Catalog('catalog3.txt', 'config_input', comments=None, _nobjects_only=True)
-    assert cat3n.nobjects == 3
 
     # Check construction errors
     assert_raises(galsim.GalSimValueError, galsim.Catalog, 'catalog.txt', file_type='invalid')
@@ -102,15 +90,6 @@ def test_fits_catalog():
     assert len(cat2) == cat2.nobjects == cat2.getNObjects() == cat.nobjects
     assert cat2.ncols == cat.ncols
 
-    # Special _nobjects_only option sets nobjects, but doesn't finish setting up object.
-    cat3 = galsim.Catalog('catalog.fits', 'config_input', _nobjects_only=True)
-    assert cat3 == cat
-    assert len(cat3) == cat3.nobjects == cat3.getNObjects() == cat.nobjects
-    with assert_raises(AttributeError):
-        assert cat3.ncols
-    with assert_raises(AttributeError):
-        cat3.get(1, 'angle2')
-
     # Check construction errors
     assert_raises(galsim.GalSimValueError, galsim.Catalog, 'catalog.fits', file_type='invalid')
     assert_raises((IOError, OSError), galsim.Catalog, 'catalog.fits')  # Wrong dir
@@ -136,9 +115,6 @@ def test_fits_catalog():
     assert cat3 != cat
     assert cat3 != cat2  # Even though these are the same, it doesn't know 'data' is hdu 2.
     do_pickle(cat3)
-
-    cat2n = galsim.Catalog('catalog2.fits', 'config_input', hdu=2, _nobjects_only=True)
-    assert cat2n.nobjects == 3
 
 
 

--- a/tests/test_config_image.py
+++ b/tests/test_config_image.py
@@ -1160,7 +1160,7 @@ def test_scattered_whiten():
     # Should give a warning for the objects that fall off the edge
     # Note: CaptureLog doesn't work correctly in multiprocessing for some reason.
     # I haven't figured out what about the implementation fails, but it prints these
-    # just fine when usinga  regular logger with nproc=2.  Oh well.
+    # just fine when using a regular logger with nproc=2.  Oh well.
     config['image']['nproc'] = 1
     with CaptureLog() as cl:
         im3 = galsim.config.BuildImage(config, logger=cl.logger)

--- a/tests/test_config_image.py
+++ b/tests/test_config_image.py
@@ -50,7 +50,7 @@ def test_single():
 
     logger = logging.getLogger('test_single')
     logger.addHandler(logging.StreamHandler(sys.stdout))
-    #logger.setLevel(logging.DEBUG)
+    logger.setLevel(logging.INFO)
 
     # Test a little bit of the LoggerWrapper functionality
     logger_wrapper = galsim.config.LoggerWrapper(logger)

--- a/tests/test_config_image.py
+++ b/tests/test_config_image.py
@@ -1845,13 +1845,20 @@ def test_index_key():
 
     # First generate using the config layer.
     config = galsim.config.ReadConfig('config_input/index_key.yaml')[0]
+    if __name__ == '__main__':
+        logger = logging.getLogger('test_index_key')
+        logger.addHandler(logging.StreamHandler(sys.stdout))
+        logger.setLevel(logging.DEBUG)
+    else:
+        logger = None
 
     # Normal sequential
     config1 = galsim.config.CopyConfig(config)
     # Note: Using BuildFiles(config1) would normally work, but it has an extra copy internally,
     # which messes up some of the current checks later.
     for n in range(nfiles):
-        galsim.config.BuildFile(config1, file_num=n, image_num=n*nimages, obj_num=n*n_per_file)
+        galsim.config.BuildFile(config1, file_num=n, image_num=n*nimages, obj_num=n*n_per_file,
+                                logger=logger)
     images1 = [ galsim.fits.readMulti('output/index_key%02d.fits'%n) for n in range(nfiles) ]
 
     if __name__ == '__main__':
@@ -1863,14 +1870,16 @@ def test_index_key():
         config2 = galsim.config.CopyConfig(config)
         config2['output']['nproc'] = nfiles
         for n in range(nfiles):
-            galsim.config.BuildFile(config2, file_num=n, image_num=n*nimages, obj_num=n*n_per_file)
+            galsim.config.BuildFile(config2, file_num=n, image_num=n*nimages, obj_num=n*n_per_file,
+                                    logger=logger)
         images2 = [ galsim.fits.readMulti('output/index_key%02d.fits'%n) for n in range(nfiles) ]
 
         # Multiprocessing images
         config3 = galsim.config.CopyConfig(config)
         config3['image']['nproc'] = nfiles
         for n in range(nfiles):
-            galsim.config.BuildFile(config3, file_num=n, image_num=n*nimages, obj_num=n*n_per_file)
+            galsim.config.BuildFile(config3, file_num=n, image_num=n*nimages, obj_num=n*n_per_file,
+                                    logger=logger)
         images3 = [ galsim.fits.readMulti('output/index_key%02d.fits'%n) for n in range(nfiles) ]
 
         # New config for each file
@@ -1879,7 +1888,8 @@ def test_index_key():
             galsim.config.SetupConfigFileNum(config4[n], n, n*nimages, n*n_per_file)
             galsim.config.SetupConfigRNG(config4[n])
         images4 = [ galsim.config.BuildImages(nimages, config4[n],
-                                              image_num=n*nimages, obj_num=n*n_per_file)
+                                              image_num=n*nimages, obj_num=n*n_per_file,
+                                              logger=logger)
                     for n in range(nfiles) ]
 
     # New config for each image
@@ -1890,7 +1900,8 @@ def test_index_key():
 
     images5 = [ [ galsim.config.BuildImage(galsim.config.CopyConfig(config5[n]),
                                            image_num=n*nimages+i,
-                                           obj_num=n*n_per_file + i*n_per_image)
+                                           obj_num=n*n_per_file + i*n_per_image,
+                                           logger=logger)
                   for i in range(nimages) ]
                 for n in range(nfiles) ]
 

--- a/tests/test_config_image.py
+++ b/tests/test_config_image.py
@@ -52,6 +52,14 @@ def test_single():
     logger.addHandler(logging.StreamHandler(sys.stdout))
     #logger.setLevel(logging.DEBUG)
 
+    # Test a little bit of the LoggerWrapper functionality
+    logger_wrapper = galsim.config.LoggerWrapper(logger)
+    assert logger_wrapper.level == logger.getEffectiveLevel()
+    assert logger_wrapper.getEffectiveLevel() == logger.getEffectiveLevel()
+    assert logger_wrapper.isEnabledFor(logging.WARNING)
+    assert logger_wrapper.isEnabledFor(logging.CRITICAL)
+    assert not logger_wrapper.isEnabledFor(logging.DEBUG)
+
     im1_list = []
     nimages = 6
     for k in range(nimages):

--- a/tests/test_config_image.py
+++ b/tests/test_config_image.py
@@ -1090,6 +1090,7 @@ def test_scattered_whiten():
                 'variance' : variance,
                 'whiten' : True,
             },
+            'nproc' : 2,
         },
         'gal' : {
             'type' : 'RealGalaxy',
@@ -1157,6 +1158,10 @@ def test_scattered_whiten():
     np.testing.assert_almost_equal(im2.array, im1.array)
 
     # Should give a warning for the objects that fall off the edge
+    # Note: CaptureLog doesn't work correctly in multiprocessing for some reason.
+    # I haven't figured out what about the implementation fails, but it prints these
+    # just fine when usinga  regular logger with nproc=2.  Oh well.
+    config['image']['nproc'] = 1
     with CaptureLog() as cl:
         im3 = galsim.config.BuildImage(config, logger=cl.logger)
     #print(cl.output)

--- a/tests/test_real.py
+++ b/tests/test_real.py
@@ -76,6 +76,19 @@ def test_real_galaxy_catalog():
 
     assert rgc.getIndexForID(100533) == 0
 
+    # Test some values that are lazy evaluated:
+    assert rgc.ident[0] == '100533'
+    assert rgc.gal_file_name[0] == './real_comparison_images/test_images.fits'
+    assert rgc.psf_file_name[0] == './real_comparison_images/test_images.fits'
+    assert rgc.noise_file_name is None
+    np.testing.assert_array_equal(rgc.gal_hdu, [0,1])
+    np.testing.assert_array_equal(rgc.psf_hdu, [2,3])
+    assert np.isclose(rgc.pixel_scale[0], 0.03)
+    assert np.isclose(rgc.variance[0], 8.22509992e-06)
+    assert np.isclose(rgc.mag[0], 20.3220005)
+    assert rgc.band[0] == 'F814W'
+    assert rgc.weight[0] == 1
+
     assert_raises(TypeError, galsim.RealGalaxyCatalog, catalog_file, dir=image_dir, sample='25.2')
     assert_raises(ValueError, galsim.RealGalaxyCatalog, sample='23.2')
     assert_raises(ValueError, galsim.RealGalaxyCatalog, sample='23.2')

--- a/tests/test_real.py
+++ b/tests/test_real.py
@@ -76,19 +76,6 @@ def test_real_galaxy_catalog():
 
     assert rgc.getIndexForID(100533) == 0
 
-    # With _nobjects_only=True, it doesn't finish loadin
-    rgc2 = galsim.RealGalaxyCatalog(file_name=catalog_file, dir=image_dir, _nobjects_only=True)
-    assert len(rgc2) == rgc2.nobjects == rgc2.getNObjects() == 2
-    assert rgc2.file_name == os.path.join(image_dir, catalog_file)
-    assert rgc2.image_dir == image_dir
-    assert rgc2.sample == None
-    with assert_raises(AttributeError):
-        rgc2.ident
-    with assert_raises(AttributeError):
-        rgc2.getGalImage(0)
-    with assert_raises(AttributeError):
-        rgc2.getPSFImage(0)
-
     assert_raises(TypeError, galsim.RealGalaxyCatalog, catalog_file, dir=image_dir, sample='25.2')
     assert_raises(ValueError, galsim.RealGalaxyCatalog, sample='23.2')
     assert_raises(ValueError, galsim.RealGalaxyCatalog, sample='23.2')

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -236,7 +236,7 @@ def test_cosmos_random():
     np.testing.assert_almost_equal(np.mean(wtrand), wavg_weight_val,3,
                                    err_msg='Average weight for random sample is wrong')
 
-    # The example catalog doesn't have weights, so it does unweighted selection, which emits a
+    # The param-only catalog doesn't have weights, so it does unweighted selection, which emits a
     # warning.  We know about this and want to ignore it here.
     with assert_warns(galsim.GalSimWarning):
         randind = cat_param.selectRandomIndex(30000, rng=galsim.BaseDeviate(1234))

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -312,7 +312,7 @@ def test_cosmos_random():
     # Also check for the unweighted case.  Just remove that info from the catalogs and redo the
     # test.
     cat.real_cat = None
-    del rgc.weight
+    rgc.weight = None
     with assert_warns(galsim.GalSimWarning):
         ind_cc = cat.selectRandomIndex(1, rng=galsim.BaseDeviate(use_seed))
     foo = galsim.RealGalaxy(rgc, random=True, rng=galsim.BaseDeviate(use_seed))

--- a/tests/test_sed.py
+++ b/tests/test_sed.py
@@ -105,6 +105,8 @@ def test_SED_basic():
         s_list[21].thin(),
         s_list[21].thin(preserve_range=True),
         galsim.SED('1000', 'nm', 'flambda', redshift=4),
+        galsim.SED(galsim.LookupTable([1,1e4],[100,100], interpolant='linear'),
+                   wave_type='ang', flux_type='flambda').atRedshift(4.0),
         galsim.SED('1000', 'nm', 'flambda').atRedshift(4.0),
     ]
 
@@ -117,13 +119,17 @@ def test_SED_basic():
         waves = np.arange(700,800,10)
         np.testing.assert_array_almost_equal(s(waves) * h*c/waves, 200, decimal=10)
 
-        if k < len(s_list)-2:
+        if k < len(s_list)-3:
             np.testing.assert_equal(s.redshift, 0.)
         else:
             np.testing.assert_almost_equal(s.redshift, 4.)
 
-        # Only the first one is not picklable
-        if k > 0:
+        # Not picklable when the original spec is a lambda.
+        # This is just true for the first (explicit lambda) and last (atRedshift with something
+        # that had to be converted into a lambda).
+        if isinstance(s._orig_spec, type(lambda: None)):
+            print('\nSkip pickle test for k=%d, since spec is %s\n'%(k,s._spec))
+        else:
             do_pickle(s, lambda x: (x(470), x(490), x(910)) )
             do_pickle(s)
 

--- a/tests/test_sed.py
+++ b/tests/test_sed.py
@@ -416,7 +416,7 @@ def test_combine_wave_list():
 
     # Degenerate case works.
     sed = galsim.SED('CWW_Scd_ext.sed', wave_type='nm', flux_type='flambda')
-    wave_list, blue_limit, red_limit = galsim.utilities.combine_wave_list(sed)
+    wave_list, blue_limit, red_limit = galsim.utilities.combine_wave_list([sed])
     np.testing.assert_equal(wave_list, sed.wave_list)
     np.testing.assert_equal(blue_limit, sed.blue_limit)
     np.testing.assert_equal(red_limit, sed.red_limit)

--- a/tests/test_sed.py
+++ b/tests/test_sed.py
@@ -421,6 +421,11 @@ def test_combine_wave_list():
     np.testing.assert_equal(blue_limit, sed.blue_limit)
     np.testing.assert_equal(red_limit, sed.red_limit)
 
+    wave_list, blue_limit, red_limit = galsim.utilities.combine_wave_list([])
+    np.testing.assert_equal(wave_list, [])
+    np.testing.assert_equal(blue_limit, 0)
+    np.testing.assert_equal(red_limit, np.inf)
+
     # Doesn't know about our A class though.
     assert_raises(TypeError, galsim.utilities.combine_wave_list, a)
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1019,12 +1019,17 @@ def test_omp():
 
     # If num_threads == 1, it should always set to 1
     assert galsim.set_omp_threads(1) == 1
+    assert galsim.get_omp_threads() == 1
 
     # If num_threads > 1, it could be 1 or up to the input num_threads
+    num_threads = galsim.set_omp_threads(2)
     assert galsim.set_omp_threads(2) >= 1
     assert galsim.set_omp_threads(2) <= 2
+    assert galsim.get_omp_threads() == num_threads
+    num_threads = galsim.set_omp_threads(20)
     assert galsim.set_omp_threads(20) >= 1
     assert galsim.set_omp_threads(20) <= 20
+    assert galsim.get_omp_threads() == num_threads
 
     # Repeat and check that appropriate messages are emitted
     with CaptureLog() as cl:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -298,14 +298,23 @@ def test_lens():
     pix_scale = 0.1
     imsize = 100
     ser = galsim.Sersic(n, half_light_radius = re)
+
+    ser1 = ser.shear(g1=g1, g2=g2).magnify(mu)
+    im1 = galsim.ImageF(imsize, imsize, scale=pix_scale)
+    im1 = ser1.drawImage(im1, method='no_pixel')
+
     ser2 = ser.lens(g1, g2, mu)
-    ser = ser.shear(g1=g1, g2=g2).magnify(mu)
-    im = galsim.ImageF(imsize, imsize, scale=pix_scale)
-    im = ser.drawImage(im, method='no_pixel')
     im2 = galsim.ImageF(imsize, imsize, scale=pix_scale)
     im2 = ser2.drawImage(im2, method='no_pixel')
-    np.testing.assert_array_almost_equal(im.array, im2.array, 5,
+    np.testing.assert_array_almost_equal(im2.array, im1.array, 5,
         err_msg="Lensing of Sersic profile done in two different ways gives different answer")
+
+    # _lens is equivalent in this case.
+    ser3 = ser._lens(g1, g2, mu)
+    im3 = galsim.ImageF(imsize, imsize, scale=pix_scale)
+    im3 = ser3.drawImage(im3, method='no_pixel')
+    np.testing.assert_array_almost_equal(im3.array, im1.array, 5,
+        err_msg="Lensing of Sersic profile with _lens gives different answer")
 
 
 @timer

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -46,12 +46,14 @@ def test_pos():
     pi5 = galsim.PositionI(galsim.PositionD(11.0,23.0))
     pi6 = galsim.PositionD(11.3,23.4).round()
     pi7 = pi2.round()
+    pi8 = galsim._PositionI(11,23)
     assert pi2 == pi1
     assert pi3 == pi1
     assert pi4 == pi1
     assert pi5 == pi1
     assert pi6 == pi1
     assert pi7 == pi1
+    assert pi8 == pi1
     assert isinstance(pi3.x, int)
     assert isinstance(pi3.y, int)
     assert isinstance(pi5.x, int)
@@ -69,11 +71,13 @@ def test_pos():
     pd4 = galsim.PositionD(pd1)
     pd5 = galsim.PositionD(pi1)
     pd6 = galsim.PositionD(galsim.PositionD(11.3,23.4).round())
+    pd7 = galsim._PositionD(11.0,23.0)
     assert pd2 == pd1
     assert pd3 == pd1
     assert pd4 == pd1
     assert pd5 == pd1
     assert pd6 == pd1
+    assert pd7 == pd1
     assert isinstance(pd3.x, float)
     assert isinstance(pd3.y, float)
     assert isinstance(pd5.x, float)

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -2679,7 +2679,7 @@ def test_fittedsipwcs():
         center=center
     )
     ra_test, dec_test = fittedWCS.xyToradec(x, y, units='rad')
-    check_sphere(ra, dec, ra_test, dec_test, atol=2200)
+    check_sphere(ra, dec, ra_test, dec_test, atol=2400)
     x_test, y_test = fittedWCS.radecToxy(ra, dec, units='rad')
     np.testing.assert_allclose(
         np.hstack([x, y]),

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -2596,6 +2596,21 @@ def test_fittedsipwcs():
             atol=tol[tag][1]
         )
 
+        # Check x,y being higher dim than 1
+        x_test_2d, y_test_2d = fittedWCS.radecToxy(ra.reshape(30,10), dec.reshape(30,10),
+                                                   units='rad')
+        assert x_test_2d.shape == (30,10)
+        assert y_test_2d.shape == (30,10)
+        np.testing.assert_array_equal(x_test_2d.ravel(), x_test)
+        np.testing.assert_array_equal(y_test_2d.ravel(), y_test)
+
+        ra_test_3d, dec_test_3d = fittedWCS.xyToradec(x.reshape(5,5,12), y.reshape(5,5,12),
+                                                      units='rad')
+        assert ra_test_3d.shape == (5,5,12)
+        assert dec_test_3d.shape == (5,5,12)
+        np.testing.assert_array_equal(ra_test_3d.ravel(), ra_test)
+        np.testing.assert_array_equal(dec_test_3d.ravel(), dec_test)
+
         # Try again, but force a different center
         # Increase tolerance since WCS no longer nicely centered on region of
         # interest.


### PR DESCRIPTION
**Background**:

One of the features of input objects in the config layer is that if they have a well-defined number of objects in them (e.g. an input catalog for instance), then the code can automatically use that to set the number of objects to render in the simulation.  Namely, doing all of them in turn.

Furthermore, sometimes the config layer needs to know the number of objects that will be rendered before it needs the rest of the information in the input object.  Say when planning out the number of objects that it will need for each image, so it can plan out the right random number seeds to send to each of several jobs.  If the input object takes a fair amount of time to load in (or potentially uses a lot of memory once it's fully loaded), it would be nice to only load in enough to get the number of objects for the cases where that's all we need at the moment.

**Current Code**:

The mechanism that the current config code uses to deal with that case efficiently is to require that each input object that can return a number of objects must have an optional construction parameter, `_nobjects_only`, which when set to True will only do what is necessary to figure out nobjects, and not bother loading in the rest of the data.

This mechanism works ok if the particular input data has a quick way to figure out the number of objects without having to load in everything.  The RealGalaxyCatalog was the paradigm I used when designing this.  The parametric catalog records the total number of objects.  So there is no need to load the real galaxy data if all you need is the number of objects.

**The Problem**:

The instance catalog we read in in imsim doesn't work like this at all.  It takes a *very* long time to read in, even if all you're doing is counting which objects fall in the image in question.  Furthermore, the nobjects special construction is actually called twice before the real load, so it ends up reading in the instance catalog essentially in full 3 times before getting to actually do anything with it.

Also, the current mechanism of requiring a special (nominally private) construction argument is kind of bad form anyway.  It was a hack that was probably ill-advised from the start.  Most simulation runs will eventually need to load in the full input data anyway, and I suspect it is rare that people run versions where lots of different input objects need to compute their number of objects so it can plan out a long complicated sim run.  I think most people use command-line arguments to set things appropriately for a single image or small set of images using a single input catalog.  So this optimization was probably premature.

**The Solution**:

The better solution to this is to let the input class itself delay loading in the rest of the data if it's useful to do so.  I refactored the Catalog and RealGalaxyCatalog classes to use lazy properties to only load the data once they are needed.  The constructor just does enough to be able to return the number of objects, so if that's all that ever is needed, it doesn't waste time.  But if we only have the one input object, then there is only ever one call to the constructor.  Not 3.  So for the instance catalog situation, it doesn't waste time there.