### PR TITLE
Use Ogata, 2005 algorithm for computing Hankel transforms.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -122,6 +122,7 @@ New Features
   with `galsim.trapz` as a drop in replacement for ``numpy.trapz``, which
   is often somewhat faster. (#1098)
 - Added galsim.integ.hankel function. (#1099)
+- Added galsim.bessel.jv_root function. (#1099)
 
 
 Performance Improvements

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -135,6 +135,8 @@ Performance Improvements
 - Sped up `SED.calculateFlux` and a few other SED and Bandpass calculations
   by switching to `LookupTable.integrate_product` for the implementation of
   the integrals. (#1098)
+- Sped up the Hankel transforms several classes use for computing either the
+  k-space values (e.g. Sersic) or real-space values (e.g. Kolmogorov). (#1099)
 
 
 Bug Fixes

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -121,6 +121,7 @@ New Features
 - Added `LookupTable.integrate` and `LookupTable.integrate_product`, along
   with `galsim.trapz` as a drop in replacement for ``numpy.trapz``, which
   is often somewhat faster. (#1098)
+- Added galsim.integ.hankel function. (#1099)
 
 
 Performance Improvements

--- a/devel/time_sersic.py
+++ b/devel/time_sersic.py
@@ -16,6 +16,8 @@
 #    and/or other materials provided with the distribution.
 #
 
+from __future__ import print_function
+
 import galsim
 import time
 
@@ -32,9 +34,9 @@ for iter in range(2):
         final = galsim.Convolve(psf,gal)
         im = final.drawImage(image=im)
         t1 = time.time()
-        print 'n = %f, time = %f'%(n,t1-t0)
+        print('n = %f, time = %f'%(n,t1-t0))
     tend = time.time()
-    print 'Total time = %f'%(tend-tstart)
+    print('Total time = %f'%(tend-tstart))
 
 gsparams = galsim.GSParams(xvalue_accuracy=1.e-2, kvalue_accuracy=1.e-2,
                            maxk_threshold=1.e-2, folding_threshold=1.e-2)
@@ -47,6 +49,6 @@ for iter in range(2):
         final = galsim.Convolve(psf,gal)
         im = final.drawImage(image=im)
         t1 = time.time()
-        print 'n = %f, time = %f'%(n,t1-t0)
+        print('n = %f, time = %f'%(n,t1-t0))
     tend = time.time()
-    print 'Total time with loose params = %f'%(tend-tstart)
+    print('Total time with loose params = %f'%(tend-tstart))

--- a/docs/bessel.rst
+++ b/docs/bessel.rst
@@ -16,3 +16,4 @@ is mostly to enable unit tests that these C++ function are correct.
 .. autofunction:: galsim.bessel.yn
 .. autofunction:: galsim.bessel.iv
 .. autofunction:: galsim.bessel.j0_root
+.. autofunction:: galsim.bessel.jv_root

--- a/docs/integ.rst
+++ b/docs/integ.rst
@@ -3,6 +3,8 @@ Integration
 
 .. autofunction:: galsim.integ.int1d
 
+.. autofunction:: galsim.integ.hankel
+
 .. autoclass:: galsim.integ.IntegrationRule
     :members:
 

--- a/galsim/bessel.py
+++ b/galsim/bessel.py
@@ -16,7 +16,7 @@
 #    and/or other materials provided with the distribution.
 #
 
-from ._galsim import j0, j1, jv, kv, yv, iv, j0_root
+from ._galsim import j0, j1, jv, kv, yv, iv, j0_root, jv_root
 
 # Alias the "n" names, which don't get any advantage from being implemented differently,
 # so we only have the generic nu implementation.  But to match scipy.special, we also

--- a/galsim/integ.py
+++ b/galsim/integ.py
@@ -57,17 +57,18 @@ def int1d(func, min, max, rel_err=1.e-6, abs_err=1.e-12):
     else:
         raise GalSimError(result)
 
-def hankel(func, k, rmax=None, rel_err=1.e-6, abs_err=1.e-12):
-    r"""Perform an order 0 Hankel transform of the given function f(r) at a specific k value.
+def hankel(func, k, nu=0, rmax=None, rel_err=1.e-6, abs_err=1.e-12):
+    r"""Perform an order nu Hankel transform of the given function f(r) at a specific k value.
 
     .. math::
 
-        F(k) = \int_0^\infty f(r) J_0(k r) r dr
+        F(k) = \int_0^\infty f(r) J_\nu(k r) r dr
 
     Parameters:
 
         func:       The function f(r)
         k:          The value of k for which to calculate F(k)
+        nu:         The order of the Bessel function to use for the transform. [default: 0]
         rmax:       An optional truncation radius at which to have f(r) drop to 0. [default: None]
         rel_err:    The desired relative accuracy [default: 1.e-6]
         abs_err:    The desired absolute accuracy [default: 1.e-12]
@@ -79,9 +80,15 @@ def hankel(func, k, rmax=None, rel_err=1.e-6, abs_err=1.e-12):
     rel_err = float(rel_err)
     abs_err = float(abs_err)
     k = float(k)
+    nu = float(nu)
     rmax = float(rmax) if rmax is not None else 0.
+
+    if k < 0:
+        raise GalSimValueError("k must be >= 0",k)
+    if nu < 0:
+        raise GalSimValueError("nu must be >= 0",k)
     with convert_cpp_errors():
-        return _galsim.PyHankel(func, k, rmax, rel_err, abs_err)
+        return _galsim.PyHankel(func, k, nu, rmax, rel_err, abs_err)
 
 class IntegrationRule(object):
     """A class that can be used to integrate something more complicated than a normal

--- a/galsim/integ.py
+++ b/galsim/integ.py
@@ -57,6 +57,32 @@ def int1d(func, min, max, rel_err=1.e-6, abs_err=1.e-12):
     else:
         raise GalSimError(result)
 
+def hankel(func, k, rmax=None, rel_err=1.e-6, abs_err=1.e-12):
+    r"""Perform an order 0 Hankel transform of the given function f(r) at a specific k value.
+
+    .. math::
+
+        F(k) = \int_0^\infty f(r) J_0(k r) r dr
+
+    Parameters:
+
+        func:       The function f(r)
+        k:          The value of k for which to calculate F(k)
+        rmax:       An optional truncation radius at which to have f(r) drop to 0. [default: None]
+        rel_err:    The desired relative accuracy [default: 1.e-6]
+        abs_err:    The desired absolute accuracy [default: 1.e-12]
+
+    Returns:
+
+        An estimate of F(k)
+    """
+    rel_err = float(rel_err)
+    abs_err = float(abs_err)
+    k = float(k)
+    rmax = float(rmax) if rmax is not None else 0.
+    with convert_cpp_errors():
+        return _galsim.PyHankel(func, k, rmax, rel_err, abs_err)
+
 class IntegrationRule(object):
     """A class that can be used to integrate something more complicated than a normal
     scalar function.

--- a/galsim/integ.py
+++ b/galsim/integ.py
@@ -34,6 +34,15 @@ def int1d(func, min, max, rel_err=1.e-6, abs_err=1.e-12):
         >>> galsim.integ.int1d(func, -1, 1)
         0.66666666666666674
 
+    .. note::
+
+        This uses an adaptive Gauss-Kronrod-Patterson method for doing the integration.
+
+        cf. https://www.jstor.org/stable/2004583
+
+        If one or both endpoints are infinite, it will automatically use an appropriate
+        transformation to turn it into a finite integral.
+
     Parameters:
         func:       The function to be integrated.  y = func(x) should be valid.
         min:        The lower end of the integration bounds (anything < -1.e10 is treated as
@@ -63,6 +72,14 @@ def hankel(func, k, nu=0, rmax=None, rel_err=1.e-6, abs_err=1.e-12):
     .. math::
 
         F(k) = \int_0^\infty f(r) J_\nu(k r) r dr
+
+    .. note::
+
+        For non-truncated Hankel integrals, this uses the method outlined in Ogata, 2005:
+        http://www.kurims.kyoto-u.ac.jp/~prims/pdf/41-4/41-4-40.pdf
+
+        For truncated integrals (and k=0), it uses the same adaptive Gauss-Kronrod-Patterson
+        method used for `int1d`.
 
     Parameters:
 

--- a/galsim/photon_array.py
+++ b/galsim/photon_array.py
@@ -734,7 +734,7 @@ class PhotonDCR(PhotonOp):
         s = "galsim.PhotonDCR(base_wavelength=%r, scale_unit=%r, alpha=%r, "%(
                 self.base_wavelength, self.scale_unit, self.alpha)
         s += "zenith_angle=%r, parallactic_angle=%r"%(self.zenith_angle, self.parallactic_angle)
-        for k in self.kw:
+        for k in sorted(self.kw):
             s += ", %s=%r"%(k, self.kw[k])
         s += ")"
         return s

--- a/include/galsim/SBMoffatImpl.h
+++ b/include/galsim/SBMoffatImpl.h
@@ -124,7 +124,7 @@ namespace galsim {
         mutable double _stepk;
         mutable double _maxk; ///< Maximum k with kValue > 1.e-3
 
-        double (*_pow_beta)(double x, double beta);
+        double (*_pow_mbeta)(double x, double beta);
         double (SBMoffatImpl::*_kV)(double ksq) const;
 
         /// Setup the FT Table.

--- a/include/galsim/integ/Int.h
+++ b/include/galsim/integ/Int.h
@@ -178,14 +178,14 @@ namespace integ {
     struct IntFailure : public std::runtime_error
     { IntFailure(const std::string& s) : std::runtime_error(s) {} };
 
-#ifdef NDEBUG
-#define integ_dbg1 if (false) (*dbgout)
-#define integ_dbg2 if (false) (*reg.dbgout)
-#define integ_dbg3 if (false) (*tempreg.dbgout)
-#else
+#ifdef DEBUGLOGGING
 #define integ_dbg1 if (dbgout) (*dbgout)
 #define integ_dbg2 if (reg.dbgout) (*reg.dbgout)
 #define integ_dbg3 if (tempreg.dbgout) (*tempreg.dbgout)
+#else
+#define integ_dbg1 if (false) (*dbgout)
+#define integ_dbg2 if (false) (*reg.dbgout)
+#define integ_dbg3 if (false) (*tempreg.dbgout)
 #endif
 
 #ifdef COUNTFEVAL

--- a/include/galsim/math/Bessel.h
+++ b/include/galsim/math/Bessel.h
@@ -37,6 +37,9 @@ namespace math {
     double j0(double x);
     double j1(double x);
 
+    double getBesselRoot0(int s);
+    double getBesselRoot(double nu, int s);
+
 } }
 
 #endif

--- a/include/galsim/math/Hankel.h
+++ b/include/galsim/math/Hankel.h
@@ -25,9 +25,9 @@
 namespace galsim {
 namespace math {
 
-    double hankel_trunc(const std::function<double(double)> f, double k, double maxr,
+    double hankel_trunc(const std::function<double(double)> f, double k, double nu, double maxr,
                         double relerr=1.e-8, double abserr=1.e-15, int nzeros=10);
-    double hankel_inf(const std::function<double(double)> f, double k,
+    double hankel_inf(const std::function<double(double)> f, double k, double nu,
                       double relerr=1.e-8, double abserr=1.e-15, int nzeros=10);
 
 }

--- a/include/galsim/math/Hankel.h
+++ b/include/galsim/math/Hankel.h
@@ -1,0 +1,36 @@
+/* -*- c++ -*-
+ * Copyright (c) 2012-2020 by the GalSim developers team on GitHub
+ * https://github.com/GalSim-developers
+ *
+ * This file is part of GalSim: The modular galaxy image simulation toolkit.
+ * https://github.com/GalSim-developers/GalSim
+ *
+ * GalSim is free software: redistribution and use in source and binary forms,
+ * with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions, and the disclaimer given in the accompanying LICENSE
+ *    file.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the disclaimer given in the documentation
+ *    and/or other materials provided with the distribution.
+ */
+
+#ifndef GalSim_Hankel_H
+#define GalSim_Hankel_H
+
+#include <functional>
+
+namespace galsim {
+namespace math {
+
+    double hankel(const std::function<double(double)> f, double k, double maxr,
+                  double relerr=1.e-8, double abserr=1.e-15, int nzeros=0);
+    double hankel_inf(const std::function<double(double)> f, double k,
+                      double relerr=1.e-8, double abserr=1.e-15, int nzeros=0);
+
+}
+}
+
+#endif

--- a/include/galsim/math/Hankel.h
+++ b/include/galsim/math/Hankel.h
@@ -25,8 +25,8 @@
 namespace galsim {
 namespace math {
 
-    double hankel(const std::function<double(double)> f, double k, double maxr,
-                  double relerr=1.e-8, double abserr=1.e-15, int nzeros=0);
+    double hankel_trunc(const std::function<double(double)> f, double k, double maxr,
+                        double relerr=1.e-8, double abserr=1.e-15, int nzeros=0);
     double hankel_inf(const std::function<double(double)> f, double k,
                       double relerr=1.e-8, double abserr=1.e-15, int nzeros=0);
 

--- a/include/galsim/math/Hankel.h
+++ b/include/galsim/math/Hankel.h
@@ -26,9 +26,9 @@ namespace galsim {
 namespace math {
 
     double hankel_trunc(const std::function<double(double)> f, double k, double maxr,
-                        double relerr=1.e-8, double abserr=1.e-15, int nzeros=0);
+                        double relerr=1.e-8, double abserr=1.e-15, int nzeros=10);
     double hankel_inf(const std::function<double(double)> f, double k,
-                      double relerr=1.e-8, double abserr=1.e-15, int nzeros=0);
+                      double relerr=1.e-8, double abserr=1.e-15, int nzeros=10);
 
 }
 }

--- a/include/galsim/math/Hankel.h
+++ b/include/galsim/math/Hankel.h
@@ -26,9 +26,9 @@ namespace galsim {
 namespace math {
 
     double hankel_trunc(const std::function<double(double)> f, double k, double nu, double maxr,
-                        double relerr=1.e-8, double abserr=1.e-15, int nzeros=10);
+                        double relerr=1.e-6, double abserr=1.e-12, int nzeros=10);
     double hankel_inf(const std::function<double(double)> f, double k, double nu,
-                      double relerr=1.e-8, double abserr=1.e-15, int nzeros=10);
+                      double relerr=1.e-6, double abserr=1.e-12, int nzeros=10);
 
 }
 }

--- a/pysrc/Bessel.cpp
+++ b/pysrc/Bessel.cpp
@@ -18,7 +18,6 @@
  */
 
 #include "PyBind11Helper.h"
-#include "math/BesselRoots.h"
 #include "math/Bessel.h"
 
 namespace galsim {
@@ -27,6 +26,7 @@ namespace math {
     void pyExportBessel(PY_MODULE& _galsim)
     {
         GALSIM_DOT def("j0_root", &getBesselRoot0);
+        GALSIM_DOT def("jv_root", &getBesselRoot);
         GALSIM_DOT def("j0", &j0);
         GALSIM_DOT def("j1", &j1);
         GALSIM_DOT def("jv", &cyl_bessel_j);

--- a/pysrc/Integ.cpp
+++ b/pysrc/Integ.cpp
@@ -59,14 +59,14 @@ namespace integ {
     }
 
     // Integrate a python function using int1d.
-    double PyHankel(const py::object& func, double k, double rmax,
+    double PyHankel(const py::object& func, double k, double nu, double rmax,
                     double rel_err=DEFRELERR, double abs_err=DEFABSERR)
     {
         PyFunc pyfunc(func);
         if (rmax == 0.) {
-            return math::hankel_inf(pyfunc, k, rel_err, abs_err);
+            return math::hankel_inf(pyfunc, k, nu, rel_err, abs_err);
         } else {
-            return math::hankel_trunc(pyfunc, k, rmax, rel_err, abs_err);
+            return math::hankel_trunc(pyfunc, k, nu, rmax, rel_err, abs_err);
         }
     }
 

--- a/pysrc/Integ.cpp
+++ b/pysrc/Integ.cpp
@@ -59,7 +59,7 @@ namespace integ {
     }
 
     // Integrate a python function using int1d.
-    double PyHankel(const py::object& func, double k, double nu, double rmax,
+    double PyHankel(const py::function& func, double k, double nu, double rmax,
                     double rel_err=DEFRELERR, double abs_err=DEFABSERR)
     {
         PyFunc pyfunc(func);

--- a/pysrc/Integ.cpp
+++ b/pysrc/Integ.cpp
@@ -19,6 +19,7 @@
 
 #include "PyBind11Helper.h"
 #include "integ/Int.h"
+#include "math/Hankel.h"
 #include <iostream>
 
 namespace galsim {
@@ -57,10 +58,22 @@ namespace integ {
         }
     }
 
+    // Integrate a python function using int1d.
+    double PyHankel(const py::object& func, double k, double rmax,
+                    double rel_err=DEFRELERR, double abs_err=DEFABSERR)
+    {
+        PyFunc pyfunc(func);
+        if (rmax == 0.) {
+            return math::hankel_inf(pyfunc, k, rel_err, abs_err);
+        } else {
+            return math::hankel_trunc(pyfunc, k, rmax, rel_err, abs_err);
+        }
+    }
+
     void pyExportInteg(PY_MODULE& _galsim)
     {
         GALSIM_DOT def("PyInt1d", &PyInt1d);
-
+        GALSIM_DOT def("PyHankel", &PyHankel);
     }
 
 } // namespace integ

--- a/src/SBKolmogorov.cpp
+++ b/src/SBKolmogorov.cpp
@@ -283,7 +283,7 @@ namespace galsim {
         double operator()(double r) const
         {
             KolmKValue kvalue;
-            return math::hankel_inf(kvalue, r,
+            return math::hankel_inf(kvalue, r, 0,
                                     _gsparams.integration_relerr,
                                     _gsparams.integration_abserr);
         }

--- a/src/SBKolmogorov.cpp
+++ b/src/SBKolmogorov.cpp
@@ -370,6 +370,7 @@ namespace galsim {
         // 10 h^4 <= kvalue_accuracy
         // h = (kvalue_accuracy/10)^0.25
         double dlogr = gsparams->table_spacing * sqrt(sqrt(gsparams->xvalue_accuracy / 10.));
+        xdbg<<"dlogr = "<<dlogr<<std::endl;
 
         // Along the way accumulate the flux integral to determine the radius
         // that encloses (1-folding_threshold) of the flux.
@@ -377,6 +378,7 @@ namespace galsim {
         double thresh0 = 0.5 / (2.*M_PI*dlogr);
         double thresh1 = (1.-gsparams->folding_threshold) / (2.*M_PI*dlogr);
         double thresh2 = gsparams->shoot_accuracy / (2.*M_PI*dlogr);
+        xdbg<<"thresh values = "<<thresh0<<"  "<<thresh1<<"  "<<thresh2<<std::endl;
         double R = 0., hlr = 0.;
         KolmXValue xval_func(*gsparams);
 
@@ -404,7 +406,7 @@ namespace galsim {
             // At high r, the profile is well approximated by a power law, F ~ r^-3.68
             // The integral of the missing flux out to infinity is int_r^inf F(r) r dr = F r^2/1.68
             xdbg<<"F r^2/1.68 = "<<val*r*r/1.68<<"  thresh2 = "<<thresh2<<std::endl;
-            if (val * r * r / 1.68 < thresh2) break;
+            if (hlr != 0 && val * r * r / 1.68 < thresh2) break;
         }
         _radial.finalize();
         dbg<<"Done loop to build radial function.\n";

--- a/src/SBMoffat.cpp
+++ b/src/SBMoffat.cpp
@@ -598,7 +598,7 @@ namespace galsim {
             if (_trunc > 0) {
                 val = math::hankel_trunc(I, k, _maxRrD,
                                          this->gsparams.integration_relerr,
-                                         this->gsparams.integration_abserr, 10);
+                                         this->gsparams.integration_abserr)
             } else {
                 val = math::hankel_inf(I, k,
                                        this->gsparams.integration_relerr,

--- a/src/SBMoffat.cpp
+++ b/src/SBMoffat.cpp
@@ -595,11 +595,11 @@ namespace galsim {
 
             double val;
             if (_trunc > 0) {
-                val = math::hankel_trunc(I, k, _maxRrD,
+                val = math::hankel_trunc(I, k, 0., _maxRrD,
                                          this->gsparams.integration_relerr,
                                          this->gsparams.integration_abserr);
             } else {
-                val = math::hankel_inf(I, k,
+                val = math::hankel_inf(I, k, 0.,
                                        this->gsparams.integration_relerr,
                                        this->gsparams.integration_abserr);
             }

--- a/src/SBMoffat.cpp
+++ b/src/SBMoffat.cpp
@@ -595,7 +595,7 @@ namespace galsim {
         for(double k=0.; k < 50; k += dk) {
 
             double val;
-            if (trunc > 0) {
+            if (_trunc > 0) {
                 val = math::hankel(I, k, _maxRrD,
                                    this->gsparams.integration_relerr,
                                    this->gsparams.integration_abserr, 10);

--- a/src/SBMoffat.cpp
+++ b/src/SBMoffat.cpp
@@ -598,7 +598,7 @@ namespace galsim {
             if (_trunc > 0) {
                 val = math::hankel_trunc(I, k, _maxRrD,
                                          this->gsparams.integration_relerr,
-                                         this->gsparams.integration_abserr)
+                                         this->gsparams.integration_abserr);
             } else {
                 val = math::hankel_inf(I, k,
                                        this->gsparams.integration_relerr,

--- a/src/SBMoffat.cpp
+++ b/src/SBMoffat.cpp
@@ -602,7 +602,7 @@ namespace galsim {
             } else {
                 val = math::hankel_inf(I, k,
                                        this->gsparams.integration_relerr,
-                                       this->gsparams.integration_abserr, 10);
+                                       this->gsparams.integration_abserr);
             }
             val *= prefactor;
 

--- a/src/SBMoffat.cpp
+++ b/src/SBMoffat.cpp
@@ -596,9 +596,9 @@ namespace galsim {
 
             double val;
             if (_trunc > 0) {
-                val = math::hankel(I, k, _maxRrD,
-                                   this->gsparams.integration_relerr,
-                                   this->gsparams.integration_abserr, 10);
+                val = math::hankel_trunc(I, k, _maxRrD,
+                                         this->gsparams.integration_relerr,
+                                         this->gsparams.integration_abserr, 10);
             } else {
                 val = math::hankel_inf(I, k,
                                        this->gsparams.integration_relerr,

--- a/src/SBMoffat.cpp
+++ b/src/SBMoffat.cpp
@@ -25,7 +25,6 @@
 #include "SBMoffatImpl.h"
 #include "integ/Int.h"
 #include "Solve.h"
-#include "math/BesselRoots.h"
 #include "math/Bessel.h"
 #include "math/Gamma.h"
 #include "math/Angle.h"

--- a/src/SBSecondKick.cpp
+++ b/src/SBSecondKick.cpp
@@ -27,7 +27,6 @@
 #include "math/Bessel.h"
 #include "math/Gamma.h"
 #include "math/Hankel.h"
-#include "math/BesselRoots.h"
 
 #ifdef DEBUGLOGGING
 #include <ctime>

--- a/src/SBSecondKick.cpp
+++ b/src/SBSecondKick.cpp
@@ -253,7 +253,7 @@ namespace galsim {
     double SKInfo::xValueRaw(double r) const {
         // r in units of 1/k0 = lambda/(2pi r0)
         SKIXIntegrand I(*this);
-        double result = math::hankel_inf(I, r,
+        double result = math::hankel_inf(I, r, 0.,
                                          _gsparams->integration_relerr,
                                          _gsparams->integration_abserr)/(2.*M_PI);
         dbg<<"xValueRaw("<<r<<") = "<<result<<"\n";
@@ -277,7 +277,7 @@ namespace galsim {
     double SKInfo::xValueExact(double r) const {
         // r in units of 1/k0 = lambda/(2pi r0)
         SKIExactXIntegrand I(*this);
-        double result = math::hankel_inf(I, r,
+        double result = math::hankel_inf(I, r, 0.,
                                          _gsparams->integration_relerr,
                                          _gsparams->integration_abserr)/(2.*M_PI);
         xdbg<<"xValueExact("<<r<<") = "<<result<<"\n";

--- a/src/SBSecondKick.cpp
+++ b/src/SBSecondKick.cpp
@@ -256,8 +256,7 @@ namespace galsim {
         SKIXIntegrand I(*this);
         double result = math::hankel_inf(I, r,
                                          _gsparams->integration_relerr,
-                                         _gsparams->integration_abserr,
-                                         r > 0 ? 10 : 0)/(2.*M_PI);
+                                         _gsparams->integration_abserr)/(2.*M_PI);
         dbg<<"xValueRaw("<<r<<") = "<<result<<"\n";
         return result;
     }
@@ -281,8 +280,7 @@ namespace galsim {
         SKIExactXIntegrand I(*this);
         double result = math::hankel_inf(I, r,
                                          _gsparams->integration_relerr,
-                                         _gsparams->integration_abserr,
-                                         r > 0 ? 10 : 0)/(2.*M_PI);
+                                         _gsparams->integration_abserr)/(2.*M_PI);
         xdbg<<"xValueExact("<<r<<") = "<<result<<"\n";
         return result;
     }

--- a/src/SBSersic.cpp
+++ b/src/SBSersic.cpp
@@ -472,11 +472,11 @@ namespace galsim {
 
             double val;
             if (_truncated) {
-                val = math::hankel_trunc(I, k, _trunc,
+                val = math::hankel_trunc(I, k, 0., _trunc,
                                          _gsparams->integration_relerr,
                                          _gsparams->integration_abserr*hankel_norm);
             } else {
-                val = math::hankel_inf(I, k,
+                val = math::hankel_inf(I, k, 0.,
                                        _gsparams->integration_relerr,
                                        _gsparams->integration_abserr*hankel_norm);
             }

--- a/src/SBSersic.cpp
+++ b/src/SBSersic.cpp
@@ -475,7 +475,7 @@ namespace galsim {
             if (_truncated) {
                 val = math::hankel_trunc(I, k, _trunc,
                                          _gsparams->integration_relerr,
-                                         _gsparams->integration_abserr*hankel_norm, 10);
+                                         _gsparams->integration_abserr*hankel_norm);
             } else {
                 val = math::hankel_inf(I, k,
                                        _gsparams->integration_relerr,

--- a/src/SBSersic.cpp
+++ b/src/SBSersic.cpp
@@ -24,7 +24,6 @@
 #include "integ/Int.h"
 #include "Solve.h"
 #include "math/Bessel.h"
-#include "math/BesselRoots.h"
 #include "math/Gamma.h"
 #include "math/Hankel.h"
 #include "fmath/fmath.hpp"

--- a/src/SBSersic.cpp
+++ b/src/SBSersic.cpp
@@ -483,7 +483,7 @@ namespace galsim {
             } else {
                 val = math::hankel_inf(I, k,
                                        _gsparams->integration_relerr,
-                                       _gsparams->integration_abserr*hankel_norm, 10);
+                                       _gsparams->integration_abserr*hankel_norm);
             }
             val /= hankel_norm;
             xdbg<<"logk = "<<logk<<", ft("<<exp(logk)<<") = "<<val<<"   "<<val*ksq<<std::endl;

--- a/src/SBSersic.cpp
+++ b/src/SBSersic.cpp
@@ -398,15 +398,11 @@ namespace galsim {
         }
     }
 
-    // Integrand class for the Hankel transform of Sersic
-    class SersicHankel : public std::function<double(double)>
+    class SersicRadialFunction: public FluxDensity
     {
     public:
-        SersicHankel(double invn): _invn(invn) {}
-
-        double operator()(double r) const
-        { return fmath::expd(-fast_pow(r, _invn)); }
-
+        SersicRadialFunction(double invn): _invn(invn) {}
+        double operator()(double r) const { return fmath::expd(-fast_pow(r,_invn)); }
     private:
         double _invn;
     };
@@ -469,7 +465,7 @@ namespace galsim {
         // Don't go past k = 500
         _ksq_max = -1.;
         _maxk = kmin; // Just in case we break on the first iteration.
-        SersicHankel I(_invn);
+        SersicRadialFunction I(_invn);
         bool found_maxk = false;
         for (double logk = std::log(kmin)-0.001; logk < std::log(500.); logk += dlogk) {
             double k = fmath::expd(logk);
@@ -800,15 +796,6 @@ namespace galsim {
         double b = CalculateB(n, invn, math::tgamma(2*n), 1.);
         return hlr * CalculateTruncatedScale(n, invn, b, trunc/hlr);
     }
-
-    class SersicRadialFunction: public FluxDensity
-    {
-    public:
-        SersicRadialFunction(double invn): _invn(invn) {}
-        double operator()(double r) const { return fmath::expd(-fast_pow(r,_invn)); }
-    private:
-        double _invn;
-    };
 
     void SersicInfo::shoot(PhotonArray& photons, UniformDeviate ud) const
     {

--- a/src/SBSersic.cpp
+++ b/src/SBSersic.cpp
@@ -473,9 +473,9 @@ namespace galsim {
 
             double val;
             if (_truncated) {
-                val = math::hankel(I, k, _trunc,
-                                   _gsparams->integration_relerr,
-                                   _gsparams->integration_abserr*hankel_norm, 10);
+                val = math::hankel_trunc(I, k, _trunc,
+                                         _gsparams->integration_relerr,
+                                         _gsparams->integration_abserr*hankel_norm, 10);
             } else {
                 val = math::hankel_inf(I, k,
                                        _gsparams->integration_relerr,

--- a/src/SBVonKarman.cpp
+++ b/src/SBVonKarman.cpp
@@ -223,7 +223,7 @@ namespace galsim {
         integ::IntRegion<double> reg(0, integ::MOCK_INF);
         double relerr = _gsparams->integration_relerr;
         double abserr = _gsparams->integration_abserr;
-        return math::hankel_inf(I, r, relerr, abserr) / (2.*M_PI);
+        return math::hankel_inf(I, r, 0., relerr, abserr) / (2.*M_PI);
     }
 
     double VonKarmanInfo::xValue(double r) const {

--- a/src/SBVonKarman.cpp
+++ b/src/SBVonKarman.cpp
@@ -222,36 +222,9 @@ namespace galsim {
         // r in arcsec
         VKXIntegrand I(*this);
         integ::IntRegion<double> reg(0, integ::MOCK_INF);
-        int nsplits = 0;
-        if (r > 0.) {
-            // Add explicit splits at first several roots of J0.
-            // This tends to make the integral more accurate.
-            // Emplirically, around r/2 is a decent number of oscillations to include explicitly.
-            // This is tested by test_vk_r0 in test_vonkarman.py.
-            nsplits = int(r/2);
-        }
         double relerr = _gsparams->integration_relerr;
         double abserr = _gsparams->integration_abserr;
-        double result = math::hankel_inf(I, r, relerr, abserr, nsplits);
-        // Sometimes this still fails.  The failure mode is always that the result is
-        // negative.  If this happens, double the number of split points and try again.
-        // Also cut the relerr down by a factor of 10.
-        // TODO: This is probably a sign that we should rethink how we are doing this integral.
-        //       There are a number of more sophisticated techniquest for handling oscillating
-        //       functions that just adding explicit split points.  Might be worth looking into
-        //       whether any of these would be more robust and/or more efficient.
-        int max_iter = 10;  // Don't do this forever!
-        while (result < 0) {
-            if (max_iter-- == 0)
-                throw SBError("Invalid von Karman XValue unresolved after 10 attempts");
-            dbg<<"Bad result: "<<result<<std::endl;
-            nsplits *= 2;
-            relerr /= 10;
-            abserr /= 10;
-            result = math::hankel_inf(I, r, relerr, abserr, nsplits);
-        }
-        // We've been ignoring a factor of 2 pi so far.  Apply it here.
-        return result / (2.*M_PI);
+        return math::hankel_inf(I, r, relerr, abserr) / (2.*M_PI);
     }
 
     double VonKarmanInfo::xValue(double r) const {

--- a/src/SBVonKarman.cpp
+++ b/src/SBVonKarman.cpp
@@ -24,7 +24,6 @@
 #include "Solve.h"
 #include "math/Bessel.h"
 #include "math/Gamma.h"
-#include "math/BesselRoots.h"
 #include "math/Hankel.h"
 #include "fmath/fmath.hpp"
 

--- a/src/math/BesselRoots.cpp
+++ b/src/math/BesselRoots.cpp
@@ -125,10 +125,10 @@ namespace math {
             return getBesselRoot0(s);
         } else {
             // This doesn't work for negative nu.
-            if (s <= 0)
-                throw std::runtime_error("s must be > 0");
             if (nu < 0)
                 throw std::runtime_error("nu must be >= 0.");
+            if (s <= 0)
+                throw std::runtime_error("s must be > 0");
             dbg<<"Bessel Root for nu="<<nu<<" s = "<<s<<std::endl;
             double m = 4.*nu*nu;
             double b = (s + nu/2. - 0.25)*M_PI;
@@ -136,7 +136,7 @@ namespace math {
             double inv8bsq = temp*temp;
             temp *= (m-1);
 
-            // As above, not b is the running total.
+            // As above, now b is the running total.
             // We compute the following approximation:
             // b - (m-1)/8b - 4(m-1)(7m-31)/3(8b)^3 - 32(m-1)(83m^2-982m+3779)/15(8b)^5
             //   - 64(m-1)(6949m^3-153855m^2+1585743m-6277237)/105(8b)^7

--- a/src/math/Hankel.cpp
+++ b/src/math/Hankel.cpp
@@ -1,0 +1,83 @@
+/* -*- c++ -*-
+ * Copyright (c) 2012-2020 by the GalSim developers team on GitHub
+ * https://github.com/GalSim-developers
+ *
+ * This file is part of GalSim: The modular galaxy image simulation toolkit.
+ * https://github.com/GalSim-developers/GalSim
+ *
+ * GalSim is free software: redistribution and use in source and binary forms,
+ * with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions, and the disclaimer given in the accompanying LICENSE
+ *    file.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the disclaimer given in the documentation
+ *    and/or other materials provided with the distribution.
+ */
+
+
+//#define DEBUGLOGGING
+
+#include <cmath>
+#include <functional>
+#include "math/Bessel.h"
+#include "math/BesselRoots.h"
+#include "integ/Int.h"
+#include "Std.h"
+
+namespace galsim {
+namespace math {
+
+    // Integrand class for the Hankel transform
+    class Integrand : public std::function<double(double)>
+    {
+    public:
+        Integrand(const std::function<double(double)> f, double k) : _f(f), _k(k)
+        {
+            dbg<<"Make Integrand: "<<k<<std::endl;
+        }
+        double operator()(double r) const
+        { 
+            dbg<<"Call integrand: "<<r<<std::endl;
+            return r*_f(r) * math::j0(_k*r);
+        }
+
+    private:
+        const std::function<double(double)> _f;
+        double _k;
+    };
+
+    double hankel(const std::function<double(double)> f, double k, double maxr,
+                  double relerr, double abserr, int nzeros)
+        {
+            dbg<<"Start hankel: "<<k<<"  "<<maxr<<std::endl;
+            Integrand I(f, k);
+
+    #ifdef DEBUGLOGGING
+            std::ostream* integ_dbgout = verbose_level >= 3 ? &Debugger::instance().get_dbgout() : 0;
+            integ::IntRegion<double> reg(0, maxr, integ_dbgout);
+    #else
+            integ::IntRegion<double> reg(0, maxr);
+    #endif
+            // Add explicit splits at first several roots of J0.
+            // This tends to make the integral more accurate.
+            for (int s=1; s<=nzeros; ++s) {
+                double root = math::getBesselRoot0(s);
+                if (root > k * maxr) break;
+                reg.addSplit(root/k);
+            }
+            return integ::int1d(I, reg, relerr, abserr);
+        }
+
+        double hankel_inf(const std::function<double(double)> f, double k,
+                      double relerr, double abserr, int nzeros)
+    {
+        dbg<<"Start hankel_inf: "<<k<<std::endl;
+        const double inf = integ::MOCK_INF;
+        return hankel(f, k, inf, relerr, abserr, nzeros);
+    }
+
+}
+}

--- a/src/math/Hankel.cpp
+++ b/src/math/Hankel.cpp
@@ -21,10 +21,12 @@
 //#define DEBUGLOGGING
 
 #include <cmath>
+#include <vector>
+#include <map>
 #include <functional>
+#include "integ/Int.h"
 #include "math/Bessel.h"
 #include "math/BesselRoots.h"
-#include "integ/Int.h"
 #include "Std.h"
 
 namespace galsim {
@@ -36,11 +38,11 @@ namespace math {
     public:
         Integrand(const std::function<double(double)> f, double k) : _f(f), _k(k)
         {
-            dbg<<"Make Integrand: "<<k<<std::endl;
+            xdbg<<"Make Integrand: "<<k<<std::endl;
         }
         double operator()(double r) const
-        { 
-            dbg<<"Call integrand: "<<r<<std::endl;
+        {
+            xdbg<<"Call integrand: "<<r<<std::endl;
             return r*_f(r) * math::j0(_k*r);
         }
 
@@ -49,35 +51,189 @@ namespace math {
         double _k;
     };
 
-    double hankel(const std::function<double(double)> f, double k, double maxr,
-                  double relerr, double abserr, int nzeros)
-        {
-            dbg<<"Start hankel: "<<k<<"  "<<maxr<<std::endl;
-            Integrand I(f, k);
-
-    #ifdef DEBUGLOGGING
-            std::ostream* integ_dbgout = verbose_level >= 3 ? &Debugger::instance().get_dbgout() : 0;
-            integ::IntRegion<double> reg(0, maxr, integ_dbgout);
-    #else
-            integ::IntRegion<double> reg(0, maxr);
-    #endif
-            // Add explicit splits at first several roots of J0.
-            // This tends to make the integral more accurate.
-            for (int s=1; s<=nzeros; ++s) {
-                double root = math::getBesselRoot0(s);
-                if (root > k * maxr) break;
-                reg.addSplit(root/k);
-            }
-            return integ::int1d(I, reg, relerr, abserr);
-        }
-
-        double hankel_inf(const std::function<double(double)> f, double k,
+    // This is the straightforward GKP method for doing the Hankel integral.
+    double hankel_gkp(const std::function<double(double)> f, double k, double maxr,
                       double relerr, double abserr, int nzeros)
     {
-        dbg<<"Start hankel_inf: "<<k<<std::endl;
-        const double inf = integ::MOCK_INF;
-        return hankel(f, k, inf, relerr, abserr, nzeros);
+        xdbg<<"Start hankel: "<<k<<"  "<<maxr<<std::endl;
+        Integrand I(f, k);
+
+#ifdef DEBUGLOGGING
+        std::ostream* integ_dbgout = verbose_level >= 3 ? &Debugger::instance().get_dbgout() : 0;
+        integ::IntRegion<double> reg(0, maxr, integ_dbgout);
+#else
+        integ::IntRegion<double> reg(0, maxr);
+#endif
+        // Add explicit splits at first several roots of J0.
+        // This tends to make the integral more accurate.
+        for (int s=1; s<=nzeros; ++s) {
+            double root = math::getBesselRoot0(s);
+            if (root > k * maxr) break;
+            reg.addSplit(root/k);
+        }
+        return integ::int1d(I, reg, relerr, abserr);
     }
+
+    class HankelIntegrator
+    {
+    public:
+        // Helper class that can perform a Hankel integral for a specific choice of h
+        // using the method of Ogata (2005):
+        // http://www.kurims.kyoto-u.ac.jp/~prims/pdf/41-4/41-4-40.pdf
+        HankelIntegrator(double h, double batch=256) :
+            _h(h), _Nmax(long(std::min(M_PI/h,1.e6))), _batch(batch), _N(0)
+        {
+            dbg<<"Setup HankelIntegrator for h="<<h<<std::endl;
+            dbg<<"Nmax = "<<_Nmax<<std::endl;
+            // Rarely will we need more than a few hundred values in the sum, even with very
+            // small values of h (since when that is needed, usually the function is highly
+            // concentrated at small values of x).  So do this in batches of 256.
+            // Only make the next batch if we end up needing it.
+            setWeightsBatch();
+        }
+
+        void setWeightsBatch()
+        {
+            // Set up a batch of the weights and kernel values for this choice of h.
+            long N1 = _N;  // Number of values already set.
+            _N += _batch;
+            if (_N > _Nmax) _N = _Nmax;
+            _w.resize(_N);
+            _x.resize(_N);
+            for (long i=N1; i<_N; ++i) {
+                double xi = math::getBesselRoot0(i+1)/M_PI;
+                double t = _h * xi;
+                _x[i] = M_PI/_h * psi(t);
+                _w[i] = math::cyl_bessel_y(0,M_PI*xi) / math::j1(M_PI*xi);
+                _w[i] *= M_PI * _x[i] * math::j0(_x[i]) * dpsi(t);
+                xdbg<<i<<"  "<<xi<<"  "<<t<<"  "<<_x[i]<<"  "<<_w[i]<<std::endl;
+            }
+            dbg<<"Done setWeightsBatch: _N = "<<_N<<std::endl;
+        }
+
+        inline double psi(double t)
+        {
+            return t * std::tanh(M_PI/2. * std::sinh(t));
+        }
+
+        inline double SQR(double x)
+        {
+            return x*x;
+        }
+
+        inline double dpsi(double t)
+        {
+            return t * M_PI/2. * std::cosh(t) / SQR(std::cosh(M_PI/2. * std::sinh(t))) + psi(t)/t;
+        }
+
+        double integrate(const std::function<double(double)> f, double k)
+        {
+            xdbg<<"start integrate for k = "<<k<<std::endl;
+            xdbg<<"h, N = "<<_h<<"  "<<_N<<std::endl;
+            assert(_N == long(_w.size()));
+            assert(_N == long(_x.size()));
+            double ans = 0.;
+            long N1 = 0;
+            bool done = false;
+            do {
+                double step;
+                for (long i=N1; i<_N; ++i) {
+                    step = _w[i] * f(_x[i]/k);
+                    ans += step;
+                    xdbg<<i<<"  "<<step<<"  "<<ans<<std::endl;
+                    if (std::abs(step) < 1.e-15 * std::abs(ans)) {
+                        xdbg<<"Break at i = "<<i<<std::endl;
+                        xdbg<<"step = "<<step<<", ans = "<<ans<<std::endl;
+                        done = true;
+                        break;
+                    }
+                }
+                N1 = _N;
+                if (_N == _Nmax) done = true;  // Can't go higher than this.
+                if (!done) {
+                    dbg<<"Didn't converge with current values.  N="<<_N<<std::endl;
+                    dbg<<"current ans = "<<ans<<", last step = "<<step<<std::endl;
+                    setWeightsBatch();
+                }
+            } while (!done);
+
+            // We omitted a factor of 1/k^2, so apply that now.
+            ans /= k*k;
+            xdbg<<"ans = "<<ans<<std::endl;
+            return ans;
+        }
+    private:
+        double _h;
+        long _Nmax;
+        long _batch;
+        long _N;
+        std::vector<double> _w;
+        std::vector<double> _x;
+    };
+
+    class AdaptiveHankelIntegrator
+    {
+    public:
+        // Wraps the above HankelIntegrator to get requested rel/abs errors.
+        AdaptiveHankelIntegrator(double h0=1./32.) : _h0(h0)
+        {
+            _integrators[h0] = std::unique_ptr<HankelIntegrator>(new HankelIntegrator(h0));
+            double h1 = 0.5 * h0;
+            _integrators[h1] = std::unique_ptr<HankelIntegrator>(new HankelIntegrator(h1));
+        }
+
+        HankelIntegrator* get_integrator(double h)
+        {
+            if (_integrators.count(h) == 0) {
+                _integrators[h] = std::unique_ptr<HankelIntegrator>(new HankelIntegrator(h));
+            }
+            return _integrators[h].get();
+        }
+
+        double integrate(const std::function<double(double)> f, double k,
+                         double relerr, double abserr)
+        {
+            dbg<<"start adaptive integrate for k = "<<k<<std::endl;
+
+            double h0 = _h0;
+            while (h0 > k) h0 *= 0.5;
+
+            double ans0 = get_integrator(h0)->integrate(f,k);
+            double h1 = 0.5 * h0;
+            double ans1 = get_integrator(h1)->integrate(f,k);
+            double err = std::abs(ans1-ans0);
+            dbg<<"first answers = "<<ans0<<", "<<ans1<<"  diff = "<<err<<std::endl;
+            while (err > abserr && err > relerr * ans1) {
+                h0 = h1;
+                ans0 = ans1;
+                h1 *= 0.5;
+                ans1 = get_integrator(h1)->integrate(f,k);
+                err = std::abs(ans1 - ans0);
+                dbg<<"answers = "<<ans0<<", "<<ans1<<"  diff = "<<err<<std::endl;
+            }
+            return ans1;
+        }
+    private:
+        double _h0;
+        std::map<double, std::unique_ptr<HankelIntegrator> > _integrators;
+    };
+
+    double hankel_inf(const std::function<double(double)> f, double k,
+                      double relerr, double abserr, int nzeros)
+    {
+        static AdaptiveHankelIntegrator H;
+        dbg<<"Start hankel_inf: "<<k<<std::endl;
+        if (k == 0.) {
+            // If k = 0, can't do the Ogata method, since it integrates f(x/k) J(x).
+            return hankel_gkp(f, k, integ::MOCK_INF, relerr, abserr, nzeros);
+        } else {
+            return H.integrate(f, k, relerr, abserr);
+        }
+    }
+
+    double hankel(const std::function<double(double)> f, double k, double maxr,
+                  double relerr, double abserr, int nzeros)
+    { return hankel_gkp(f, k, maxr, relerr, abserr, nzeros); }
 
 }
 }

--- a/src/math/Hankel.cpp
+++ b/src/math/Hankel.cpp
@@ -25,6 +25,7 @@
 #include <map>
 #include <functional>
 #include "integ/Int.h"
+#include "math/Hankel.h"
 #include "math/Bessel.h"
 #include "math/BesselRoots.h"
 #include "Std.h"

--- a/src/math/Hankel.cpp
+++ b/src/math/Hankel.cpp
@@ -139,7 +139,7 @@ namespace math {
             long N1 = 0;
             bool done = false;
             do {
-                double step;
+                double step = 0.;
                 for (long i=N1; i<_N; ++i) {
                     step = _w[i] * f(_x[i]/k);
                     ans += step;

--- a/src/math/Hankel.cpp
+++ b/src/math/Hankel.cpp
@@ -27,7 +27,6 @@
 #include "integ/Int.h"
 #include "math/Hankel.h"
 #include "math/Bessel.h"
-#include "math/BesselRoots.h"
 #include "Std.h"
 
 namespace galsim {

--- a/src/math/Hankel.cpp
+++ b/src/math/Hankel.cpp
@@ -201,7 +201,12 @@ namespace math {
             double ans1 = get_integrator(h1)->integrate(f,k);
             double err = std::abs(ans1-ans0);
             dbg<<"first answers = "<<ans0<<", "<<ans1<<"  diff = "<<err<<std::endl;
-            while (err > abserr && err > relerr * ans1) {
+            // Three checks for convergence:
+            // 1. if err < relerr * ans, then we're done
+            // 2. if err < abserr, then we're done
+            // 3. ... unless ans1 is much larger than ans0, then we probably don't have a good
+            //    estimate yet, so keep going.
+            while (err > relerr * ans1 && (err > abserr || ans1 > 2*ans0)) {
                 h0 = h1;
                 ans0 = ans1;
                 h1 *= 0.5;

--- a/src/math/Hankel.cpp
+++ b/src/math/Hankel.cpp
@@ -53,23 +53,23 @@ namespace math {
     };
 
     // This is the straightforward GKP method for doing the Hankel integral.
-    double hankel_gkp(const std::function<double(double)> f, double k, double maxr,
+    double hankel_gkp(const std::function<double(double)> f, double k, double rmax,
                       double relerr, double abserr, int nzeros)
     {
-        xdbg<<"Start hankel: "<<k<<"  "<<maxr<<std::endl;
+        xdbg<<"Start hankel: "<<k<<"  "<<rmax<<std::endl;
         Integrand I(f, k);
 
 #ifdef DEBUGLOGGING
         std::ostream* integ_dbgout = verbose_level >= 3 ? &Debugger::instance().get_dbgout() : 0;
-        integ::IntRegion<double> reg(0, maxr, integ_dbgout);
+        integ::IntRegion<double> reg(0, rmax, integ_dbgout);
 #else
-        integ::IntRegion<double> reg(0, maxr);
+        integ::IntRegion<double> reg(0, rmax);
 #endif
         // Add explicit splits at first several roots of J0.
         // This tends to make the integral more accurate.
         for (int s=1; s<=nzeros; ++s) {
             double root = math::getBesselRoot0(s);
-            if (root > k * maxr) break;
+            if (root > k * rmax) break;
             reg.addSplit(root/k);
         }
         return integ::int1d(I, reg, relerr, abserr);
@@ -230,9 +230,12 @@ namespace math {
         }
     }
 
-    double hankel_trunc(const std::function<double(double)> f, double k, double maxr,
+    double hankel_trunc(const std::function<double(double)> f, double k, double rmax,
                         double relerr, double abserr, int nzeros)
-    { return hankel_gkp(f, k, maxr, relerr, abserr, nzeros); }
+    {
+        dbg<<"Start hankel_trunc: "<<k<<"  "<<rmax<<std::endl;
+        return hankel_gkp(f, k, rmax, relerr, abserr, nzeros);
+    }
 
 }
 }

--- a/src/math/Hankel.cpp
+++ b/src/math/Hankel.cpp
@@ -114,17 +114,17 @@ namespace math {
             dbg<<"Done setWeightsBatch: _N = "<<_N<<std::endl;
         }
 
-        inline double psi(double t)
+        double psi(double t)
         {
             return t * std::tanh(M_PI/2. * std::sinh(t));
         }
 
-        inline double SQR(double x)
+        double SQR(double x)
         {
             return x*x;
         }
 
-        inline double dpsi(double t)
+        double dpsi(double t)
         {
             return t * M_PI/2. * std::cosh(t) / SQR(std::cosh(M_PI/2. * std::sinh(t))) + psi(t)/t;
         }

--- a/src/math/Hankel.cpp
+++ b/src/math/Hankel.cpp
@@ -229,8 +229,8 @@ namespace math {
         }
     }
 
-    double hankel(const std::function<double(double)> f, double k, double maxr,
-                  double relerr, double abserr, int nzeros)
+    double hankel_trunc(const std::function<double(double)> f, double k, double maxr,
+                        double relerr, double abserr, int nzeros)
     { return hankel_gkp(f, k, maxr, relerr, abserr, nzeros); }
 
 }

--- a/src/math/Hankel.cpp
+++ b/src/math/Hankel.cpp
@@ -196,7 +196,9 @@ namespace math {
             dbg<<"start adaptive integrate for k = "<<k<<std::endl;
 
             double h0 = _h0;
-            while (h0 > k) h0 *= 0.5;
+            // Empirically, for very small k, we'll at least need to drop h down to 100*k,
+            // so do this first before possibly iterating further.
+            while (h0 > 100*k) h0 *= 0.5;
 
             double ans0 = get_integrator(h0)->integrate(f,k);
             double h1 = 0.5 * h0;
@@ -211,6 +213,7 @@ namespace math {
                 err = std::abs(ans1 - ans0);
                 dbg<<"answers = "<<ans0<<", "<<ans1<<"  diff = "<<err<<std::endl;
             }
+            dbg<<"Final: "<<ans1<<"  k,h0 = "<<k<<"  "<<h0<<std::endl;
             return ans1;
         }
     private:

--- a/src/math/Hankel.cpp
+++ b/src/math/Hankel.cpp
@@ -175,12 +175,7 @@ namespace math {
     {
     public:
         // Wraps the above HankelIntegrator to get requested rel/abs errors.
-        AdaptiveHankelIntegrator(double h0=1./32.) : _h0(h0)
-        {
-            _integrators[h0] = std::unique_ptr<HankelIntegrator>(new HankelIntegrator(h0));
-            double h1 = 0.5 * h0;
-            _integrators[h1] = std::unique_ptr<HankelIntegrator>(new HankelIntegrator(h1));
-        }
+        AdaptiveHankelIntegrator(double h0=1./32.) : _h0(h0) {}
 
         HankelIntegrator* get_integrator(double h)
         {

--- a/src/math/files.txt
+++ b/src/math/files.txt
@@ -3,6 +3,7 @@ BesselJ.cpp
 BesselY.cpp
 BesselI.cpp
 BesselK.cpp
+BesselRoots.cpp
 Gamma.cpp
 Sinc.cpp
 Angle.cpp

--- a/src/math/files.txt
+++ b/src/math/files.txt
@@ -8,3 +8,4 @@ Sinc.cpp
 Angle.cpp
 Nan.cpp
 Horner.cpp
+Hankel.cpp

--- a/tests/test_bessel.py
+++ b/tests/test_bessel.py
@@ -360,8 +360,8 @@ def test_kv():
 
 
 @timer
-def test_j0_root():
-    """Test the bessel.j0_root function"""
+def test_jv_root():
+    """Test the bessel.j0_root and jv_root functions"""
     # Our version uses tabulated values up to 40, so a useful test of the extrapolation
     # requires this to have more than 40 items.
     vals1 = [ galsim.bessel.j0_root(s) for s in range(1,51) ]
@@ -370,32 +370,48 @@ def test_j0_root():
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore",category=RuntimeWarning)
         import scipy.special
+
     vals2 = scipy.special.jn_zeros(0,50)
     print('vals2 = ',vals2)
     np.testing.assert_allclose(
         vals1, vals2, rtol=1.e-10, err_msg="bessel.j0_root disagrees with scipy.special.jn_zeros")
 
-    # These values are what scipy returns.  Check against these, so not require scipy.
-    vals2 = [   2.404825557695773, 5.520078110286311, 8.653727912911013,
-                11.791534439014281, 14.930917708487787, 18.071063967910924,
-                21.21163662987926, 24.352471530749302, 27.493479132040257,
-                30.634606468431976, 33.77582021357357, 36.917098353664045,
-                40.05842576462824, 43.19979171317673, 46.341188371661815,
-                49.482609897397815, 52.624051841115, 55.76551075501998,
-                58.90698392608094, 62.04846919022717, 65.18996480020687,
-                68.3314693298568, 71.47298160359374, 74.61450064370185,
-                77.75602563038805, 80.89755587113763, 84.0390907769382,
-                87.18062984364116, 90.32217263721049, 93.46371878194478,
-                96.60526795099626, 99.7468198586806, 102.8883742541948,
-                106.02993091645162, 109.17148964980538, 112.3130502804949,
-                115.45461265366694, 118.59617663087253, 121.73774208795096,
-                124.87930891323295, 128.02087700600833, 131.1624462752139,
-                134.30401663830546, 137.44558802028428, 140.58716035285428,
-                143.72873357368974, 146.87030762579664, 150.01188245695477,
-                153.15345801922788, 156.29503426853353,
-            ]
+    vals3 = [ galsim.bessel.jv_root(0,s) for s in range(1,51) ]
     np.testing.assert_allclose(
-        vals1, vals2, rtol=1.e-10, err_msg="bessel.j0_root disagrees with reference values")
+        vals1, vals2, rtol=1.e-10,
+        err_msg="bessel.jv_root disagrees with scipy.special.jn_zeros with n=0")
+
+    for v in vals1:
+        np.testing.assert_allclose(galsim.bessel.j0(v), 0., atol=1.e-12)
+        np.testing.assert_allclose(scipy.special.j0(v), 0., atol=1.e-12)
+
+    for nu in [0, 1, 7, 13]:
+        print('nu = ',nu)
+        vals1 = [ galsim.bessel.jv_root(nu,s) for s in range(1,51) ]
+        print('vals1 = ',vals1)
+        vals2 = scipy.special.jn_zeros(nu,50)
+        print('vals2 = ',vals2)
+        np.testing.assert_allclose(
+            vals1, vals2, rtol=1.e-10,
+            err_msg="bessel.jv_root disagrees with scipy.special.jn_zeros with n=%f"%nu)
+        for v in vals1:
+            np.testing.assert_allclose(galsim.bessel.jv(nu,v), 0., atol=1.e-12)
+            np.testing.assert_allclose(scipy.special.jv(nu,v), 0., atol=1.e-12)
+
+    # We can also compute zeros of non-integral order, although scipy cannot.
+    # So we can't compare with scipy's answers here.  Just check that they really are zeros.
+    for nu in [0.5, 0.001, 1.39, 7.3, 13.9, 0.183]:
+        print('nu = ',nu)
+        vals1 = [ galsim.bessel.jv_root(nu,s) for s in range(1,51) ]
+        print('vals1 = ',vals1)
+        for v in vals1:
+            np.testing.assert_allclose(galsim.bessel.jv(nu,v), 0., atol=1.e-12)
+            np.testing.assert_allclose(scipy.special.jv(nu,v), 0., atol=1.e-12)
+
+    with assert_raises(RuntimeError):
+        galsim.bessel.jv_root(-0.3,1)
+    with assert_raises(RuntimeError):
+        galsim.bessel.jv_root(0.3,-1)
 
 
 if __name__ == "__main__":
@@ -409,4 +425,4 @@ if __name__ == "__main__":
     test_iv()
     test_kn()
     test_kv()
-    test_j0_root()
+    test_jv_root()

--- a/tests/test_chromatic.py
+++ b/tests/test_chromatic.py
@@ -211,9 +211,9 @@ def test_draw_add_commutativity():
     assert_raises(ValueError, chromatic_final.drawKImage, bandpass,
                   integrator='midp') # minor misspelling
     assert_raises(TypeError, chromatic_final.drawImage, bandpass, method='no_pixel',
-                  integrator=galsim.integ.midpt)
+                  integrator=galsim.integ.midptRule)
     assert_raises(TypeError, chromatic_final.drawKImage, bandpass,
-                  integrator=galsim.integ.midpt)
+                  integrator=galsim.integ.midptRule)
 
     # Can't use base class directly.
     assert_raises(NotImplementedError, galsim.integ.ImageIntegrator)
@@ -546,7 +546,7 @@ def test_chromatic_flux():
         err_msg="Drawn ChromaticConvolve flux (interpolated) doesn't match analytic prediction")
     # As an aside, check for appropriate tests of 'integrator' argument.
     assert_raises(ValueError, final_int.drawImage, bandpass, integrator='midp') # minor misspelling
-    assert_raises(ValueError, final_int.drawImage, bandpass, integrator=galsim.integ.midpt)
+    assert_raises(ValueError, final_int.drawImage, bandpass, integrator=galsim.integ.midptRule)
     do_pickle(PSF)
 
     # Check option to not use exact SED
@@ -565,7 +565,7 @@ def test_chromatic_flux():
         err_msg="Drawn ChromaticConvolve flux (interpolated) doesn't match analytic prediction")
     # As an aside, check for appropriate tests of 'integrator' argument.
     assert_raises(ValueError, final_int.drawImage, bandpass, integrator='midp') # minor misspelling
-    assert_raises(ValueError, final_int.drawImage, bandpass, integrator=galsim.integ.midpt)
+    assert_raises(ValueError, final_int.drawImage, bandpass, integrator=galsim.integ.midptRule)
     do_pickle(PSF)
 
     # Go back to no interpolation (this will effect the PSFs that are used below).

--- a/tests/test_integ.py
+++ b/tests/test_integ.py
@@ -273,6 +273,31 @@ def test_quad_basic():
     with assert_raises(galsim.GalSimError):
         galsim.integ.quadRule(func, [])
 
+@timer
+def test_hankel():
+    """Test the hankel_int and hankel_trunc functions
+    """
+    # Most of the use of this function is in C++, but we provide hooks to use it in python
+    # too in case that's useful for people.
+    # (We don't currently use this from python in GalSim proper.)
+
+    f1 = lambda r: np.exp(-r)
+    # The Hankel transform of exp(-r) is (1+k^2)**(-3/2)
+    for k in [1, 1.e-2, 0.234, 23.9]:
+        result = galsim.integ.hankel(f1, k)
+        expected_val = (1+k**2)**-1.5
+        np.testing.assert_allclose(result, expected_val)
+
+    r0 = 1.7
+    f2 = lambda r: 1.-(r/r0)**2
+    # The truncated Hankel transform of (1-(r/r0)^2) up to r0 is
+    # (4 J_1(r0 k) - 2 k r1 J_0(r0 k)/(r0 k^3)
+    for k in [1, 1.e-2, 0.234, 23.9]:
+        result = galsim.integ.hankel(f2, k, rmax=r0)
+        expected_val = (4*galsim.bessel.j1(r0*k) - 2*r0*k*galsim.bessel.j0(r0*k))/(r0*k**3)
+        np.testing.assert_allclose(result, expected_val)
+
+
 
 if __name__ == "__main__":
     test_gaussian_finite_limits()
@@ -283,3 +308,4 @@ if __name__ == "__main__":
     test_invroot_infinite_limits()
     test_midpoint_basic()
     test_trapz_basic()
+    test_hankel()

--- a/tests/test_integ.py
+++ b/tests/test_integ.py
@@ -275,7 +275,7 @@ def test_quad_basic():
 
 @timer
 def test_hankel():
-    """Test the hankel_int and hankel_trunc functions
+    """Test the galsim.integ.hankel function
     """
     # Most of the use of this function is in C++, but we provide hooks to use it in python
     # too in case that's useful for people.
@@ -299,7 +299,21 @@ def test_hankel():
             expected_val = 2*galsim.bessel.jn(2,r0*k)/k**2
         np.testing.assert_allclose(result, expected_val, rtol=1.e-6)
 
+    # The generalized Hankel transform of exp(-r) is:
+    # (1 + nu (1+k^2)^0.5) k^nu / ( (1+k^2)^1.5 (1 + (1+k^2)^0.5)^nu
+    for nu in [0, 1, 7, 0.5, 0.003, 12.23]:
+        for k in [1, 1.e-2, 0.234, 23.9, 1.e-5, 1.e-8, 0]:
+            result = galsim.integ.hankel(f1, k, nu=nu)
+            expected_val = (1+k**2)**-1.5 * (1+nu*(1+k**2)**0.5) * k**nu / (1+(1+k**2)**0.5)**nu
+            print(nu, k, result, expected_val)
+            np.testing.assert_allclose(result, expected_val, rtol=1.e-6, atol=1.e-12)
 
+    with assert_raises(galsim.GalSimValueError):
+        galsim.integ.hankel(f1, k=-0.3)
+    with assert_raises(galsim.GalSimValueError):
+        galsim.integ.hankel(f1, k=0.3, nu=-1)
+    with assert_raises(galsim.GalSimValueError):
+        galsim.integ.hankel(f1, k=0.3, nu=-0.5)
 
 if __name__ == "__main__":
     test_gaussian_finite_limits()

--- a/tests/test_integ.py
+++ b/tests/test_integ.py
@@ -283,19 +283,18 @@ def test_hankel():
 
     f1 = lambda r: np.exp(-r)
     # The Hankel transform of exp(-r) is (1+k^2)**(-3/2)
-    for k in [1, 1.e-2, 0.234, 23.9]:
+    for k in [1, 1.e-2, 0.234, 23.9, 1.e-8]:
         result = galsim.integ.hankel(f1, k)
         expected_val = (1+k**2)**-1.5
         np.testing.assert_allclose(result, expected_val)
 
     r0 = 1.7
     f2 = lambda r: 1.-(r/r0)**2
-    # The truncated Hankel transform of (1-(r/r0)^2) up to r0 is
-    # (4 J_1(r0 k) - 2 k r1 J_0(r0 k)/(r0 k^3)
-    for k in [1, 1.e-2, 0.234, 23.9]:
-        result = galsim.integ.hankel(f2, k, rmax=r0)
-        expected_val = (4*galsim.bessel.j1(r0*k) - 2*r0*k*galsim.bessel.j0(r0*k))/(r0*k**3)
-        np.testing.assert_allclose(result, expected_val)
+    # The truncated Hankel transform of (1-(r/r0)^2) up to r0 is 2 J_2(r0 k)/k^2
+    for k in [1, 1.e-2, 0.234, 23.9, 1.e-8]:
+        result = galsim.integ.hankel(f2, k, rmax=r0, rel_err=1.e-8)
+        expected_val = 2*galsim.bessel.jn(2,r0*k)/k**2
+        np.testing.assert_allclose(result, expected_val, rtol=1.e-6)
 
 
 

--- a/tests/test_integ.py
+++ b/tests/test_integ.py
@@ -283,7 +283,7 @@ def test_hankel():
 
     f1 = lambda r: np.exp(-r)
     # The Hankel transform of exp(-r) is (1+k^2)**(-3/2)
-    for k in [1, 1.e-2, 0.234, 23.9, 1.e-8]:
+    for k in [1, 1.e-2, 0.234, 23.9, 1.e-8, 0]:
         result = galsim.integ.hankel(f1, k)
         expected_val = (1+k**2)**-1.5
         np.testing.assert_allclose(result, expected_val)
@@ -291,9 +291,12 @@ def test_hankel():
     r0 = 1.7
     f2 = lambda r: 1.-(r/r0)**2
     # The truncated Hankel transform of (1-(r/r0)^2) up to r0 is 2 J_2(r0 k)/k^2
-    for k in [1, 1.e-2, 0.234, 23.9, 1.e-8]:
+    for k in [1, 1.e-2, 0.234, 23.9, 1.e-8, 0]:
         result = galsim.integ.hankel(f2, k, rmax=r0, rel_err=1.e-8)
-        expected_val = 2*galsim.bessel.jn(2,r0*k)/k**2
+        if k == 0:
+            expected_val = r0**2/4  # The limit as k->0.
+        else:
+            expected_val = 2*galsim.bessel.jn(2,r0*k)/k**2
         np.testing.assert_allclose(result, expected_val, rtol=1.e-6)
 
 

--- a/tests/test_kolmogorov.py
+++ b/tests/test_kolmogorov.py
@@ -137,7 +137,7 @@ def test_kolmogorov_properties():
     np.testing.assert_equal(psf.centroid, cen)
     # Check Fourier properties
     np.testing.assert_almost_equal(psf.maxk, 8.644067599028375, 9)
-    np.testing.assert_almost_equal(psf.stepk, 0.3698212155333603, 9)
+    np.testing.assert_almost_equal(psf.stepk, 0.3512294667416627, 9)
     np.testing.assert_almost_equal(psf.kValue(cen), test_flux+0j)
     np.testing.assert_almost_equal(psf.lam_over_r0, lor)
     np.testing.assert_almost_equal(psf.half_light_radius, lor * 0.5548101137)

--- a/tests/test_vonkarman.py
+++ b/tests/test_vonkarman.py
@@ -271,6 +271,9 @@ def test_vk_r0():
     Note: the resolution of the bug was to add explicit split points for the first several
     j0 zeros.  Without that, the integral in rawXValue can spuriously fail badly, leading to
     an invalid estimate of the total integrated flux within R=pi/stepk.
+
+    Update: With the new Ogata method for doing the Hankel transform, this seems no longer to
+    be necessary.  However, we continue to test these r values anyway.
     """
     # The first one was issue #957.
     # Aaron Roodman ran across another, which is now included here as well.


### PR DESCRIPTION
@damonge recently pointed me to a clever method for computing Hankel transforms:

http://www.kurims.kyoto-u.ac.jp/~prims/pdf/41-4/41-4-40.pdf

The paper is kind of technical math and mostly involves proofs about the method converging and whatnot, but if you want to take a look, the upshot is found in equation 5.2.  The Hankel integral is approximated as a sum of function evaluations that get closer and closer to the zeros of the bessel function.  Since J_nu(x) is part of the integrand, this means that the items being summed get very close to zero very rapidly, so the series can be truncated after not very many terms.

It's worth pointing out that this algorithm is implemented in python in the [hankel](https://github.com/steven-murray/hankel) package, which is also quite nice, although it suffers slightly from not having an adaptive version that can automatically reduce h for you until achieving a specified accuracy.  Still, playing around with this package in python was very useful as I was implementing this in C++.

Anyway, we now have `galsim::math::hankel_trunc` and `galsim::math::hankel_inf` which compute Hankel transforms.  The latter is when the upper limit is infinity, which can use the Ogata algorithm.  The former is used when the upper limit is not infinity, because we are truncating the function.  The Ogata algorithm seems to assume some version of smoothness for the input function, so it often fails when I gave it a function with a step function down to zero at some r value.  So for truncated integrals, we need to continue to use the GKP integration.

But for (the usual case of) integration to infinity, the Ogata algorithm is both faster and more accurate.  We had found some cases of the GKP integral failing for certain r values in the VonKarman calculation (cf. #958, #1058) where we had to add explicit split points to the integral to get it to converge reliably.  This method doesn't need that.  It also seems to be more accurate in general, showing less numerical noise in the resulting Hankel function than the GKP integrals at the same nominal relative accuracy.

The one unit test change I had to make was in the Kolmogorov stepk estimate.  The numerical noise in the old values meant that it thought it got to the requested integral sooner than was correct, since a value scattered up a little prematurely.  I think the new test has a more accurate value, although still with many more digits than we actually care about or know correctly.

This speed up doesn't completely obviate the need or desire for #566, but it definitely lessens the importance of it.  Unless people are doing lots of sersics with n > 4 and are not quantizing the n values, I think it will be rare that the Sersic Hankel calculation will be the tall pole for many real life applications.  The time_sersic.py program times how long it takes to build every n from n=0.3 to n=6.2 in steps of 0.1.  On master it takes 39 seconds.  On this branch, it takes 9 seconds.