### PR TITLE
Fix config world pos to be the real world_pos, not tangent plane projection

### DIFF
--- a/docs/config_values.rst
+++ b/docs/config_values.rst
@@ -605,7 +605,7 @@ Variables that GalSim will provide for you to use:
     * Available if ``world_pos`` is defined (as per above) and the WCS is a CelestialWCS.
     * A `galsim.CelestialCoord` instance
 
-* ``uv_pos`` = the position of the object in a tangent plane projection relative to ``world_center``, if that is defined, or the image center if not.
+* ``uv_pos`` = the position of the object in a tangent plane projection relative to ``world_center``.
 
     * Available if either image_pos or world_pos is defined and the wcs is defined.
     * A `galsim.PositionD` instance

--- a/docs/config_values.rst
+++ b/docs/config_values.rst
@@ -654,6 +654,9 @@ Variables that GalSim will provide for you to use:
     * A `galsim.BaseDeviate` instance
     * You can convert it to whatever deviate you need.  e.g. ``galsim.GaussianDeviate(rng,1.0,0.2)()``
 
+Available Modules
+^^^^^^^^^^^^^^^^^^
+
 Python modules that GalSim will import for you to use:
 
 * ``math``
@@ -709,6 +712,7 @@ Initial letters of user-defined variables for 'Eval':
 * 'd' = ``dict``  (This takes a dict as a literal, rather than evaluating it.)
 * 'l' = ``list``  (Similarly, this allows for a literal list in the config file.)
 
+
 The eval-variables field
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -741,6 +745,34 @@ or as part of an ``Eval`` item:
         type : RTheta
         r : { type : Eval , str : 'pixel_scale * 0.5' }
         theta : { type : Random }
+
+
+Module-defined variables
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you are using any user-defined modules (loaded in the ``modules`` field), then they are
+allowed to add to the list of `Preset variables`. The mechanism for this is to append items
+to the list ``galsim.config.eval_base_variables``.  This list includes all of the variables
+that an Eval type will load into the local namespace before evaluating.  For instance,
+if a user-defined module wants to make available a variable called, say, ``coadd_wcs``,
+then the module could add this name to the list of avilable variables as folllows:
+
+.. code-block:: python
+
+    galsim.config.eval_base_variables.append('coadd_wcs')
+
+This should be done at module scope, since you only want to add it once.  So probably best
+to add it when your module is imported.
+
+Then in some processing step, you could set this variable as
+
+.. code-block:: python
+
+    base['coadd_wcs'] = coadd_wcs
+
+Then any subsequent Eval field could use this variable as a local variable, just like the
+ones listed in `Preset variables`.
+
 
 Shorthand notation
 ^^^^^^^^^^^^^^^^^^

--- a/docs/config_values.rst
+++ b/docs/config_values.rst
@@ -593,7 +593,7 @@ Variables that GalSim will provide for you to use:
     * Available if ``image_pos`` or ``world_pos`` is explicitly given in the ``stamp`` field.
     * A `galsim.PositionD` instance
 
-* ``world_pos`` = the position of the object in world coordinates relative to the center of the image.
+* ``world_pos`` = the position of the object in world coordinates.
 
     * Available if image ``type`` is 'Tiled' or 'Scattered'
     * Available if ``image_pos`` or ``world_pos`` is explicitly given in the ``stamp`` field.

--- a/docs/config_values.rst
+++ b/docs/config_values.rst
@@ -605,14 +605,20 @@ Variables that GalSim will provide for you to use:
     * Available if ``world_pos`` is defined (as per above) and the WCS is a CelestialWCS.
     * A `galsim.CelestialCoord` instance
 
-* ``uv_pos`` = the position of the object in a tangent plane projection relative to the center of the image, or ``world_center`` if that is defined.
+* ``uv_pos`` = the position of the object in a tangent plane projection relative to ``world_center``, if that is defined, or the image center if not.
 
     * Available if either image_pos or world_pos is defined and the wcs is defined.
     * A `galsim.PositionD` instance
 
-* ``image_center`` = the center of the image in pixels.  This is the position on the image that corresponds to ``world_pos = (0,0)``.
+* ``image_center`` = the center of the image in pixels.
 
     * A `galsim.PositionD` instance
+
+* ``world_center`` = the world position of ``image_center``.
+
+    * Computed automatically from ``image_center`` and the wcs.
+    * A `galsim.PositionD` instance if the wcs is a `galsim.wcs.EuclideanWCS` or a `galsim.CelestialCoord` if the wcs is a `galsim.wcs.CelestialWCS`.
+    * May also be provided directly if you want something different for this, by specifically including a ``world_center`` item in the ``image`` field.  In this case, it should be a `galsim.CelestialCoord` value.
 
 * ``image_origin`` = the origin of the image in pixels.  This is the position on the image that corresponds to the lower-leftmost pixel
 

