### PR TITLE
Use the fork context explicitly in some places where spawn fails

### DIFF
--- a/galsim/config/extra.py
+++ b/galsim/config/extra.py
@@ -20,7 +20,7 @@ import os
 import logging
 import inspect
 
-from .util import LoggerWrapper, SetDefaultExt, RetryIO
+from .util import LoggerWrapper, SetDefaultExt, RetryIO, SafeManager
 from .value import ParseValue
 from ..utilities import ensure_dir
 from ..errors import GalSimConfigValueError, GalSimConfigError
@@ -61,8 +61,8 @@ def SetupExtraOutput(config, logger=None):
             ParseValue(config['image'], 'nproc', config, int)[0] != 1 )
 
     if use_manager and 'output_manager' not in config:
-        from multiprocessing.managers import BaseManager, ListProxy, DictProxy
-        class OutputManager(BaseManager): pass
+        from multiprocessing.managers import ListProxy, DictProxy
+        class OutputManager(SafeManager): pass
 
         # We'll use a list and a dict as work space to do the extra output processing.
         OutputManager.register('dict', dict, DictProxy)

--- a/galsim/config/input.py
+++ b/galsim/config/input.py
@@ -23,6 +23,7 @@ import logging
 
 from .value import RegisterValueType
 from .util import LoggerWrapper, RemoveCurrent, GetRNG
+from .util import SafeManager
 from .value import ParseValue, CheckAllParams, GetAllParams, SetDefaultIndex, _GetBoolValue
 from ..errors import GalSimConfigError, GalSimConfigValueError
 from ..catalog import Catalog, Dict
@@ -104,8 +105,7 @@ def ProcessInput(config, logger=None, file_scope_only=False, safe_only=False):
                    ParseValue(config['output'], 'nproc', config, int)[0] != 1) ) )
 
         if use_manager and '_input_manager' not in config:
-            from multiprocessing.managers import BaseManager
-            class InputManager(BaseManager): pass
+            class InputManager(SafeManager): pass
 
             # Register each input field with the InputManager class
             for key in all_keys:

--- a/galsim/config/util.py
+++ b/galsim/config/util.py
@@ -236,6 +236,8 @@ class SafeManager(BaseManager):
         if sys.version_info >= (3,8):
             from multiprocessing import get_context
             super(SafeManager, self).__init__(ctx=get_context('fork'))
+        else:
+            super(SafeManager, self).__init__()
 
 
 def GetLoggerProxy(logger):

--- a/galsim/config/util.py
+++ b/galsim/config/util.py
@@ -18,7 +18,9 @@
 
 import logging
 import copy
+import sys
 from collections import OrderedDict
+from multiprocessing.managers import BaseManager
 
 from ..utilities import SimpleGenerator
 from ..random import BaseDeviate
@@ -221,6 +223,21 @@ def CopyConfig(config):
 
     return config1
 
+class SafeManager(BaseManager):
+    """There are a few places we need a Manager object.  This one uses the 'fork' context,
+    rather than whatever the default is on your system (which may be fork or may be spawn).
+
+    Starting in python 3.8, the spawn context started becoming more popular.  It's supposed to
+    be safer, but it wants to pickle a lot of things that aren't picklable, so it doesn't work.
+    Using this as the base class instead, should work.  And doing it it one place means that we
+    only have one place to change this is there is a different strategy that works better.
+    """
+    def __init__(self):
+        if sys.version_info >= (3,8):
+            from multiprocessing import get_context
+            super(SafeManager, self).__init__(ctx=get_context('fork'))
+
+
 def GetLoggerProxy(logger):
     """Make a proxy for the given logger that can be passed into multiprocessing Processes
     and used safely.
@@ -231,9 +248,8 @@ def GetLoggerProxy(logger):
     Returns:
         a proxy for the given logger
     """
-    from multiprocessing.managers import BaseManager
     if logger:
-        class LoggerManager(BaseManager): pass
+        class LoggerManager(SafeManager): pass
         logger_generator = SimpleGenerator(logger)
         LoggerManager.register('logger', callable = logger_generator)
         logger_manager = LoggerManager()
@@ -706,8 +722,14 @@ def MultiProcess(nproc, config, job_func, tasks, item, logger=None,
     if nproc > 1:
         logger.warning("Using %d processes for %s processing",nproc,item)
 
-        from multiprocessing import Process, Queue, current_process
-        from multiprocessing.managers import BaseManager
+        from multiprocessing import current_process
+        if sys.version_info < (3,8):
+            from multiprocessing import Process, Queue
+        else:
+            from multiprocessing import get_context
+            ctx = get_context('fork')
+            Process = ctx.Process
+            Queue = ctx.Queue
 
         # Send the tasks to the task_queue.
         task_queue = Queue()

--- a/galsim/config/util.py
+++ b/galsim/config/util.py
@@ -233,7 +233,7 @@ class SafeManager(BaseManager):
     only have one place to change this is there is a different strategy that works better.
     """
     def __init__(self):
-        if sys.version_info >= (3,8):
+        if sys.version_info >= (3,0):
             from multiprocessing import get_context
             super(SafeManager, self).__init__(ctx=get_context('fork'))
         else:
@@ -725,7 +725,7 @@ def MultiProcess(nproc, config, job_func, tasks, item, logger=None,
         logger.warning("Using %d processes for %s processing",nproc,item)
 
         from multiprocessing import current_process
-        if sys.version_info < (3,8):
+        if sys.version_info < (3,0):
             from multiprocessing import Process, Queue
         else:
             from multiprocessing import get_context

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -1581,7 +1581,7 @@ def test_multiprocess():
     """Test that the same random numbers are generated in single-process and multi-process modes.
     """
     from multiprocessing import current_process
-    if sys.version_info < (3,8):
+    if sys.version_info < (3,0):
         from multiprocessing import Process, Queue
     else:
         from multiprocessing import get_context

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -1580,7 +1580,14 @@ def test_distLookupTable():
 def test_multiprocess():
     """Test that the same random numbers are generated in single-process and multi-process modes.
     """
-    from multiprocessing import Process, Queue, current_process
+    from multiprocessing import current_process
+    if sys.version_info < (3,8):
+        from multiprocessing import Process, Queue
+    else:
+        from multiprocessing import get_context
+        ctx = get_context('fork')
+        Process = ctx.Process
+        Queue = ctx.Queue
 
     def generate_list(seed):
         """Given a particular seed value, generate a list of random numbers.


### PR DESCRIPTION
This addresses issue #1112.  @erykoff pointed out that some uses of multiprocessing, especially in the config layer, fails when using a 'spawn' context.  Some versions of Python 3.8 (notable MacOS) have made that the default, so they fail.  Linux still seems to use 'fork' as the default, so the CI tests of 3.8 have been passing.

Anyway, it's probably best to be explicit about our use of 'fork' where necessary, so I added context stuff in various places to use 'fork' where it was necessary for the unit tests in python 3.8 on my Mac to pass.

This PR is directed at the releases/2.2 branch.  This is in support of issue #1115 to make a 2.2.5 release that works in Python 3.8.  I'll cherry pick it over to main after merging.