### PR TITLE
Switch the (x,y) order convention in LookupTable2D

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -73,6 +73,12 @@ API Changes
 - Deprecated ``galsim.integ.midpt``.  You should use ``np.trapz`` or
   ``galsim.trapz`` instead, which are almost equivalent, but slightly more
   accurate. (#1098)
+- Changed the convention for the ``f`` array passed to the `LookupTable2D`
+  constructor to be the transpose of what it was.  This is arguably a bug
+  fix, since the old convention was the opposite of every other array used
+  in GalSim that reprented (x,y) positions.  But if you have been using
+  `LookupTable2D`, you will need to add ``.T`` (or remove it) from the
+  ``f`` argument you are passing to the class. (#1103)
 
 
 Config Updates

--- a/galsim/lensing_ps.py
+++ b/galsim/lensing_ps.py
@@ -883,10 +883,10 @@ class PowerSpectrum(object):
             # get reduced shear (just discard magnification)
             g1_grid, g2_grid, _ = theoryToObserved(g1_grid, g2_grid, self.im_kappa.array)
 
-        lut_g1 = LookupTable2D(self.x_grid, self.y_grid, g1_grid.T,
+        lut_g1 = LookupTable2D(self.x_grid, self.y_grid, g1_grid,
                                edge_mode='wrap' if periodic else 'warn',
                                interpolant=self.interpolant)
-        lut_g2 = LookupTable2D(self.x_grid, self.y_grid, g2_grid.T,
+        lut_g2 = LookupTable2D(self.x_grid, self.y_grid, g2_grid,
                                edge_mode='wrap' if periodic else 'warn',
                                interpolant=self.interpolant)
 
@@ -954,7 +954,7 @@ class PowerSpectrum(object):
         """
         kappa_grid = self.im_kappa.array
 
-        lut_kappa = LookupTable2D(self.x_grid, self.y_grid, kappa_grid.T,
+        lut_kappa = LookupTable2D(self.x_grid, self.y_grid, kappa_grid,
                                   edge_mode='wrap' if periodic else 'warn',
                                   interpolant=self.interpolant)
 
@@ -1021,7 +1021,7 @@ class PowerSpectrum(object):
             the magnification, mu (either a scalar or a numpy array)
         """
         _, _, mu_grid = theoryToObserved(self.im_g1.array, self.im_g2.array, self.im_kappa.array)
-        lut_mu = LookupTable2D(self.x_grid, self.y_grid, mu_grid.T - 1,
+        lut_mu = LookupTable2D(self.x_grid, self.y_grid, mu_grid - 1,
                                edge_mode='wrap' if periodic else 'warn',
                                interpolant=self.interpolant)
 
@@ -1093,13 +1093,13 @@ class PowerSpectrum(object):
         g1_grid, g2_grid, mu_grid = theoryToObserved(
             self.im_g1.array, self.im_g2.array, self.im_kappa.array)
 
-        lut_g1 = LookupTable2D(self.x_grid, self.y_grid, g1_grid.T,
+        lut_g1 = LookupTable2D(self.x_grid, self.y_grid, g1_grid,
                                edge_mode='wrap' if periodic else 'warn',
                                interpolant=self.interpolant)
-        lut_g2 = LookupTable2D(self.x_grid, self.y_grid, g2_grid.T,
+        lut_g2 = LookupTable2D(self.x_grid, self.y_grid, g2_grid,
                                edge_mode='wrap' if periodic else 'warn',
                                interpolant=self.interpolant)
-        lut_mu = LookupTable2D(self.x_grid, self.y_grid, mu_grid.T-1,
+        lut_mu = LookupTable2D(self.x_grid, self.y_grid, mu_grid-1,
                                edge_mode='wrap' if periodic else 'warn',
                                interpolant=self.interpolant)
 

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -1304,7 +1304,7 @@ def structure_function(image):
     """
     from .table import LookupTable2D
     array = image.array
-    nx, ny = array.shape
+    ny, nx = array.shape
     scale = image.scale
 
     # The structure function can be derived from the correlation function B(r) as:

--- a/src/Table.cpp
+++ b/src/Table.cpp
@@ -1217,7 +1217,6 @@ namespace galsim {
         }
 
     private:
-        const int _nx;
         const Interpolant* _gsinterp;
 
         void _clearCache() const {

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -1397,7 +1397,7 @@ def test_table_screen():
         u, v = np.meshgrid(u1, u1)
         wf = Zscreen.wavefront(u, v)
 
-        table = galsim.LookupTable2D(u1, u1, wf.T, interpolant='spline')
+        table = galsim.LookupTable2D(u1, u1, wf, interpolant='spline')
         tscreen = galsim.TableScreen(table)
 
         rr = np.empty(1000)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -365,14 +365,14 @@ def test_table_GSInterp():
 
     x = np.linspace(0.1, 3.3, 25)
     y = np.arange(20) # Need something big enough to avoid having the interpolant fall off the edge
-    yy, xx = np.meshgrid(y, x)
+    xx, yy = np.meshgrid(x, y)
 
     interpolants = ['lanczos3', 'lanczos3F', 'lanczos7', 'sinc', 'quintic']
 
     for interpolant in interpolants:
         z = f(xx)
 
-        tab = galsim.LookupTable(x, z[:,0], interpolant=interpolant)
+        tab = galsim.LookupTable(x, z[0,:], interpolant=interpolant)
         do_pickle(tab)
 
         # Use InterpolatedImage to validate
@@ -381,7 +381,7 @@ def test_table_GSInterp():
             0, 0,
             (max(y) - min(y))/(len(y)-1),
         )
-        img = galsim.Image(z.T, wcs=wcs)
+        img = galsim.Image(z, wcs=wcs)
         ii = galsim.InterpolatedImage(
             img,
             use_true_center=True,
@@ -403,7 +403,7 @@ def test_table_GSInterp():
             atol=1e-10, rtol=0
         )
 
-        tab2 = galsim._LookupTable(x, z[:,0], interpolant=interpolant)
+        tab2 = galsim._LookupTable(x, z[0,:], interpolant=interpolant)
         assert tab2 == tab
 
 
@@ -418,7 +418,7 @@ def test_table2d():
 
     x = np.linspace(0.1, 3.3, 25)
     y = np.linspace(0.2, 10.4, 75)
-    yy, xx = np.meshgrid(y, x)  # Note the ordering of both input and output here!
+    xx, yy = np.meshgrid(x, y)
     z = f(xx, yy)
 
     tab2d = galsim.LookupTable2D(x, y, z)
@@ -432,17 +432,17 @@ def test_table2d():
 
     newx = np.linspace(0.2, 3.1, 45)
     newy = np.linspace(0.3, 10.1, 85)
-    newyy, newxx = np.meshgrid(newy, newx)
+    newxx, newyy = np.meshgrid(newx, newy)
 
     # Compare different ways of evaluating Table2D
     ref = tab2d(newxx, newyy)
     np.testing.assert_array_almost_equal(ref, tab2d(newx, newy, grid=True))
     np.testing.assert_array_almost_equal(ref, np.array([[tab2d(x0, y0)
-                                                         for y0 in newy]
-                                                        for x0 in newx]))
+                                                         for x0 in newx]
+                                                        for y0 in newy]))
 
-    scitab2d = interp2d(x, y, np.transpose(z))
-    np.testing.assert_array_almost_equal(ref, np.transpose(scitab2d(newx, newy)))
+    scitab2d = interp2d(x, y, z)
+    np.testing.assert_array_almost_equal(ref, scitab2d(newx, newy))
 
     # Try using linear GSInterp
     tab2d2 = galsim.LookupTable2D(x, y, z, interpolant=galsim.Linear())
@@ -462,16 +462,16 @@ def test_table2d():
     # Test non-equally-spaced table.
     x = np.delete(x, 10)
     y = np.delete(y, 10)
-    yy, xx = np.meshgrid(y, x)
+    xx, yy = np.meshgrid(x, y)
     z = f(xx, yy)
     tab2d = galsim.LookupTable2D(x, y, z)
     ref = tab2d(newxx, newyy)
     np.testing.assert_array_almost_equal(ref, tab2d(newx, newy, grid=True))
     np.testing.assert_array_almost_equal(ref, np.array([[tab2d(x0, y0)
-                                                         for y0 in newy]
-                                                        for x0 in newx]))
-    scitab2d = interp2d(x, y, np.transpose(z))
-    np.testing.assert_array_almost_equal(ref, np.transpose(scitab2d(newx, newy)))
+                                                         for x0 in newx]
+                                                        for y0 in newy]))
+    scitab2d = interp2d(x, y, z)
+    np.testing.assert_array_almost_equal(ref, scitab2d(newx, newy))
 
     # Using a galsim.Interpolant should raise an exception if x/y are not equal spaced.
     with assert_raises(galsim.GalSimIncompatibleValuesError):
@@ -487,8 +487,8 @@ def test_table2d():
 
     np.testing.assert_array_almost_equal(f(newxx, newyy), tab2d(newxx, newyy))
     np.testing.assert_array_almost_equal(f(newxx, newyy), np.array([[tab2d(x0, y0)
-                                                                     for y0 in newy]
-                                                                    for x0 in newx]))
+                                                                     for x0 in newx]
+                                                                    for y0 in newy]))
 
     # Test edge exception
     with assert_raises(ValueError):
@@ -640,14 +640,14 @@ def test_table2d_gradient():
 
     x = np.linspace(0.1, 3.3, 250)
     y = np.linspace(0.2, 10.4, 750)
-    yy, xx = np.meshgrid(y, x)  # Note the ordering of both input and output here!
+    xx, yy = np.meshgrid(x, y)
     z = f(xx, yy)
 
     tab2d = galsim.LookupTable2D(x, y, z)
 
     newx = np.linspace(0.2, 3.1, 45)
     newy = np.linspace(0.3, 10.1, 85)
-    newyy, newxx = np.meshgrid(newy, newx)
+    newxx, newyy = np.meshgrid(newx, newy)
 
     # Check single value functionality.
     x1,y1 = 1.1, 4.9
@@ -823,7 +823,7 @@ def test_table2d_cubic():
 
     x = np.linspace(0.1, 3.3, 250)
     y = np.linspace(0.2, 10.4, 750)
-    yy, xx = np.meshgrid(y, x)  # Note the ordering of both input and output here!
+    xx, yy = np.meshgrid(x, y)
 
     for f, dfdx, dfdy in zip(fs, dfdxs, dfdys):
         z = f(xx, yy)
@@ -841,7 +841,7 @@ def test_table2d_cubic():
         # Check vectorized output
         newx = np.linspace(0.2, 3.1, 45)
         newy = np.linspace(0.3, 10.1, 85)
-        newyy, newxx = np.meshgrid(newy, newx)
+        newxx, newyy = np.meshgrid(newx, newy)
 
         np.testing.assert_allclose(tab2d(newxx, newyy), f(newxx, newyy), atol=1e-11, rtol=0)
         ref_dfdx = dfdx(newxx, newyy)
@@ -893,7 +893,7 @@ def test_table2d_cubic():
         # Check vectorized output
         newx = np.linspace(0.2, 3.1, 45)
         newy = np.linspace(0.3, 10.1, 85)
-        newyy, newxx = np.meshgrid(newy, newx)
+        newxx, newyy = np.meshgrid(newx, newy)
 
         np.testing.assert_allclose(tab2d(newxx, newyy), f(newxx, newyy), atol=1e-10, rtol=0)
         ref_dfdx = dfdx(newxx, newyy)
@@ -910,7 +910,7 @@ def test_table2d_GSInterp():
 
     x = np.linspace(0.1, 3.3, 25)
     y = np.linspace(0.2, 10.4, 75)
-    yy, xx = np.meshgrid(y, x)  # Note the ordering of both input and output here!
+    xx, yy = np.meshgrid(x, y)
 
     interpolants = ['lanczos3', 'lanczos3F', 'lanczos7', 'sinc', 'quintic']
 
@@ -927,7 +927,7 @@ def test_table2d_GSInterp():
             0, 0,
             (max(y) - min(y))/(len(y)-1),
         )
-        img = galsim.Image(z.T, wcs=wcs)
+        img = galsim.Image(z, wcs=wcs)
         ii = galsim.InterpolatedImage(
             img,
             use_true_center=True,
@@ -944,7 +944,7 @@ def test_table2d_GSInterp():
         # Check vectorized output
         newx = np.linspace(0.2, 3.1, 15)
         newy = np.linspace(0.3, 10.1, 25)
-        newyy, newxx = np.meshgrid(newy, newx)
+        newxx, newyy = np.meshgrid(newx, newy)
         np.testing.assert_allclose(
             tab2d(newxx, newyy).ravel(),
             np.array([ii.xValue(x_, y_)


### PR DESCRIPTION
@jmeyers314 Here is what it would look like to switch the convention of LookupTable2D.  I think this is a net positive, since most of the changes to unit tests and such were to get rid of transposes that were used in various places to account for the reverse convention being used here.

However, there are two down-sides of which I'm aware:
1. This is an API change.  I called it out in the CHANGELOG, but this isn't one that would be easy to go through a deprecation stage.  I think it's minor enough that it doesn't require a major version number, but we could go to 3.0 if you think that would be more appropriate.  I'm fine either way.
2. The internal calculations in `T2DGSInterpolant::interp` are now a bit slower.  Reversing the storage order means that the sums now cut across the rows rather than go along them.  If we decide we want to do this, I may try out a couple optimizations to see if I can recover any of that time.  But also, I don't think this calculation is very often a tall pole, so it might not really matter.

This PR is set to merge into your branch, so you can evaluate this on those terms.  It includes removing the suspect `.T` that I called out.