--- a/docs/config_values.rst
+++ b/docs/config_values.rst
@@ -587,23 +587,28 @@ position on the image.
 
 Variables that GalSim will provide for you to use:
 
-* ``world_pos`` = the position of the object in world coordinates relative to the center of the image.
-
-    * Available if image ``type`` is 'Tiled' or 'Scattered'
-    * Available if ``image_pos`` or ``world_pos`` is explicitly given in the ``stamp`` field.
-    * A `galsim.PositionD` instance
-
 * ``image_pos`` = the position of the object on the image in pixels.
 
     * Available if image ``type`` is 'Tiled' or 'Scattered'
     * Available if ``image_pos`` or ``world_pos`` is explicitly given in the ``stamp`` field.
     * A `galsim.PositionD` instance
 
+* ``world_pos`` = the position of the object in world coordinates relative to the center of the image.
+
+    * Available if image ``type`` is 'Tiled' or 'Scattered'
+    * Available if ``image_pos`` or ``world_pos`` is explicitly given in the ``stamp`` field.
+    * A `galsim.PositionD` instance if the wcs is a `galsim.wcs.EuclideanWCS` or a `galsim.CelestialCoord` if the wcs is a `galsim.wcs.CelestialWCS`.
+
 * ``sky_pos`` = the position of the object in sky coordinates (RA, Dec)
 
     * Available if ``sky_pos`` is explicitly given in the ``stamp`` field.
     * Available if ``world_pos`` is defined (as per above) and the WCS is a CelestialWCS.
     * A `galsim.CelestialCoord` instance
+
+* ``uv_pos`` = the position of the object in a tangent plane projection relative to the center of the image, or ``world_center`` if that is defined.
+
+    * Available if either image_pos or world_pos is defined and the wcs is defined.
+    * A `galsim.PositionD` instance
 
 * ``image_center`` = the center of the image in pixels.  This is the position on the image that corresponds to ``world_pos = (0,0)``.
 

--- a/galsim/config/input_nfw.py
+++ b/galsim/config/input_nfw.py
@@ -41,9 +41,9 @@ def _GenerateFromNFWHaloShear(config, base, value_type):
     nfw_halo = GetInputObj('nfw_halo', config, base, 'NFWHaloShear')
     logger = nfw_halo.logger
 
-    if 'world_pos' not in base:
+    if 'uv_pos' not in base:
         raise GalSimConfigError("NFWHaloShear requested, but no position defined.")
-    pos = base['world_pos']
+    pos = base['uv_pos']
 
     if 'gal' not in base or 'redshift' not in base['gal']:
         raise GalSimConfigError("NFWHaloShear requested, but no gal.redshift defined.")
@@ -74,9 +74,9 @@ def _GenerateFromNFWHaloMagnification(config, base, value_type):
     nfw_halo = GetInputObj('nfw_halo', config, base, 'NFWHaloMagnification')
     logger = nfw_halo.logger
 
-    if 'world_pos' not in base:
+    if 'uv_pos' not in base:
         raise GalSimConfigError("NFWHaloMagnification requested, but no position defined.")
-    pos = base['world_pos']
+    pos = base['uv_pos']
 
     if 'gal' not in base or 'redshift' not in base['gal']:
         raise GalSimConfigError("NFWHaloMagnification requested, but no gal.redshift defined.")

--- a/galsim/config/input_powerspectrum.py
+++ b/galsim/config/input_powerspectrum.py
@@ -192,9 +192,9 @@ def _GenerateFromPowerSpectrumShear(config, base, value_type):
     power_spectrum = GetInputObj('power_spectrum', config, base, 'PowerSpectrumShear')
     logger = power_spectrum.logger
 
-    if 'world_pos' not in base:
+    if 'uv_pos' not in base:
         raise GalSimConfigError("PowerSpectrumShear requested, but no position defined.")
-    pos = base['world_pos']
+    pos = base['uv_pos']
 
     # There aren't any parameters for this, so just make sure num is the only (optional)
     # one present.
@@ -231,10 +231,10 @@ def _GenerateFromPowerSpectrumMagnification(config, base, value_type):
     power_spectrum = GetInputObj('power_spectrum', config, base, 'PowerSpectrumMagnification')
     logger = power_spectrum.logger
 
