### PR TITLE
Fix rare possibility of SED.sampleWavelength generating wavelengths outside of bandpass limits.

### DIFF
--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -1324,8 +1324,9 @@ class InterpolatedChromaticObject(ChromaticObject):
 
         w = photons.wavelength
         if np.any((w < self.waves[0]) | (w > self.waves[-1])):
+            bad_waves = [w for w in photons.wavelength if w < self.waves[0] or w > self.waves[-1]]
             raise GalSimRangeError("Shooting photons outside the interpolated wave_list",
-                                   w, self.waves[0], self.waves[-1])
+                                   bad_waves, self.waves[0], self.waves[-1])
 
         k = np.searchsorted(self.waves, w)
         k[k==0] = 1  # if k == 0, then w == min(waves). Using k=1 instead is fine for this.
@@ -1398,8 +1399,9 @@ class InterpolatedChromaticObject(ChromaticObject):
         if np.any((wave_list < self.waves[0]) | (wave_list > self.waves[-1])):  # pragma: no cover
             # MJ: I'm pretty sure it's impossible to hit this.
             #     But just in case I'm wrong, I'm leaving it here but with pragma: no cover.
+            bad_waves = [w for w in wave_list if w < self.waves[0] or w > self.waves[-1]]
             raise GalSimRangeError("Requested wavelength is outside the allowed range.",
-                                   wave_list, self.waves[0], self.waves[-1])
+                                   bad_waves, self.waves[0], self.waves[-1])
 
         # weights are the weights to use at each of the given wavelengths for the integration.
         weights = rule.calculateWeights(wave_list, bandpass)

--- a/galsim/sed.py
+++ b/galsim/sed.py
@@ -1028,7 +1028,8 @@ class SED(object):
             # I'm not sure if the red limit overrun can happen (we didn't see any in the use case
             # that noticed the blue overruns), but it seems prudent to also correct any of these
             # that may occur too.  Plus it's not noticeably slower using clip to do both at once.
-            np.clip(ret, sed.blue_limit, sed.red_limit, out=ret)
+            if bandpass is not None:
+                np.clip(ret, bandpass.blue_limit, bandpass.red_limit, out=ret)
 
         return ret
 

--- a/galsim/sed.py
+++ b/galsim/sed.py
@@ -1020,7 +1020,16 @@ class SED(object):
 
         ret = np.empty(nphotons)
         dev.generate(ret)
-        ret *= (1. + self.redshift)
+
+        if self.redshift != 0:
+            ret *= (1. + self.redshift)
+            # Rarely, with the redshift round trip, this can produce wavelengths < blue_limit.
+            # If this happens, set those values equal to blue_limit.
+            # I'm not sure if the red limit overrun can happen (we didn't see any in the use case
+            # that noticed the blue overruns), but it seems prudent to also correct any of these
+            # that may occur too.  Plus it's not noticeably slower using clip to do both at once.
+            np.clip(ret, sed.blue_limit, sed.red_limit, out=ret)
+
         return ret
 
     def __eq__(self, other):

--- a/tests/test_sed.py
+++ b/tests/test_sed.py
@@ -924,7 +924,7 @@ def test_sampleWavelength_limits():
     # Clearly this is a floating point accuracy issue.  The difference is of order 1.e-16.
     #
     # The problem sees to be that sampleWavelength samples in the rest frame, and then multiplies
-    # by (1+z) at the end to get bac to the intended range.  That divide and multiply
+    # by (1+z) at the end to get back to the intended range.  That divide and multiply
     # is not guaranteed to roundtrip properly, and you can get errors of order epsilon.
     import galsim.roman
 


### PR DESCRIPTION
@matroxel ran into a rare bug in the Roman simulations where some wavelengths would be barely outside of the allowed range for the PSF (which is based on the bandpass limits):
```
galsim.errors.GalSimRangeError: Shooting photons outside the interpolated wave_list Value [1192.14102378 
972.39138558 1058.912179  ... 1170.73736364 951.20426042 1180.4948833 ] not in range [885.0, 1245.0]
```
First, that error message isn't particularly useful, since most of the wavelengths are fine.  So I changed the messaging to only list the bad wavelengths.  That produced error messages like the following (for a different band than above):
```
galsim.errors.GalSimRangeError: Shooting photons outside the interpolated wave_list Value 
[1604.9999999999998] not in range [1605.0, 2090.0]
```
Clearly this is just a numerical rounding error.  I tracked it down to the SED.sampleWavelength function.  In that function, we sample wavelengths in the SED's native reference frame.  If it is nominally at some other redshift, then the bandpass limits are divided by (1+z).  Then after the waves are generated, we multiply back by (1+z) to get the final waves.  This round trip can lead to errors of order epsilon, which meant you could get the range error that Troxel found.

The solution in this PR is to just clip the values to the bandpass limits at the end (with `np.clip`).  I'm targeting this at releases/2.3, so we can cut 2.3.2 with this fix.