### PR TITLE
Improve the accuracy of Kolmogorov stepk for very low folding_threshold

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -161,3 +161,5 @@ Bug Fixes
 - Fixed bug in RandomKnots when multiplied by an SED. (#1064)
 - Fixed bug that galsim.fits.writeMulti didn't properly write the header
   information in each hdu. (#1091)
+- Improved the accuracy of stepk for Kolmogorov profiles, especially when
+  folding_threshold is very small. (#1110)

--- a/src/SBKolmogorov.cpp
+++ b/src/SBKolmogorov.cpp
@@ -401,16 +401,21 @@ namespace galsim {
         // 2pi F1 r1^n / (n-2) f_t = R^(n-2)
         double r1 = _radial.argMax();
         double F1 = _radial.lookup(r1);
+#ifdef DEBUGLOGGING
         double r2 = r1 * (1-dlogr);
         double F2 = _radial.lookup(r2);
         dbg<<"r1,F1 = "<<r1<<','<<F1<<std::endl;
         dbg<<"r2,F2 = "<<r2<<','<<F2<<std::endl;
         // power law index = dlog(F)/dlog(r)
-        double n = -(std::log(F2)-std::log(F1)) / (std::log(r2)-std::log(r1));
-        // For high folding_threshold, n can come out too low (e.g. < 2), which is bad.
-        // We know the right answer is close to 3.67, so just use that if n < 3.6.
-        if (n < 3.6) n = std::max(n, 3.67);
-        dbg<<"n = "<<n<<std::endl;
+        double n_emp = -(std::log(F2)-std::log(F1)) / (std::log(r2)-std::log(r1));
+        dbg<<"Empirical n = "<<n_emp<<std::endl;
+#endif
+        // Emprically n is very close to 11/3.  This is probably exact, since it's the kind of
+        // fraction that probably comes out of the Komogorov turbulence.  But I (MJ) haven't
+        // figured out how to prove this.
+        // Regardless, let's just always use this for the purpose of estimating stepk,
+        // since any deviations from the exactly correct answer don't matter much.
+        double n = 11./3.;
         double R = fast_pow(2.*M_PI*F1*fast_pow(r1,n)/((n-2)*gsparams->folding_threshold),
                             1./(n-2));
         dbg<<"R = "<<R<<std::endl;

--- a/src/SBKolmogorov.cpp
+++ b/src/SBKolmogorov.cpp
@@ -407,6 +407,9 @@ namespace galsim {
         dbg<<"r2,F2 = "<<r2<<','<<F2<<std::endl;
         // power law index = dlog(F)/dlog(r)
         double n = -(std::log(F2)-std::log(F1)) / (std::log(r2)-std::log(r1));
+        // For high folding_threshold, n can come out too low (e.g. < 2), which is bad.
+        // We know the right answer is close to 3.67, so just use that if n < 3.6.
+        if (n < 3.6) n = std::max(n, 3.67);
         dbg<<"n = "<<n<<std::endl;
         double R = fast_pow(2.*M_PI*F1*fast_pow(r1,n)/((n-2)*gsparams->folding_threshold),
                             1./(n-2));

--- a/src/SBKolmogorov.cpp
+++ b/src/SBKolmogorov.cpp
@@ -373,7 +373,7 @@ namespace galsim {
         xdbg<<"dlogr = "<<dlogr<<std::endl;
 
         // Continue until the missing flux is less than shoot_accuracy.
-        double thresh = gsparams->shoot_accuracy / (2.*M_PI*dlogr);
+        double thresh = gsparams->shoot_accuracy / (2.*M_PI);
         xdbg<<"thresh  = "<<thresh<<std::endl;
         KolmXValue xval_func(*gsparams);
 

--- a/src/SBKolmogorov.cpp
+++ b/src/SBKolmogorov.cpp
@@ -385,25 +385,31 @@ namespace galsim {
             dbg<<"f("<<r<<") = "<<val<<std::endl;
             _radial.addEntry(r,val);
 
-            // At high r, the profile is well approximated by a power law, F ~ r^-3.68
-            // The integral of the missing flux out to infinity is int_r^inf F(r) r dr = F r^2/1.68
-            xdbg<<"F r^2/1.68 = "<<val*r*r/1.68<<"  thresh = "<<thresh<<std::endl;
-            if (val * r * r / 1.68 < thresh) break;
+            // At high r, the profile is well approximated by a power law, F ~ r^-3.67
+            // The integral of the missing flux out to infinity is int_r^inf F(r) r dr = F r^2/1.67
+            xdbg<<"F r^2/1.67 = "<<val*r*r/1.67<<"  thresh = "<<thresh<<std::endl;
+            if (val * r * r / 1.67 < thresh) break;
         }
         _radial.finalize();
         dbg<<"Done loop to build radial function.\n";
 
-        // The large r behavior of F(r) is well approximated by a power law, F ~ r^-3.68
+        // The large r behavior of F(r) is well approximated by a power law, F ~ r^-3.67
         // This affords an easier calculation of R for stepk than numerically accumulating
         // the integral.
-        // F(r) = F1 (r/r1)^-3.68
+        // F(r) = F1 (r/r1)^-n
         // int_r^inf F(r) 2pi r dr = folding_threshold
-        // 2pi F1 r1^3.68 / 1.68 f_t = R^1.68
+        // 2pi F1 r1^n / (n-2) f_t = R^(n-2)
         double r1 = _radial.argMax();
         double F1 = _radial.lookup(r1);
+        double r2 = r1 * (1-dlogr);
+        double F2 = _radial.lookup(r2);
         dbg<<"r1,F1 = "<<r1<<','<<F1<<std::endl;
-        double R = fast_pow(2.*M_PI*F1*fast_pow(r1,3.68)/(1.68*gsparams->folding_threshold),
-                            1./1.68);
+        dbg<<"r2,F2 = "<<r2<<','<<F2<<std::endl;
+        // power law index = dlog(F)/dlog(r)
+        double n = -(std::log(F2)-std::log(F1)) / (std::log(r2)-std::log(r1));
+        dbg<<"n = "<<n<<std::endl;
+        double R = fast_pow(2.*M_PI*F1*fast_pow(r1,n)/((n-2)*gsparams->folding_threshold),
+                            1./(n-2));
         dbg<<"R = "<<R<<std::endl;
 
         // Make sure it is at least 5 hlr

--- a/src/SBSecondKick.cpp
+++ b/src/SBSecondKick.cpp
@@ -200,7 +200,7 @@ namespace galsim {
         for (k=dk; k<1.; k+=dk) {
             double val = structureFunction(k);
             xdbg<<"sf("<<k<<") "<<val<<std::endl;
-            double kv = fmath::exp(-0.5*val)-_delta;
+            double kv = fmath::expd(-0.5*val)-_delta;
             dbg<<"kv("<<k<<") "<<kv<<std::endl;
             _kvLUT.addEntry(k, kv);
             if (val > limit) { k += dk; break; }
@@ -211,7 +211,7 @@ namespace galsim {
         for (; k<_maxk; k*=expdlogk) {
             double val = structureFunction(k);
             xdbg<<"sf("<<k<<") "<<val<<std::endl;
-            double kv = fmath::exp(-0.5*val)-_delta;
+            double kv = fmath::expd(-0.5*val)-_delta;
             dbg<<"kv("<<k<<") "<<kv<<std::endl;
             _kvLUT.addEntry(k, kv);
             if (std::abs(kv) < _gsparams->kvalue_accuracy) {

--- a/src/SBVonKarman.cpp
+++ b/src/SBVonKarman.cpp
@@ -305,16 +305,22 @@ namespace galsim {
         // 2pi F1 r1^n / (n-2) f_t = R^(n-2)
         double r1 = _radial.argMax();
         double F1 = _radial.lookup(r1);
+#ifdef DEBUGLOGGING
         double r2 = r1 * (1-dlogr);
         double F2 = _radial.lookup(r2);
         dbg<<"r1,F1 = "<<r1<<','<<F1<<std::endl;
         dbg<<"r2,F2 = "<<r2<<','<<F2<<std::endl;
         // power law index = dlog(F)/dlog(r)
-        double n = -(std::log(F2)-std::log(F1)) / (std::log(r2)-std::log(r1));
-        // For high folding_threshold, n can come out too low (e.g. < 2), which is bad.
-        // We know the right answer when L0=inf is close to 3.67, so just use that if n < 3.
-        if (n < 3.) n = std::max(n, 3.67);
-        dbg<<"n = "<<n<<std::endl;
+        double n_emp = -(std::log(F2)-std::log(F1)) / (std::log(r2)-std::log(r1));
+        dbg<<"Empirical n = "<<n_emp<<std::endl;
+#endif
+        // Emprically n is very close to 11/3, independent of L0.  This is probably exact
+        // for L0 -> infinity (i.e. -> Kolmogorov), and there is probably some good reason
+        // that L0 doesn't affect this for reasonable values of L0/r0.  But I (MJ) haven't
+        // actually proven this to be true.
+        // Regardless, let's just always use this for the purpose of estimating stepk,
+        // since any deviations from the exactly correct answer don't matter much.
+        double n = 11./3.;
         double R = fast_pow(2.*M_PI*F1*fast_pow(r1,n)/((n-2)*_gsparams->folding_threshold),
                             1./(n-2));
         dbg<<"R = "<<R<<" arcsec\n";

--- a/src/SBVonKarman.cpp
+++ b/src/SBVonKarman.cpp
@@ -311,6 +311,9 @@ namespace galsim {
         dbg<<"r2,F2 = "<<r2<<','<<F2<<std::endl;
         // power law index = dlog(F)/dlog(r)
         double n = -(std::log(F2)-std::log(F1)) / (std::log(r2)-std::log(r1));
+        // For high folding_threshold, n can come out too low (e.g. < 2), which is bad.
+        // We know the right answer when L0=inf is close to 3.67, so just use that if n < 3.
+        if (n < 3.) n = std::max(n, 3.67);
         dbg<<"n = "<<n<<std::endl;
         double R = fast_pow(2.*M_PI*F1*fast_pow(r1,n)/((n-2)*_gsparams->folding_threshold),
                             1./(n-2));

--- a/tests/test_kolmogorov.py
+++ b/tests/test_kolmogorov.py
@@ -137,7 +137,7 @@ def test_kolmogorov_properties():
     np.testing.assert_equal(psf.centroid, cen)
     # Check Fourier properties
     np.testing.assert_almost_equal(psf.maxk, 8.644067599028375, 9)
-    np.testing.assert_almost_equal(psf.stepk, 0.3750302010950857, 9)
+    np.testing.assert_almost_equal(psf.stepk, 0.37671691124595064, 9)
     np.testing.assert_almost_equal(psf.kValue(cen), test_flux+0j)
     np.testing.assert_almost_equal(psf.lam_over_r0, lor)
     np.testing.assert_almost_equal(psf.half_light_radius, lor * 0.5548101137)
@@ -389,7 +389,7 @@ def test_low_folding_threshold():
     # Note: Older versions gave 574 for this choice, which was actually too small due to
     # numerical rounding errors. Then it was wrongly zero for a while (only on main, not on
     # a release branch), and now I think this is correct.
-    assert image_size == 6660
+    assert image_size == 6776
 
     # I think going forward, 1.e-6 is much too small a folding_threshold for the desired
     # effect Jim wants in imSim.  I think 1.e-4 is more appropriate to get a stamp that will
@@ -399,7 +399,7 @@ def test_low_folding_threshold():
     psf = galsim.Kolmogorov(fwhm=fwhm, gsparams=gsparams)
     image_size = psf.getGoodImageSize(pixel_scale)
     print('ft = 1.e-4: psf.getGoodImageSize:', image_size)
-    assert image_size == 430
+    assert image_size == 432
 
 
 if __name__ == "__main__":

--- a/tests/test_kolmogorov.py
+++ b/tests/test_kolmogorov.py
@@ -136,8 +136,8 @@ def test_kolmogorov_properties():
     cen = galsim.PositionD(0, 0)
     np.testing.assert_equal(psf.centroid, cen)
     # Check Fourier properties
-    np.testing.assert_almost_equal(psf.maxk, 8.644067599028375, 9)
-    np.testing.assert_almost_equal(psf.stepk, 0.379103528681262, 9)
+    np.testing.assert_almost_equal(psf.maxk, 8.644067599028375, 5)
+    np.testing.assert_almost_equal(psf.stepk, 0.379103528681262, 5)
     np.testing.assert_almost_equal(psf.kValue(cen), test_flux+0j)
     np.testing.assert_almost_equal(psf.lam_over_r0, lor)
     np.testing.assert_almost_equal(psf.half_light_radius, lor * 0.5548101137)

--- a/tests/test_kolmogorov.py
+++ b/tests/test_kolmogorov.py
@@ -137,7 +137,7 @@ def test_kolmogorov_properties():
     np.testing.assert_equal(psf.centroid, cen)
     # Check Fourier properties
     np.testing.assert_almost_equal(psf.maxk, 8.644067599028375, 9)
-    np.testing.assert_almost_equal(psf.stepk, 0.37671691124595064, 9)
+    np.testing.assert_almost_equal(psf.stepk, 0.379103528681262, 9)
     np.testing.assert_almost_equal(psf.kValue(cen), test_flux+0j)
     np.testing.assert_almost_equal(psf.lam_over_r0, lor)
     np.testing.assert_almost_equal(psf.half_light_radius, lor * 0.5548101137)
@@ -389,7 +389,7 @@ def test_low_folding_threshold():
     # Note: Older versions gave 574 for this choice, which was actually too small due to
     # numerical rounding errors. Then it was wrongly zero for a while (only on main, not on
     # a release branch), and now I think this is correct.
-    assert image_size == 6776
+    assert image_size == 6862
 
     # I think going forward, 1.e-6 is much too small a folding_threshold for the desired
     # effect Jim wants in imSim.  I think 1.e-4 is more appropriate to get a stamp that will
@@ -399,7 +399,7 @@ def test_low_folding_threshold():
     psf = galsim.Kolmogorov(fwhm=fwhm, gsparams=gsparams)
     image_size = psf.getGoodImageSize(pixel_scale)
     print('ft = 1.e-4: psf.getGoodImageSize:', image_size)
-    assert image_size == 432
+    assert image_size == 434
 
 
 if __name__ == "__main__":

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -864,7 +864,7 @@ def test_geometric_shoot():
         opt_psf = galsim.OpticalPSF(diam=diam, lam=lam, aberrations=aberrations,
                                     geometric_shooting=True)
         # Use really good seeing, so that the optics contribution actually matters.
-        atm_psf = galsim.Kolmogorov(fwhm=0.4)
+        atm_psf = galsim.Kolmogorov(fwhm=0.3)
 
         psf = galsim.Convolve(opt_psf, atm_psf)
         u1 = u.duplicate()

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -534,7 +534,7 @@ def test_stepk_maxk():
     print('goodImageSize = ',psf.getGoodImageSize(0.2))
     print('t2 = ',t2-t1)
 
-    np.testing.assert_allclose(stepk1, stepk2, rtol=0.05)
+    np.testing.assert_allclose(stepk1, stepk2, rtol=0.06)
     np.testing.assert_allclose(maxk1, maxk2, rtol=0.05)
 
     # Also make sure that prepareDraw wasn't called to calculate the first one.

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -534,7 +534,7 @@ def test_stepk_maxk():
     print('goodImageSize = ',psf.getGoodImageSize(0.2))
     print('t2 = ',t2-t1)
 
-    np.testing.assert_allclose(stepk1, stepk2, rtol=0.06)
+    np.testing.assert_allclose(stepk1, stepk2, rtol=0.07)
     np.testing.assert_allclose(maxk1, maxk2, rtol=0.05)
 
     # Also make sure that prepareDraw wasn't called to calculate the first one.

--- a/tests/test_vonkarman.py
+++ b/tests/test_vonkarman.py
@@ -365,6 +365,15 @@ def test_low_folding_threshold():
     print('ft = 1.e-6: psf.getGoodImageSize:', image_size)
     assert image_size == 600
 
+    # Check an extremely small L0
+    kwargs['L0'] = 1.0
+    with assert_warns(galsim.GalSimWarning):
+        # This low an L0 has a non-negligible delta function, hence a warning.
+        psf = galsim.VonKarman(gsparams=gsparams, **kwargs)
+    image_size = psf.getGoodImageSize(pixel_scale)
+    print('L0=1.0, ft = 1.e-6: psf.getGoodImageSize:', image_size)
+    assert image_size == 600
+
 
 if __name__ == "__main__":
     from argparse import ArgumentParser

--- a/tests/test_vonkarman.py
+++ b/tests/test_vonkarman.py
@@ -345,6 +345,26 @@ def test_vk_force_stepk():
     assert vk4.flux == 11.0
     assert vk3.force_stepk == vk4.force_stepk
 
+@timer
+def test_low_folding_threshold():
+    """Test VonKarman with a very low folding_threshold.
+    """
+    folding_threshold = 1e-4
+    pixel_scale = 0.2
+    kwargs = {'lam':500, 'r0':0.2, 'L0':25.0, 'flux':2.2}
+    gsparams = galsim.GSParams(folding_threshold=folding_threshold)
+    psf = galsim.VonKarman(gsparams=gsparams, **kwargs)
+    image_size = psf.getGoodImageSize(pixel_scale)
+    print('ft = 1.e-4: psf.getGoodImageSize:', image_size)
+    assert image_size == 298
+
+    folding_threshold = 1e-6
+    gsparams = galsim.GSParams(folding_threshold=folding_threshold)
+    psf = galsim.VonKarman(gsparams=gsparams, **kwargs)
+    image_size = psf.getGoodImageSize(pixel_scale)
+    print('ft = 1.e-6: psf.getGoodImageSize:', image_size)
+    assert image_size == 600
+
 
 if __name__ == "__main__":
     from argparse import ArgumentParser


### PR DESCRIPTION
@jchiang87 noticed a bug introduced in commit 56003a938963ba4bef875c2b34fadeb41fb25bf7 (part of PR #1099) where if folding_threshold was too small, R would never be set and stepk was way too large.  

This was a straight bug in that commit.  But in investigating it, I realized that the old implementation of stepk for Kolmogorov was also not very accurate, especially for very low folding_threshold.  The problem is that the accumulation of the integral is just a crude rectangular rule integral, which isn't accurate enough to tell precisely when the integral reaches 0.999999 (for instance).  

So here, I use the high-r asymptotic power law form for the Kolmogorov profile and use that directly to estimate what radius encloses (1-folding_threshold) of the flux, by analytically doing the integral from R to infinity, which gets more accurate for very small folding_threshold, and is plenty accurate for the default value of 5e-3.

The upshot of this is that the "good image size" for folding_threshold=1.e-6, which imSim was using, got a lot larger than the previous version 2.2 values.  I'm convinced this is actually the right answer now, but it means that the imSim function that was doing this probably needs to use a larger folding_threshold.  I suspect 1.e-4 is actually closer to what we should be using.  It looks like this produces fairly reasonable image sizes on this branch.

Note: I applied the same change to VonKarman too, which also seems to be well approximated by a power law, at least for reasonable values of L0.  I didn't investigate too hard whether things changed at extreme values of L0.