-    if 'world_pos' not in base:
+    if 'uv_pos' not in base:
         raise GalSimConfigError(
             "PowerSpectrumMagnification requested, but no position defined.")
-    pos = base['world_pos']
+    pos = base['uv_pos']
 
     opt = { 'max_mu' : float, 'num' : int }
     kwargs = GetAllParams(config, base, opt=opt)[0]

--- a/galsim/config/stamp.py
+++ b/galsim/config/stamp.py
@@ -718,9 +718,10 @@ class StampBuilder(object):
             image_pos = wcs.toImage(world_pos)
 
         # If the world_pos is a CelestialCoord, then we also call it sky_pos.
-        # If the world_pos is not celestial, then the user may optionally define a sky_pos
-        # value, which gets saved as base['sky_pos'].  This may be useful for things that need
-        # to know where in the sky the pointing is, even if the WCS is not a CelestialWCS.
+        # If the world_pos is not celestial, or the user wants to override it for some reason,
+        # then the user may optionally define a sky_pos value, which gets saved as base['sky_pos'].
+        # This may be useful for things that need to know where in the sky the pointing is,
+        # even if the WCS is not a CelestialWCS.
         if 'sky_pos' in config:
             base['sky_pos'] = ParseValue(config, 'sky_pos', base, CelestialCoord)[0]
         elif isinstance(world_pos, CelestialCoord):

--- a/galsim/config/value_eval.py
+++ b/galsim/config/value_eval.py
@@ -60,7 +60,7 @@ def _type_by_letter(key):
 eval_base_variables = [ 'image_pos', 'world_pos', 'image_center', 'image_origin', 'image_bounds',
                         'image_xsize', 'image_ysize', 'stamp_xsize', 'stamp_ysize', 'pixel_scale',
                         'wcs', 'rng', 'file_num', 'image_num', 'obj_num', 'start_obj_num',
-                        'world_center', 'sky_pos', 'bandpass' ]
+                        'world_center', 'sky_pos', 'uv_pos', 'bandpass' ]
 
 from .value import standard_ignore
 eval_ignore = ['str','_fn'] + standard_ignore

--- a/tests/test_config_value.py
+++ b/tests/test_config_value.py
@@ -352,10 +352,10 @@ def test_float_value():
 
     # Test NFWHaloMagnification
     galsim.config.SetupInputsForImage(config, None)
-    # Raise an error because no world_pos
+    # Raise an error because no uv_pos
     with assert_raises(galsim.GalSimConfigError):
         galsim.config.ParseValue(config,'nfw',config, float)
-    config['world_pos'] = galsim.PositionD(6,8)
+    config['uv_pos'] = galsim.PositionD(6,8)
     # Still raise an error because no redshift
     with assert_raises(galsim.GalSimConfigError):
         galsim.config.ParseValue(config,'nfw',config, float)
@@ -368,7 +368,7 @@ def test_float_value():
 
     # Too large magnification should max out at 25
     galsim.config.RemoveCurrent(config)
-    config['world_pos'] = galsim.PositionD(0.1,0.3)
+    config['uv_pos'] = galsim.PositionD(0.1,0.3)
     print("strong lensing mag = ",nfw_halo.getMagnification((0.1,0.3), gal_z))
     galsim.config.RemoveCurrent(config)
     with CaptureLog() as cl:
@@ -382,13 +382,13 @@ def test_float_value():
     galsim.config.RemoveCurrent(config)
     config['nfw']['max_mu'] = 3000.
     del config['nfw']['_get']
-    config['world_pos'] = galsim.PositionD(0.1,0.3)
+    config['uv_pos'] = galsim.PositionD(0.1,0.3)
     nfw3 = galsim.config.ParseValue(config,'nfw',config, float)[0]
     np.testing.assert_almost_equal(nfw3, nfw_halo.getMagnification((0.1,0.3), gal_z))
 
     # Also, if it goes negative, it should report the max_mu value.
     galsim.config.RemoveCurrent(config)
-    config['world_pos'] = galsim.PositionD(0.1,0.2)
+    config['uv_pos'] = galsim.PositionD(0.1,0.2)
     print("very strong lensing mag = ",nfw_halo.getMagnification((0.1,0.2), gal_z))
     with CaptureLog() as cl:
         galsim.config.SetupInputsForImage(config, cl.logger)
@@ -430,7 +430,7 @@ def test_float_value():
     np.testing.assert_almost_equal(ps2a, 25.)
 
     # Need a different point that happens to have strong lensing, since the PS realization changed.
