### PR TITLE
Add option to get warning about WCS defaulting to PixelScale (#1120)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -138,6 +138,9 @@ New Features
 - Added galsim.bessel.jv_root function. (#1099)
 - Added support for TPV WCS files with order > 3. (#1101)
 - Added galsim.UserScreen for arbitrary user-supplied phase screens (#1102)
+- Added option to emit WCS warnings when reading a file via `galsim.fits.read`
+  e.g. if the WCS defaulted to a PixelScale, or it reverted to an approximate
+  AffineTransformation rather than the correct WCS. (#1120)
 - Added area and exptime parameters to COSMOSCatalog constructor to make it
   easier to rescale the fluxes to a different telescope than HST. (#1121)
 

--- a/galsim/fitswcs.py
+++ b/galsim/fitswcs.py
@@ -1704,11 +1704,11 @@ def FitsWCS(file_name=None, dir=None, hdu=None, header=None, compression='auto',
                           text file with the header information (like the .head file output from
                           SCamp).  In this case you should set ``text_file = True`` to tell GalSim
                           to parse the file this way.  [default: False]
-        suppress_warning: Should a warning be emitted if none of the real FITS WCS classes
-                          are able to successfully read the file, and we have to reset to
-                          an `AffineTransform` instead?  [default: False]
-                          (Note: this is set to True when this function is implicitly called from
-                          one of the galsim.fits.read* functions.)
+        suppress_warning: Whether to suppress a warning that none of the real FITS WCS classes
+                          are able to successfully read the file, and we have defaulted to an
+                          `AffineTransform` instead?  [default: False]
+                          (Note: this is (by default) set to True when this function is implicitly
+                          called from one of the galsim.fits.read* functions.)
     """
     from .wcs import AffineTransform, PixelScale, OffsetWCS
 
@@ -1727,7 +1727,13 @@ def FitsWCS(file_name=None, dir=None, hdu=None, header=None, compression='auto',
     if not isinstance(header, fits.FitsHeader):
         header = fits.FitsHeader(header)
 
+    if 'CTYPE1' not in header and 'CDELT1' not in header:
+        if not suppress_warning:
+            galsim_warn("No WCS information found in %r. Defaulting to PixelScale(1.0)"%(file_name))
+        return PixelScale(1.0)
+
     # For linear WCS specifications, AffineTransformation should work.
+    # Note: Most files will have CTYPE1,2, but old style with only CDELT1,2 sometimes omits it.
     if header.get('CTYPE1', 'LINEAR') == 'LINEAR':
         wcs = AffineTransform._readHeader(header)
         # Convert to PixelScale if possible.

--- a/galsim/fitswcs.py
+++ b/galsim/fitswcs.py
@@ -1704,9 +1704,9 @@ def FitsWCS(file_name=None, dir=None, hdu=None, header=None, compression='auto',
                           text file with the header information (like the .head file output from
                           SCamp).  In this case you should set ``text_file = True`` to tell GalSim
                           to parse the file this way.  [default: False]
-        suppress_warning: Whether to suppress a warning that none of the real FITS WCS classes
-                          are able to successfully read the file, and we have defaulted to an
-                          `AffineTransform` instead?  [default: False]
+        suppress_warning: Whether to suppress a warning that the WCS could not be read from the
+                          FITS header, so the WCS defaulted to either a `PixelScale` or
+                          `AffineTransform`. [default: False]
                           (Note: this is (by default) set to True when this function is implicitly
                           called from one of the galsim.fits.read* functions.)
     """

--- a/galsim/wcs.py
+++ b/galsim/wcs.py
@@ -718,7 +718,7 @@ class BaseWCS(object):
             self._world_origin = world_origin
 
 
-def readFromFitsHeader(header):
+def readFromFitsHeader(header, suppress_warning=True):
     """Read a WCS function from a FITS header.
 
     This is normally called automatically from within the `galsim.fits.read` function, but
@@ -757,7 +757,10 @@ def readFromFitsHeader(header):
     correspond to the original image origin.  If not, it will default to (1,1).
 
     Parameters:
-        header:     The fits header to write the data to.
+        header:             The fits header with the WCS information.
+        suppress_warning:   Whether to suppress a warning that the WCS could not be read from the
+                            FITS header, so the WCS defaulted to either a `PixelScale` or
+                            `AffineTransform`. [default: True]
 
     Returns:
         a tuple (wcs, origin) of the wcs from the header and the image origin.
@@ -777,7 +780,7 @@ def readFromFitsHeader(header):
         wcs = wcs_type._readHeader(header)
     else:
         # If we aren't told which type to use, this should find something appropriate
-        wcs = FitsWCS(header=header, suppress_warning=True)
+        wcs = FitsWCS(header=header, suppress_warning=suppress_warning)
 
     if xmin != 1 or ymin != 1:
         # ds9 always assumes the image has an origin at (1,1), so convert back to actual

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -683,6 +683,15 @@ def test_Image_FITS_IO():
         assert_raises(OSError, galsim.fits.read, test_file0, compression='plio')
         assert_raises(OSError, galsim.fits.read, test_file, compression='none')
 
+    # Check a file with no WCS information
+    nowcs_file = 'fits_files/blankimg.fits'
+    im = galsim.fits.read(nowcs_file)
+    assert im.wcs == galsim.PixelScale(1.0)
+
+    # If desired, can get a warning about this
+    with assert_warns(galsim.GalSimWarning):
+        im = galsim.fits.read(nowcs_file, suppress_warning=False)
+    assert im.wcs == galsim.PixelScale(1.0)
 
 @timer
 def test_Image_MultiFITS_IO():
@@ -994,6 +1003,16 @@ def test_Image_MultiFITS_IO():
 
         assert_raises(OSError, galsim.fits.readMulti, test_multi_file0, compression='plio')
         assert_raises(OSError, galsim.fits.readMulti, test_multi_file, compression='none')
+
+    # Check a file with no WCS information
+    nowcs_file = 'fits_files/blankimg.fits'
+    ims = galsim.fits.readMulti(nowcs_file)
+    assert ims[0].wcs == galsim.PixelScale(1.0)
+
+    # If desired, can get a warning about this
+    with assert_warns(galsim.GalSimWarning):
+        ims = galsim.fits.readMulti(nowcs_file, suppress_warning=False)
+    assert ims[0].wcs == galsim.PixelScale(1.0)
 
 
 @timer
@@ -1316,6 +1335,16 @@ def test_Image_CubeFITS_IO():
 
         assert_raises(OSError, galsim.fits.readCube, test_cube_file0, compression='plio')
         assert_raises(OSError, galsim.fits.readCube, test_cube_file, compression='none')
+
+    # Check a file with no WCS information
+    nowcs_file = 'fits_files/blankimg.fits'
+    ims = galsim.fits.readCube(nowcs_file)
+    assert ims[0].wcs == galsim.PixelScale(1.0)
+
+    # If desired, can get a warning about this
+    with assert_warns(galsim.GalSimWarning):
+        ims = galsim.fits.readCube(nowcs_file, suppress_warning=False)
+    assert ims[0].wcs == galsim.PixelScale(1.0)
 
 
 @timer

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -2504,7 +2504,12 @@ def test_fitswcs():
     assert isinstance(linear, galsim.OffsetWCS)
 
     # This file does not have any WCS information in it.
-    pixel = galsim.FitsWCS('fits_files/blankimg.fits')
+    with assert_warns(galsim.GalSimWarning):
+        pixel = galsim.FitsWCS('fits_files/blankimg.fits')
+    assert pixel == galsim.PixelScale(1.0)
+
+    # Can suppress the warning if desired
+    pixel = galsim.FitsWCS('fits_files/blankimg.fits', suppress_warning=True)
     assert pixel == galsim.PixelScale(1.0)
 
     assert_raises(TypeError, galsim.FitsWCS)


### PR DESCRIPTION
If a FITS file doesn't have any WCS information in it, we default to a PixelScale.  This is currently done silently.

This PR adds a warning that is emitted by default when reading this via `FitsWCS(file)`, but is suppressed by default when reading via `galsim.fits.read(file)`.

If you want to get the warning, you can now do `galsim.fits.read(file, suppress_warning=False)`, and it will emit the warning.  (So you can potentially catch it and do something particular if this happened.)