### PR TITLE
Use single-precision for Silicon internal storage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,13 +147,16 @@ jobs:
                 # Extra packages needed for testing
                 pip install -U -r test_requirements.txt
                 pip install -U nose codecov coverage
-                pip install -U pandas matplotlib astroplan
+                pip install -U matplotlib astroplan
 
             - name: Install CPython-only dependencies
               if: matrix.py != 'pypy3'
-              run:
+              run: |
                 # The only one left that doesn't seem to work right on pypy is starlink-pyast.
                 pip install -U starlink-pyast
+                # And now pandas is acting up on pypy.
+                # cf. https://github.com/pandas-dev/pandas/issues/44253
+                pip install -U pandas
 
             - name: List all installed packages for reference
               run: pip list

--- a/include/galsim/Bounds.h
+++ b/include/galsim/Bounds.h
@@ -56,12 +56,20 @@ namespace galsim {
         ///@brief Constructor.
         Position(const T xin, const T yin) : x(xin), y(yin) {}
 
+        ///@brief Copy Constructor
+        Position(const Position<T>& rhs) : x(rhs.x), y(rhs.y) {}
+        template <typename T2>
+        Position(const Position<T2>& rhs) : x(rhs.x), y(rhs.y) {}
+
         ///@brief Assignment.
         Position& operator=(const Position<T>& rhs)
         {
             if (&rhs == this) return *this;
             else { x=rhs.x; y=rhs.y; return *this; }
         }
+        template <typename T2>
+        Position& operator=(const Position<T2>& rhs)
+        { x=rhs.x; y=rhs.y; return *this; }
 
         /// @brief Overloaded += operator, following standard vector algebra rules.
         template <typename T2>
@@ -251,9 +259,11 @@ namespace galsim {
 
         //@{
         /// @brief return whether the bounded region includes a given point
-        bool includes(const Position<T>& pos) const
+        template <typename T2>
+        bool includes(const Position<T2>& pos) const
         { return (defined && pos.x<=xmax && pos.x>=xmin && pos.y<=ymax && pos.y>=ymin); }
-        bool includes(const T x, const T y) const
+        template <typename T2>
+        bool includes(const T2 x, const T2 y) const
         { return (defined && x<=xmax && x>=xmin && y<=ymax && y>=ymin); }
         //@}
 

--- a/include/galsim/Polygon.h
+++ b/include/galsim/Polygon.h
@@ -32,8 +32,8 @@
 
 namespace galsim {
 
-    // For these purposes, we use Point as an alias for Position<double>
-    typedef Position<double> Point;
+    // For these purposes, we use Point as an alias for Position<float>
+    typedef Position<float> Point;
 
     class PUBLIC_API Polygon
     {

--- a/include/galsim/Polygon.h
+++ b/include/galsim/Polygon.h
@@ -32,9 +32,6 @@
 
 namespace galsim {
 
-    // For these purposes, we use Point as an alias for Position<float>
-    typedef Position<float> Point;
-
     class PUBLIC_API Polygon
     {
     public:
@@ -47,7 +44,7 @@ namespace galsim {
         // Add a point to a Polygon
         // Note: all points need to be added before doing area or contains.  If more points are
         // added after either of those calls, an exception will be thrown.
-        void add(const Point& point);
+        void add(const Position<double>& point);
 
         // Sort the points. The user is responsible for calling this after adding all the points
         // or after making any modification that might change the order of the points around
@@ -59,21 +56,21 @@ namespace galsim {
         double area() const;
 
         // Return whether the Polygon contains a given point
-        bool contains(const Point& point) const;
+        bool contains(const Position<double>& point) const;
 
         // Two functions that check whether the point is trivially inside or outside.
-        inline bool triviallyContains(const Point& point) const
+        inline bool triviallyContains(const Position<double>& point) const
         { return _inner.includes(point); }
 
-        inline bool mightContain(const Point& point) const
+        inline bool mightContain(const Position<double>& point) const
         { return _outer.includes(point); }
 
-        // Some methods that let Polygon act (in some ways) like a vector<Point>
+        // Some methods that let Polygon act (in some ways) like a vector<Position<double> >
         size_t size() const { return _points.size(); }
         void clear() { _points.clear(); }
         void reserve(int n) { _points.reserve(n); }
-        Point& operator[](int i) { return _points[i]; }
-        const Point& operator[](int i) const { return _points[i]; }
+        Position<double>& operator[](int i) { return _points[i]; }
+        const Position<double>& operator[](int i) const { return _points[i]; }
 
         // Make the Polygon a scaled version of a reference one (relative to an empty Polygon).
         void scale(const Polygon& refpoly, const Polygon& emptypoly, double factor);
@@ -92,7 +89,7 @@ namespace galsim {
 
         bool _sorted;
         mutable double _area;
-        std::vector<Point> _points;
+        std::vector<Position<double> > _points;
         int _npoints;  // Always equivalent to _points.size(), but convenient to have it as an int.
         Bounds<double> _inner;
         Bounds<double> _outer;

--- a/include/galsim/Silicon.h
+++ b/include/galsim/Silicon.h
@@ -241,12 +241,12 @@ namespace galsim
         Polygon _emptypoly;
         mutable std::vector<Polygon> _testpoly;
 
-        std::vector<Point> _horizontalBoundaryPoints;
-        std::vector<Point> _verticalBoundaryPoints;
+        std::vector<Position<float> > _horizontalBoundaryPoints;
+        std::vector<Position<float> > _verticalBoundaryPoints;
         std::vector<Bounds<double> > _pixelInnerBounds;
         std::vector<Bounds<double> > _pixelOuterBounds;
-        std::vector<Point> _horizontalDistortions;
-        std::vector<Point> _verticalDistortions;
+        std::vector<Position<float> > _horizontalDistortions;
+        std::vector<Position<float> > _verticalDistortions;
         int _numVertices, _nx, _ny, _nv, _qDist;
         double _nrecalc, _diffStep, _pixelSize, _sensorThickness;
         Table _tr_radial_table;

--- a/include/galsim/Silicon.h
+++ b/include/galsim/Silicon.h
@@ -238,25 +238,8 @@ namespace galsim
 
         void updatePixelBounds(int nx, int ny, size_t k);
 
-#if 0
-        // TO BE REMOVED
-        bool checkPixel(int i, int j, int nx, int ny);
-
-        // TO BE REMOVED
-        void makeDistortionsConsistent();
-        // TO BE REMOVED
-        void addHalo();
-
-        bool _useNewBoundaries;
-#endif
-
         Polygon _emptypoly;
         mutable std::vector<Polygon> _testpoly;
-
-#if 0
-        std::vector<Polygon> _distortions;
-        std::vector<Polygon> _imagepolys;
-#endif
 
         std::vector<Point> _horizontalBoundaryPoints;
         std::vector<Point> _verticalBoundaryPoints;

--- a/setup.py
+++ b/setup.py
@@ -498,7 +498,7 @@ def try_compile(cpp_code, compiler, cflags=[], lflags=[], prepend=None):
         # Finally, if GALSIM_CXX is in the environment, let that take precedence.
         # (I don't know if it's safe to use a user's CXX always, so make sure the user really
         # meant to direct GalSim to use some other compiler by requiring the GALSIM prefix.)
-        cpp = os.environ('GALSIM_CXX', cpp)
+        cpp = os.environ.get('GALSIM_CXX', cpp)
         cmd = [cpp] + compiler.linker_so[1:] + lflags + [o_name,'-o',exe_name]
         if debug:
             print('cmd = ',' '.join(cmd))

--- a/src/Polygon.cpp
+++ b/src/Polygon.cpp
@@ -34,7 +34,7 @@
 
 namespace galsim {
 
-    void Polygon::add(const Point& point)
+    void Polygon::add(const Position<double>& point)
     {
         xdbg<<"Current size = "<<_points.size()<<" = "<<_npoints<<std::endl;
         xdbg<<"add point "<<point.x<<','<<point.y<<std::endl;
@@ -95,7 +95,7 @@ namespace galsim {
         return _area;
     }
 
-    bool Polygon::contains(const Point& point) const
+    bool Polygon::contains(const Position<double>& point) const
     {
         //Determines if a given point is inside the polygon
         assert(_sorted);
@@ -137,8 +137,8 @@ namespace galsim {
 
     void Polygon::distort(const Polygon& refpoly, double factor)
     {
-        std::vector<Point>::iterator it = _points.begin();
-        std::vector<Point>::const_iterator ref = refpoly._points.begin();
+        std::vector<Position<double>>::iterator it = _points.begin();
+        std::vector<Position<double>>::const_iterator ref = refpoly._points.begin();
         for (int n=_npoints; n; --n) {
 #ifdef _OPENMP
 #pragma omp atomic

--- a/src/Silicon.cpp
+++ b/src/Silicon.cpp
@@ -306,8 +306,12 @@ namespace galsim {
 
                         // Loop over boundary points and update them
                         for (int n=0; n < horizontalPixelStride(); ++n, ++index, ++dist_index) {
-                            _horizontalBoundaryPoints[index].x += _horizontalDistortions[dist_index].x * charge;
-                            _horizontalBoundaryPoints[index].y += _horizontalDistortions[dist_index].y * charge;
+                            _horizontalBoundaryPoints[index].x =
+                                double(_horizontalBoundaryPoints[index].x) +
+                                _horizontalDistortions[dist_index].x * charge;
+                            _horizontalBoundaryPoints[index].y =
+                                double(_horizontalBoundaryPoints[index].y) +
+                                _horizontalDistortions[dist_index].y * charge;
                         }
                     }
                 }
@@ -350,8 +354,12 @@ namespace galsim {
 
                         // Loop over boundary points and update them
                         for (int n=0; n < verticalPixelStride(); ++n, --index, --dist_index) {
-                            _verticalBoundaryPoints[index].x += _verticalDistortions[dist_index].x * charge;
-                            _verticalBoundaryPoints[index].y += _verticalDistortions[dist_index].y * charge;
+                            _verticalBoundaryPoints[index].x =
+                                double(_verticalBoundaryPoints[index].x) +
+                                _verticalDistortions[dist_index].x * charge;
+                            _verticalBoundaryPoints[index].y =
+                                double(_verticalBoundaryPoints[index].y) +
+                                _verticalDistortions[dist_index].y * charge;
                         }
                     }
                 }
@@ -394,8 +402,8 @@ namespace galsim {
                 double dx = shift * tx / r;
                 double dy = shift * ty / r;
                 xdbg<<"dx,dy = "<<dx<<','<<dy<<std::endl;
-                poly[n].x += dx;
-                poly[n].y += dy;
+                poly[n].x = double(poly[n].x) + dx;
+                poly[n].y = double(poly[n].y) + dy;
                 xdbg<<"    x,y => "<<poly[n].x <<"  "<< poly[n].y;
             }
         }

--- a/src/Silicon.cpp
+++ b/src/Silicon.cpp
@@ -59,10 +59,10 @@ namespace galsim {
         dbg<<"corners:\n";
         for (int xpix=0; xpix<2; xpix++) {
             for (int ypix=0; ypix<2; ypix++) {
-                poly.add(Point(xpix, ypix));
+                poly.add(Position<double>(xpix, ypix));
                 // Two copies of the corner to be consistent with new code
                 // that has two corner points.
-                poly.add(Point(xpix, ypix));
+                poly.add(Position<double>(xpix, ypix));
             }
         }
         // Next the edges
@@ -70,14 +70,14 @@ namespace galsim {
         for (int xpix=0; xpix<2; xpix++) {
             for (int n=0; n<numVertices; n++) {
                 double theta = theta0 + (n + 1.0) * dtheta;
-                poly.add(Point(xpix, (std::tan(theta) + 1.0) / 2.0));
+                poly.add(Position<double>(xpix, (std::tan(theta) + 1.0) / 2.0));
             }
         }
         dbg<<"y edges:\n";
         for (int ypix=0; ypix<2; ypix++) {
             for (int n=0; n<numVertices; n++) {
                 double theta = theta0 + (n + 1.0) * dtheta;
-                poly.add(Point((std::tan(theta) + 1.0) / 2.0, ypix));
+                poly.add(Position<double>((std::tan(theta) + 1.0) / 2.0, ypix));
             }
         }
         poly.sort();
@@ -106,7 +106,7 @@ namespace galsim {
         _nv = 4 * _numVertices + 8; // Number of vertices in each pixel
         dbg<<"_numVertices = "<<_numVertices<<", _nv = "<<_nv<<std::endl;
         dbg<<"nx,ny = "<<nx<<", "<<ny<<"  ntot = "<<nx*ny<<std::endl;
-        dbg<<"total memory = "<<nx*ny*_nv*sizeof(Point)/(1024.*1024.)<<" MBytes"<<std::endl;
+        dbg<<"total memory = "<<nx*ny*_nv*sizeof(Position<float>)/(1024.*1024.)<<" MBytes"<<std::endl;
 
         buildEmptyPoly(_emptypoly, _numVertices);
         // These are mutable Polygons we'll use as scratch space
@@ -223,21 +223,21 @@ namespace galsim {
         // compute outer bounds first
         _pixelOuterBounds[k] = Bounds<double>();
 
-        iteratePixelBoundary(x, y, nx, ny, [this, k](int n, Point& pt, bool rhs, bool top) {
-                             Point p = pt;
+        iteratePixelBoundary(x, y, nx, ny, [this, k](int n, Position<float>& pt, bool rhs, bool top) {
+                             Position<double> p = pt;
                              if (rhs) p.x += 1.0;
                              if (top) p.y += 1.0;
                              _pixelOuterBounds[k] += p;
                              });
 
-        Point center = _pixelOuterBounds[k].center();
+        Position<double> center = _pixelOuterBounds[k].center();
 
         // now compute inner bounds manually
         _pixelInnerBounds[k] = _pixelOuterBounds[k];
         Bounds<double>& inner = _pixelInnerBounds[k];
 
-        iteratePixelBoundary(x, y, nx, ny, [&](int n, Point& pt, bool rhs, bool top) {
-                             Point p = pt;
+        iteratePixelBoundary(x, y, nx, ny, [&](int n, Position<float>& pt, bool rhs, bool top) {
+                             Position<double> p = pt;
                              if (rhs) p.x += 1.0;
                              if (top) p.y += 1.0;
 
@@ -405,8 +405,8 @@ namespace galsim {
     void Silicon::calculateTreeRingDistortion(int i, int j, Position<int> orig_center,
                                               int nx, int ny, int i1, int j1)
     {
-        iteratePixelBoundary(i - i1, j - j1, nx, ny, [&](int n, Point& pt, bool rhs, bool top) {
-                             Point p = pt;
+        iteratePixelBoundary(i - i1, j - j1, nx, ny, [&](int n, Position<float>& pt, bool rhs, bool top) {
+                             Position<double> p = pt;
 
                              // only do bottom and left points unless we're on top/right edge
                              if ((rhs) && ((i - i1) < (nx - 1))) return;
@@ -479,8 +479,8 @@ namespace galsim {
     {
         result = emptypoly;
 
-        iteratePixelBoundary(i, j, nx, ny, [&](int n, const Point& pt, bool rhs, bool top) {
-                             Point p = pt;
+        iteratePixelBoundary(i, j, nx, ny, [&](int n, const Position<float>& pt, bool rhs, bool top) {
+                             Position<double> p = pt;
                              if (rhs) p.x += 1.0;
                              if (top) p.y += 1.0;
                              result[n].x += (p.x - emptypoly[n].x) * factor;
@@ -527,7 +527,7 @@ namespace galsim {
 #else
         int t  = 0;
 #endif
-        Point p(x,y);
+        Position<double> p(x,y);
         bool inside;
         if (_pixelInnerBounds[index].includes(p)) {
             xdbg<<"trivial\n";
@@ -663,14 +663,14 @@ namespace galsim {
         // compute sum of triangle areas using cross-product rule (shoelace formula)
         for (int n = 0; n < _nv; n++) {
             int pi1 = getBoundaryIndex(i, j, n, &horizontal1, nx, ny);
-            Point p1 = horizontal1 ? _horizontalBoundaryPoints[pi1] :
+            Position<double> p1 = horizontal1 ? _horizontalBoundaryPoints[pi1] :
                 _verticalBoundaryPoints[pi1];
             if ((n > cornerIndexBottomRight()) && (n < cornerIndexTopRight())) p1.x += 1.0;
             if ((n >= cornerIndexTopRight()) && (n <= cornerIndexTopLeft())) p1.y += 1.0;
 
             int n2 = (n + 1) % _nv;
             int pi2 = getBoundaryIndex(i, j, n2, &horizontal2, nx, ny);
-            Point p2 = horizontal2 ? _horizontalBoundaryPoints[pi2] :
+            Position<double> p2 = horizontal2 ? _horizontalBoundaryPoints[pi2] :
                 _verticalBoundaryPoints[pi2];
             if ((n2 > cornerIndexBottomRight()) && (n2 < cornerIndexTopRight())) p2.x += 1.0;
             if ((n2 >= cornerIndexTopRight()) && (n2 <= cornerIndexTopLeft())) p2.y += 1.0;
@@ -702,7 +702,7 @@ namespace galsim {
         if (use_flux) {
             dbg<<"Start full pixel area calculation\n";
             dbg<<"nx,ny = "<<nx<<','<<ny<<std::endl;
-            dbg<<"total memory = "<<nxny*_nv*sizeof(Point)/(1024.*1024.)<<" MBytes"<<std::endl;
+            dbg<<"total memory = "<<nxny*_nv*sizeof(Position<float>)/(1024.*1024.)<<" MBytes"<<std::endl;
 
             initializeBoundaryPoints(nx, ny);
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -436,7 +436,8 @@ def test_silicon_area():
     # Repeat with transpose=True to check that things are transposed properly.
     siliconT = galsim.SiliconSensor(name='lsst_itl_8', rng=rng, transpose=True)
     area_imageT = siliconT.calculate_pixel_areas(im)
-    np.testing.assert_almost_equal(area_imageT.array, area_image.array.T, decimal=7)
+    # This actually comes out exactly equal, but only test at single precision.
+    np.testing.assert_allclose(area_imageT.array, area_image.array.T, rtol=1.e-8)
 
     # Draw a smallish but very bright Gaussian image
     obj = galsim.Gaussian(flux=5.e5, sigma=0.2)
@@ -499,7 +500,8 @@ def test_silicon_area():
                                rtol=2.e-3)
     np.testing.assert_allclose((area_imageT(1,0) + area_imageT(-1,0))/2., 0.9790312068001015,
                                rtol=4.e-4)
-    np.testing.assert_almost_equal(area_imageT.array, area_image.array.T, decimal=7)
+    # This actually comes out exactly equal, but only test at single precision.
+    np.testing.assert_allclose(area_imageT.array, area_image.array.T, rtol=1.e-8)
 
     im2T = obj.drawImage(nx=17, ny=17, scale=0.3, method='phot', sensor=siliconT, rng=rng)
     im2T.setCenter(0,0)
@@ -784,7 +786,7 @@ def test_treerings():
     areas1 = sensor5.calculate_pixel_areas(im)
     print('min/max area1 = ',np.min(areas1.array),np.max(areas1.array))
     areas2 = sensor5.calculate_pixel_areas(im, use_flux=False)
-    np.testing.assert_array_almost_equal(areas1.array, areas2.array, decimal=7)
+    np.testing.assert_allclose(areas1.array, areas2.array, rtol=2.e-8)
     print('min/max area2 = ',np.min(areas2.array),np.max(areas2.array))
     # But the areas with flux have a larger range (in both directions) because of the BFE
     assert np.min(areas0.array) < np.min(areas2.array)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -436,7 +436,7 @@ def test_silicon_area():
     # Repeat with transpose=True to check that things are transposed properly.
     siliconT = galsim.SiliconSensor(name='lsst_itl_8', rng=rng, transpose=True)
     area_imageT = siliconT.calculate_pixel_areas(im)
-    np.testing.assert_almost_equal(area_imageT.array, area_image.array.T, decimal=14)
+    np.testing.assert_almost_equal(area_imageT.array, area_image.array.T, decimal=7)
 
     # Draw a smallish but very bright Gaussian image
     obj = galsim.Gaussian(flux=5.e5, sigma=0.2)
@@ -499,7 +499,7 @@ def test_silicon_area():
                                rtol=2.e-3)
     np.testing.assert_allclose((area_imageT(1,0) + area_imageT(-1,0))/2., 0.9790312068001015,
                                rtol=4.e-4)
-    np.testing.assert_almost_equal(area_imageT.array, area_image.array.T, decimal=14)
+    np.testing.assert_almost_equal(area_imageT.array, area_image.array.T, decimal=7)
 
     im2T = obj.drawImage(nx=17, ny=17, scale=0.3, method='phot', sensor=siliconT, rng=rng)
     im2T.setCenter(0,0)
@@ -784,7 +784,7 @@ def test_treerings():
     areas1 = sensor5.calculate_pixel_areas(im)
     print('min/max area1 = ',np.min(areas1.array),np.max(areas1.array))
     areas2 = sensor5.calculate_pixel_areas(im, use_flux=False)
-    np.testing.assert_array_equal(areas1.array, areas2.array)
+    np.testing.assert_array_almost_equal(areas1.array, areas2.array, decimal=7)
     print('min/max area2 = ',np.min(areas2.array),np.max(areas2.array))
     # But the areas with flux have a larger range (in both directions) because of the BFE
     assert np.min(areas0.array) < np.min(areas2.array)


### PR DESCRIPTION
This PR changes the internal storage of the pixel boundaries from double to single precision.  I made sure everything still uses double precision for all calculations, so there isn't too much loss of precision in the various places.  

This is most important when the sides may add 1 to their positions depending on which side of the square they are on.  If these are done in single precision, there is more loss of precision.  Probably still acceptable, TBH, but it seems prudent to do as much as possible in double precision nonetheless.

Anyway, only one test ended up needing to be relaxed in its precision, and I dug into it and convinced myself that it is unavoidable.  Basically, it's when we first apply the tree rings to all the boundaries, then go back and calculate areas.  This necessarily passes through float storage, so it only ends up accurate at rtol=2e-8.  That seems completely fine to me.