-    config['world_pos'] = galsim.PositionD(-60, -60)
+    config['uv_pos'] = galsim.PositionD(-60, -60)
     galsim.config.RemoveCurrent(config)
     with CaptureLog() as cl:
         galsim.config.SetupInputsForImage(config, logger=cl.logger)
@@ -456,7 +456,7 @@ def test_float_value():
 
     # Out of bounds results in shear = 0, and a warning.
     galsim.config.RemoveCurrent(config)
-    config['world_pos'] = galsim.PositionD(1000,2000)
+    config['uv_pos'] = galsim.PositionD(1000,2000)
     with CaptureLog() as cl:
         galsim.config.SetupInputsForImage(config, cl.logger)
         ps2c = galsim.config.ParseValue(config, 'ps', config, float)[0]
@@ -465,8 +465,8 @@ def test_float_value():
             "galsim.BoundsD") in cl.output
     np.testing.assert_almost_equal(ps2c, 1.)
 
-    # Error if no world_pos
-    del config['world_pos']
+    # Error if no uv_pos
+    del config['uv_pos']
     galsim.config.RemoveCurrent(config)
     with assert_raises(galsim.GalSimConfigError):
         galsim.config.ParseValue(config, 'ps', config, float)
@@ -1329,10 +1329,10 @@ def test_shear_value():
     # Test NFWHaloShear
     galsim.config.ProcessInput(config)
     galsim.config.SetupInputsForImage(config, None)
-    # Raise an error because no world_pos
+    # Raise an error because no uv_pos
     with assert_raises(galsim.GalSimConfigError):
         galsim.config.ParseValue(config, 'nfw', config, galsim.Shear)
-    config['world_pos'] = galsim.PositionD(6,8)
+    config['uv_pos'] = galsim.PositionD(6,8)
     # Still raise an error because no redshift
     with assert_raises(galsim.GalSimConfigError):
         galsim.config.ParseValue(config, 'nfw', config, galsim.Shear)
@@ -1348,7 +1348,7 @@ def test_shear_value():
 
     # If shear is larger than 1, it raises a warning and returns 0,0
     galsim.config.RemoveCurrent(config)
-    config['world_pos'] = galsim.PositionD(0.1,0.2)
+    config['uv_pos'] = galsim.PositionD(0.1,0.2)
     print("strong lensing shear = ",nfw_halo.getShear((0.1,0.2), gal_z))
     with CaptureLog() as cl:
         galsim.config.SetupInputsForImage(config, cl.logger)
@@ -1391,7 +1391,7 @@ def test_shear_value():
 
     # Out of bounds results in shear = 0, and a warning.
     galsim.config.RemoveCurrent(config)
-    config['world_pos'] = galsim.PositionD(1000,2000)
+    config['uv_pos'] = galsim.PositionD(1000,2000)
     with CaptureLog() as cl:
         galsim.config.SetupInputsForImage(config, cl.logger)
         ps2c = galsim.config.ParseValue(config, 'ps', config, galsim.Shear)[0]
@@ -1401,8 +1401,8 @@ def test_shear_value():
             "ymin=-190.00000000000023, ymax=200.00000000000023)") in cl.output
     np.testing.assert_almost_equal((ps2c.g1, ps2c.g2), (0,0))
 
-    # Error if no world_pos
-    del config['world_pos']
+    # Error if no uv_pos
+    del config['uv_pos']
     galsim.config.RemoveCurrent(config)
     with assert_raises(galsim.GalSimConfigError):
         galsim.config.ParseValue(config, 'ps', config, galsim.Shear)
@@ -1703,6 +1703,7 @@ def test_eval():
         # These would be set by config in real runs, but just add them here for the tests.
         'image_pos' : galsim.PositionD(1.8,13),
         'world_pos' : galsim.PositionD(7.2,1.8),
+        'uv_pos' : galsim.PositionD(7.2,1.8),
         'pixel_scale' : 1.8,
         'image_xsize' : 180,
         'image_ysize' : 360,


### PR DESCRIPTION
@beckermr recently ran into a bit of cruft in the config processing that would be worth cleaning up before the next release.  He discovered that config['world_pos'] is not necessarily the real world_pos.  If the wcs is a CelestialWCS, then world_pos is a tangent plane projection.

There isn't any good reason for this behavior, and it's confusing, so the PR changes it to something more sensible.  Specifically, world_pos is whatever the current world_pos is as we normally talk about it.  If world_pos is a CelestialWCS, then we also have a uv_pos, which is the tangent plane project, which enables the use cases that the old behavior used to enable (namely having a flat "world" position for NFW halos or shear power spectra fields).