### PR TITLE
Fix shared clib

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -194,3 +194,9 @@ Bug Fixes
   information in each hdu. (#1091)
 - Improved the accuracy of stepk for Kolmogorov profiles, especially when
   folding_threshold is very small. (#1110)
+
+
+Changes from v2.3.0 to v2.3.1
+=============================
+
+- Fixed some problems with the shared library build.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -199,4 +199,4 @@ Bug Fixes
 Changes from v2.3.0 to v2.3.1
 =============================
 
-- Fixed some problems with the shared library build.
+- Fixed some problems with the shared library build. (#1128)

--- a/galsim/_version.py
+++ b/galsim/_version.py
@@ -15,5 +15,5 @@
 #    this list of conditions, and the disclaimer given in the documentation
 #    and/or other materials provided with the distribution.
 #
-__version__ = '2.3.0'
+__version__ = '2.3.1'
 __version_info__ = tuple(map(lambda x:int(x.split('-')[0]), __version__.split('.')))[:3]

--- a/setup.py
+++ b/setup.py
@@ -490,6 +490,10 @@ def try_compile(cpp_code, compiler, cflags=[], lflags=[], prepend=None):
                 cpp = 'g++'
             else:
                 cpp = 'c++'
+        # Finally, if GALSIM_CXX is in the environment, let that take precedence.
+        # (I don't know if it's safe to use a user's CXX always, so make sure the user really
+        # meant to direct GalSim to use some other compiler by requiring the GALSIM prefix.)
+        cpp = os.environ('GALSIM_CXX', cpp)
         cmd = [cpp] + compiler.linker_so[1:] + lflags + [o_name,'-o',exe_name]
         if debug:
             print('cmd = ',' '.join(cmd))

--- a/setup.py
+++ b/setup.py
@@ -998,10 +998,6 @@ class my_build_shared_clib(my_build_clib):
             library_dirs = ext.library_dirs
             print('initial library_dirs = ',library_dirs)
 
-            # Add the dir and lib for the static galsim library:
-            library_dirs.append(self.build_clib)
-            libraries.append('galsim')
-
             # Link to fftw library
             fftw_lib = find_fftw_lib()
             fftw_libpath, fftw_libname = os.path.split(fftw_lib)

--- a/setup.py
+++ b/setup.py
@@ -1018,6 +1018,9 @@ class my_build_shared_clib(my_build_clib):
                 # Set the compatibility version on macos
                 lflags.extend(['-Wl,-compatibility_version,%s.%s'%version_info[:2],
                                '-Wl,-current_version,%s.%s.%s'%version_info ])
+                # Also add rpath specification for fftw
+                if fftw_libpath != '':
+                    lflags.append('-Wl,-rpath,' + fftw_libpath)
 
             output_dir = os.path.join('build','shared_clib')
             self.compiler.link(CCompiler.SHARED_OBJECT, expected_objects, full_lib_name,

--- a/setup.py
+++ b/setup.py
@@ -73,14 +73,6 @@ test_sources = all_files_from('tests', '.cpp')
 headers = all_files_from('include')
 shared_data = all_files_from('share')
 
-# TODO: Remove this bit when we release 2.3.0 officially.
-#       But for now on main, the wfirst directory can stick around and cause problems.
-if len(glob.glob('build/*/galsim/wfirst')) > 0:
-    d = glob.glob('build/*/galsim/wfirst')
-    print('Removing obsolete wfirst dir: ',d[0])
-    import shutil
-    shutil.rmtree(d[0])
-
 copt =  {
     'gcc' : ['-O2','-msse2','-std=c++11','-fvisibility=hidden','-fopenmp'],
     'icc' : ['-O2','-msse2','-vec-report0','-std=c++11','-openmp'],

--- a/setup.py
+++ b/setup.py
@@ -1135,12 +1135,14 @@ class my_test(test):
     def run_cpp_tests(self):
         builder = self.distribution.get_command_obj('build_ext')
         compiler = builder.compiler
+        cflags, lflags = fix_compiler(compiler, 1)
 
         ext = builder.extensions[0]
         objects = compiler.compile(test_sources,
                 output_dir=builder.build_temp,
                 macros=ext.define_macros,
                 include_dirs=ext.include_dirs,
+                extra_postargs=cflags,
                 debug=builder.debug,
                 depends=ext.depends)
 

--- a/setup.py
+++ b/setup.py
@@ -896,6 +896,9 @@ class my_build_shared_clib(my_build_clib):
         from setuptools.dep_util import newer_pairwise_group
         from distutils.ccompiler import CCompiler
 
+        builder = self.distribution.get_command_obj('build_ext')
+        cflags, lflags = fix_compiler(self.compiler, 1)
+
         # Most of this is the setuptools version of the build_libraries function.
         # We just change the final link command to build a shared library that can be linked
         # to C++ programs that just want the C++ library.
@@ -974,11 +977,12 @@ class my_build_shared_clib(my_build_clib):
             ### The original used self.compiler.create_static_lib
             ###
             ###
-            output_name = self.compiler.library_filename(lib_name, lib_type="shared")
+            lib_name = self.compiler.library_filename(lib_name, lib_type="shared")
             version_str = '{}.{}'.format(*version_info[:2])
             if sys.platform == "darwin":
                 # .so -> .dylib
-                output_name = output_name[:-2] + version_str + '.dylib'
+                lib_name = lib_name.replace('so','dylib')
+                full_lib_name = lib_name[:-5] + version_str + '.dylib'
                 orig_linker_so = self.compiler.linker_so
                 assert orig_linker_so[1] == '-bundle'
                 dylib_linker_so = orig_linker_so.copy()
@@ -986,9 +990,53 @@ class my_build_shared_clib(my_build_clib):
                 self.compiler.set_executable('linker_so', dylib_linker_so)
             else:
                 # Just add the version bit
-                output_name = output_name[:-2] + version_str + '.so'
-            self.compiler.link(CCompiler.SHARED_OBJECT, expected_objects, output_name,
-                               output_dir='build/shared_clib', debug=self.debug)
+                full_lib_name = lib_name[:-2] + version_str + '.so'
+
+            libraries = builder.get_libraries(ext)
+            print('initial libraries = ',libraries)
+
+            library_dirs = ext.library_dirs
+            print('initial library_dirs = ',library_dirs)
+
+            # Add the dir and lib for the static galsim library:
+            library_dirs.append(self.build_clib)
+            libraries.append('galsim')
+
+            # Link to fftw library
+            fftw_lib = find_fftw_lib()
+            fftw_libpath, fftw_libname = os.path.split(fftw_lib)
+            if fftw_libpath != '':
+                library_dirs.append(fftw_libpath)
+            libraries.append(fftw_libname.split('.')[0][3:])
+
+            # Check for conda libraries that might host OpenMP
+            env = dict(os.environ)
+            if 'CONDA_PREFIX' in env:
+                library_dirs.append(env['CONDA_PREFIX']+'/lib')
+
+            if sys.platform == 'darwin':
+                # Set the compatibility version on macos
+                lflags.extend(['-Wl,-compatibility_version,%s.%s'%version_info[:2],
+                               '-Wl,-current_version,%s.%s.%s'%version_info ])
+
+            output_dir = os.path.join('build','shared_clib')
+            self.compiler.link(CCompiler.SHARED_OBJECT, expected_objects, full_lib_name,
+                               libraries=libraries,
+                               library_dirs=library_dirs,
+                               runtime_library_dirs=ext.runtime_library_dirs,
+                               extra_postargs=ext.extra_link_args + lflags,
+                               output_dir=output_dir, debug=self.debug)
+
+            # Also make the non-versionful one
+            full_lib_name_with_dir = os.path.join(output_dir, full_lib_name)
+            lib_name_with_dir = os.path.join(output_dir, lib_name)
+            print('Versioned library: ',full_lib_name_with_dir)
+            print('Un-versioned library: ',lib_name_with_dir)
+            if not os.path.exists(lib_name_with_dir):
+                # This is slightly confusing.
+                # The target needs the dir, but the source cannot include the dir or it
+                # will try to link to build/shared_clib/build/shared_clib/libgalsim...
+                os.symlink(full_lib_name, lib_name_with_dir)
 
 
 # Make a subclass of build_ext so we can add to the -I list.
@@ -1088,7 +1136,6 @@ class my_test(test):
     def run_cpp_tests(self):
         builder = self.distribution.get_command_obj('build_ext')
         compiler = builder.compiler
-        cflags, lflags = fix_compiler(compiler, False)
 
         ext = builder.extensions[0]
         objects = compiler.compile(test_sources,
@@ -1096,7 +1143,6 @@ class my_test(test):
                 macros=ext.define_macros,
                 include_dirs=ext.include_dirs,
                 debug=builder.debug,
-                extra_postargs=ext.extra_compile_args + cflags,
                 depends=ext.depends)
 
         if ext.extra_objects:
@@ -1104,18 +1150,12 @@ class my_test(test):
 
         libraries = builder.get_libraries(ext)
         libraries.append('galsim')
-
         library_dirs = ext.library_dirs
-        fftw_lib = find_fftw_lib()
-        fftw_libpath, fftw_libname = os.path.split(fftw_lib)
-        if fftw_libpath != '':
-            library_dirs.append(fftw_libpath)
 
         # Use the shared library when building the c++ executables to make sure it works.
         self.run_command("build_shared_clib")
         library_dirs.append('build/shared_clib')
 
-        libraries.append(fftw_libname.split('.')[0][3:])
         # Check for conda libraries that might host OpenMP
         env = dict(os.environ)
         if 'CONDA_PREFIX' in env:
@@ -1128,7 +1168,6 @@ class my_test(test):
                 libraries=libraries,
                 library_dirs=library_dirs,
                 runtime_library_dirs=ext.runtime_library_dirs,
-                extra_postargs=ext.extra_link_args + lflags,
                 debug=builder.debug,
                 target_lang='c++')
 


### PR DESCRIPTION
@erykoff has been trying out the new shared library build for use with the LSST DM stack, and found some problems.  Specifically, it had required adding `-lfftw3 -fopenmp` when using the library, which is not ideal.

This PR is to fix the linking steps to work better to not need to explicitly add these link flags whenever using the libgalsim.so library.

Will release 2.3.1 with this fix when Eli gives me the go ahead.