### PR TITLE
Move Silicon recalculation logic to python layer

### DIFF
--- a/examples/demo11.py
+++ b/examples/demo11.py
@@ -217,7 +217,7 @@ def main(argv):
     dvdx = numpy.sin(theta) * pixel_scale
     dvdy = numpy.cos(theta) * pixel_scale
     image_center = full_image.true_center
-    affine = galsim.AffineTransform(dudx, dudy, dvdx, dvdy, origin=full_image.true_center)
+    affine = galsim.AffineTransform(dudx, dudy, dvdx, dvdy, origin=image_center)
 
     # We can also put it on the celestial sphere to give it a bit more realism.
     # The TAN projection takes a (u,v) coordinate system on a tangent plane and projects
@@ -247,9 +247,11 @@ def main(argv):
         # We will need the image position as well, so use the wcs to get that
         image_pos = wcs.toImage(world_pos)
 
-        # We also need this in the tangent plane, which we call "world coordinates" here,
+        # We also need this in the tangent plane, which we call "uv coordinates" here,
         # since the PowerSpectrum class is really defined on that plane, not in (ra,dec).
-        uv_pos = affine.toWorld(image_pos)
+        world_center = wcs.toWorld(image_center)
+        u, v = world_center.project(world_pos)
+        uv_pos = galsim.PositionD(u/galsim.arcsec, v/galsim.arcsec)
 
         # Get the reduced shears and magnification at this point
         g1, g2, mu = ps.getLensing(pos = uv_pos)

--- a/include/galsim/Silicon.h
+++ b/include/galsim/Silicon.h
@@ -65,8 +65,23 @@ namespace galsim
         void addTreeRingDistortions(ImageView<T> target, Position<int> orig_center);
 
         template <typename T>
+        void subtractDelta(ImageView<T> target);
+        template <typename T>
+        void addDelta(ImageView<T> target);
+
+        template <typename T>
+        void initialize(ImageView<T> target, Position<int> orig_center);
+
+        template <typename T>
         double accumulate(const PhotonArray& photons, BaseDeviate rng, ImageView<T> target,
                           Position<int> orig_center, bool resume);
+
+        template <typename T>
+        double accumulate1(const PhotonArray& photons, int i1, int i2,
+                           BaseDeviate rng, ImageView<T> target);
+
+        template <typename T>
+        void update(ImageView<T> target);
 
         double pixelArea(int i, int j, int nx, int ny) const;
 

--- a/include/galsim/Silicon.h
+++ b/include/galsim/Silicon.h
@@ -38,7 +38,7 @@ namespace galsim
     class PUBLIC_API Silicon
     {
     public:
-        Silicon(int numVertices, double numElec, int nx, int ny, int qDist, double nrecalc,
+        Silicon(int numVertices, double numElec, int nx, int ny, int qDist,
                 double diffStep, double pixelSize, double sensorThickness, double* vertex_data,
                 const Table& tr_radial_table, Position<double> treeRingCenter,
                 const Table& abs_length_table, bool transpose);
@@ -73,12 +73,8 @@ namespace galsim
         void initialize(ImageView<T> target, Position<int> orig_center);
 
         template <typename T>
-        double accumulate(const PhotonArray& photons, BaseDeviate rng, ImageView<T> target,
-                          Position<int> orig_center, bool resume);
-
-        template <typename T>
-        double accumulate1(const PhotonArray& photons, int i1, int i2,
-                           BaseDeviate rng, ImageView<T> target);
+        double accumulate(const PhotonArray& photons, int i1, int i2,
+                          BaseDeviate rng, ImageView<T> target);
 
         template <typename T>
         void update(ImageView<T> target);
@@ -263,12 +259,11 @@ namespace galsim
         std::vector<Position<float> > _horizontalDistortions;
         std::vector<Position<float> > _verticalDistortions;
         int _numVertices, _nx, _ny, _nv, _qDist;
-        double _nrecalc, _diffStep, _pixelSize, _sensorThickness;
+        double _diffStep, _pixelSize, _sensorThickness;
         Table _tr_radial_table;
         Position<double> _treeRingCenter;
         Table _abs_length_table;
         bool _transpose;
-        double _added_flux_since_update;
         ImageAlloc<double> _delta;
     };
 

--- a/include/galsim/Silicon.h
+++ b/include/galsim/Silicon.h
@@ -268,7 +268,7 @@ namespace galsim
         Position<double> _treeRingCenter;
         Table _abs_length_table;
         bool _transpose;
-        double _resume_next_recalc;
+        double _added_flux_since_update;
         ImageAlloc<double> _delta;
     };
 

--- a/pysrc/Silicon.cpp
+++ b/pysrc/Silicon.cpp
@@ -25,24 +25,32 @@ namespace galsim {
 
     template <typename T, typename W>
     static void WrapTemplates(W& wrapper) {
-        typedef double (Silicon::*accumulate_fn)(const PhotonArray&, BaseDeviate,
-                                                 ImageView<T>, Position<int>, bool);
+        typedef void (Silicon::*subtract_fn)(ImageView<T>);
+        typedef void (Silicon::*add_fn)(ImageView<T>);
+        typedef void (Silicon::*init_fn)(ImageView<T>, Position<int>);
+        typedef double (Silicon::*accumulate_fn)(const PhotonArray&, int, int, BaseDeviate,
+                                                 ImageView<T>);
+        typedef void (Silicon::*update_fn)(ImageView<T>);
         typedef void (Silicon::*area_fn)(ImageView<T>, Position<int>, bool);
 
+        wrapper.def("subtractDelta", (subtract_fn)&Silicon::subtractDelta);
+        wrapper.def("addDelta", (add_fn)&Silicon::addDelta);
+        wrapper.def("initialize", (init_fn)&Silicon::initialize);
         wrapper.def("accumulate", (accumulate_fn)&Silicon::accumulate);
+        wrapper.def("update", (update_fn)&Silicon::update);
         wrapper.def("fill_with_pixel_areas", (area_fn)&Silicon::fillWithPixelAreas);
     }
 
     static Silicon* MakeSilicon(
         int NumVertices, double NumElect, int Nx, int Ny, int QDist,
-        double Nrecalc, double DiffStep, double PixelSize,
+        double DiffStep, double PixelSize,
         double SensorThickness, size_t idata,
         const Table& treeRingTable, const Position<double>& treeRingCenter,
         const Table& abs_length_table, bool transpose)
     {
         double* data = reinterpret_cast<double*>(idata);
         return new Silicon(NumVertices, NumElect, Nx, Ny, QDist,
-                           Nrecalc, DiffStep, PixelSize, SensorThickness, data,
+                           DiffStep, PixelSize, SensorThickness, data,
                            treeRingTable, treeRingCenter, abs_length_table, transpose);
     }
 

--- a/src/Silicon.cpp
+++ b/src/Silicon.cpp
@@ -870,7 +870,9 @@ namespace galsim {
         double addedFlux = 0.;
 
 #ifdef _OPENMP
-#pragma omp parallel for
+#pragma omp parallel reduction (+:addedFlux)
+        {
+#pragma omp for
 #endif
         for (int i=i1; i<i2; i++) {
             // Get the location where the photon strikes the silicon:
@@ -978,12 +980,14 @@ namespace galsim {
 #pragma omp atomic
 #endif
                 _delta(ix,iy) += flux;
-#ifdef _OPENMP
-#pragma omp atomic
-#endif
+
+                // This isn't atomic -- openmp is handling the reduction for us.
                 addedFlux += flux;
             }
         }
+#ifdef _OPENMP
+        }
+#endif
         return addedFlux;
     }
 

--- a/src/Silicon.cpp
+++ b/src/Silicon.cpp
@@ -804,35 +804,56 @@ namespace galsim {
     }
 
     template <typename T>
-    double Silicon::accumulate(const PhotonArray& photons, BaseDeviate rng, ImageView<T> target,
-                               Position<int> orig_center, bool resume)
+    void Silicon::initialize(ImageView<T> target, Position<int> orig_center)
     {
-        const int nphotons = photons.size();
-
-        // Generate random numbers in advance
-        std::vector<double> conversionDepthRandom(nphotons);
-        std::vector<double> pixelNotFoundRandom(nphotons);
-        std::vector<double> diffStepRandom(nphotons * 2);
-
-        UniformDeviate ud(rng);
-        GaussianDeviate gd(ud, 0, 1);
-
-        for (int i = 0; i < nphotons; i++) {
-            diffStepRandom[i*2] = gd();
-            diffStepRandom[i*2+1] = gd();
-            pixelNotFoundRandom[i] = ud();
-            conversionDepthRandom[i] = ud();
-        }
-
         Bounds<int> b = target.getBounds();
         if (!b.isDefined())
             throw std::runtime_error("Attempting to PhotonArray::addTo an Image with"
                                      " undefined Bounds");
 
+        const int nx = b.getXMax() - b.getXMin() + 1;
+        const int ny = b.getYMax() - b.getYMin() + 1;
+        dbg<<"nx,ny = "<<nx<<','<<ny<<std::endl;
+
+        initializeBoundaryPoints(nx, ny);
+
+        dbg<<"Built poly list\n";
+        // Now we add in the tree ring distortions
+        addTreeRingDistortions(target, orig_center);
+
+        // Start with the correct distortions for the initial image as it is already
+        dbg<<"Initial updatePixelDistortions\n";
+        updatePixelDistortions(target);
+
+        // Keep track of the charge we are accumulating on a separate image for efficiency
+        // of the distortion updates.
+        _delta.resize(b);
+        _delta.setZero();
+    }
+
+    template <typename T>
+    void Silicon::subtractDelta(ImageView<T> target)
+    {
+        target -= _delta;
+    }
+
+    template <typename T>
+    void Silicon::addDelta(ImageView<T> target)
+    {
+        target += _delta;
+    }
+
+    template <typename T>
+    double Silicon::accumulate(const PhotonArray& photons, BaseDeviate rng, ImageView<T> target,
+                               Position<int> orig_center, bool resume)
+    {
+        const int nphotons = photons.size();
+
 #ifdef DEBUGLOGGING
         dbg<<"In Silicon::accumulate\n";
         dbg<<"bounds = "<<b<<std::endl;
         dbg<<"total nphotons = "<<photons.size()<<std::endl;
+        dbg<<"this call nphotons = "<<nphotons<<std::endl;
         dbg<<"hasAllocatedWavelengths = "<<photons.hasAllocatedWavelengths()<<std::endl;
         dbg<<"hasAllocatedAngles = "<<photons.hasAllocatedAngles()<<std::endl;
         double Irr = 0.;
@@ -840,9 +861,6 @@ namespace galsim {
         int zerocount=0, neighborcount=0, misscount=0;
 #endif
 
-        const int nx = b.getXMax() - b.getXMin() + 1;
-        const int ny = b.getYMax() - b.getYMin() + 1;
-        dbg<<"nx,ny = "<<nx<<','<<ny<<std::endl;
         double next_recalc;
         if (resume) {
             // These two tests are now done at the python layer.
@@ -862,157 +880,25 @@ namespace galsim {
             // the last update.  The easiest way to do that is to just subtract off what has
             // been added so far now and just keep adding to the existing _delta image.
             // It will all be added back at the end of this call to accumulate.
-            target -= _delta;
+            subtractDelta(target);
             dbg<<"resume=True.  Use saved next_recalc = "<<next_recalc<<std::endl;
         } else {
-            initializeBoundaryPoints(nx, ny);
-
-            dbg<<"Built poly list\n";
-            // Now we add in the tree ring distortions
-            addTreeRingDistortions(target, orig_center);
-
-            // Start with the correct distortions for the initial image as it is already
-            dbg<<"Initial updatePixelDistortions\n";
-            updatePixelDistortions(target);
-            next_recalc = _nrecalc;
-
-            // Keep track of the charge we are accumulating on a separate image for efficiency
-            // of the distortion updates.
-            _delta.resize(b);
-            _delta.setZero();
+            initialize(target, orig_center);
         }
-        const double invPixelSize = 1./_pixelSize; // pixels/micron
-        const double diffStep_pixel_z = _diffStep / (_sensorThickness * _pixelSize);
-
         double addedFlux = 0.;
-        int startPhoton = 0;
+        int i1 = 0;
 
-        while (startPhoton < nphotons) {
-            // new parallel version of code
+        while (i1 < nphotons) {
 
             // count up how many photos we can use before recalc is needed
-            int photonsUntilRecalc = startPhoton;
+            int i2 = i1;
             double addedFlux1 = addedFlux;
-            while ((photonsUntilRecalc < nphotons) && (addedFlux1 <= next_recalc)) {
-                addedFlux1 += photons.getFlux(photonsUntilRecalc);
-                photonsUntilRecalc++;
+            while ((i2 < nphotons) && (addedFlux1 <= next_recalc)) {
+                addedFlux1 += photons.getFlux(i2);
+                i2++;
             }
 
-#ifdef _OPENMP
-#pragma omp parallel for
-#endif
-            for (int i = startPhoton; i < photonsUntilRecalc; i++) {
-                // Get the location where the photon strikes the silicon:
-                double x0 = photons.getX(i); // in pixels
-                double y0 = photons.getY(i); // in pixels
-                xdbg<<"x0,y0 = "<<x0<<','<<y0;
-
-                double dz = calculateConversionDepth(photons, i, conversionDepthRandom[i]);
-                if (photons.hasAllocatedAngles()) {
-                    double dxdz = photons.getDXDZ(i);
-                    double dydz = photons.getDYDZ(i);
-                    double dz_pixel = dz * invPixelSize;
-                    x0 += dxdz * dz_pixel; // dx in pixels
-                    y0 += dydz * dz_pixel; // dy in pixels
-                }
-                xdbg<<" => "<<x0<<','<<y0;
-                // This is the reverse of depth. zconv is how far above the substrate the e- converts.
-                double zconv = _sensorThickness - dz;
-                if (zconv < 0.0) continue; // Throw photon away if it hits the bottom
-                // TODO: Do something more realistic if it hits the bottom.
-
-                // Now we add in a displacement due to diffusion
-                if (_diffStep != 0.) {
-                    double diffStep = std::max(0.0, diffStep_pixel_z * std::sqrt(zconv * _sensorThickness));
-                    x0 += diffStep * diffStepRandom[i*2];
-                    y0 += diffStep * diffStepRandom[i*2+1];
-                }
-                xdbg<<" => "<<x0<<','<<y0<<std::endl;
-                double flux = photons.getFlux(i);
-
-#ifdef DEBUGLOGGING
-                if (i % 1000 == 0) {
-                    xdbg<<"diffStep = "<<_diffStep<<std::endl;
-                    xdbg<<"zconv = "<<zconv<<std::endl;
-                    xdbg<<"x0 = "<<x0<<std::endl;
-                    xdbg<<"y0 = "<<y0<<std::endl;
-                }
-#endif
-
-                // Now we find the undistorted pixel
-                int ix = int(floor(x0 + 0.5));
-                int iy = int(floor(y0 + 0.5));
-
-#ifdef DEBUGLOGGING
-                int ix0 = ix;
-                int iy0 = iy;
-#endif
-
-                double x = x0 - ix + 0.5;
-                double y = y0 - iy + 0.5;
-                // (ix,iy) are the undistorted pixel coordinates.
-                // (x,y) are the coordinates within the pixel, centered at the lower left
-
-                // First check the obvious choice, since this will usually work.
-                bool off_edge;
-                bool foundPixel;
-                foundPixel = insidePixel(ix, iy, x, y, zconv, target, &off_edge);
-#ifdef DEBUGLOGGING
-                if (foundPixel) ++zerocount;
-#endif
-
-                // If the nominal position is on the edge of the image, off_edge reports whether
-                // the photon has fallen off the edge of the image. In this case, we won't find it in
-                // any of the neighbors either.  Just let the photon fall off the edge in this case.
-                if (!foundPixel && off_edge) continue;
-
-                // Then check neighbors
-                int step;  // We might need this below, so let searchNeighbors return it.
-                if (!foundPixel) {
-                    foundPixel = searchNeighbors(*this, ix, iy, x, y, zconv, target, step);
-#ifdef DEBUGLOGGING
-                    if (foundPixel) ++neighborcount;
-#endif
-                }
-
-                // Rarely, we won't find it in the undistorted pixel or any of the neighboring pixels.
-                // If we do arrive here due to roundoff error of the pixel boundary, put the electron
-                // in the undistorted pixel or the nearest neighbor with equal probability.
-                if (!foundPixel) {
-#ifdef DEBUGLOGGING
-                    dbg<<"Not found in any pixel\n";
-                    dbg<<"x0,y0 = "<<x0<<','<<y0<<std::endl;
-                    dbg<<"b = "<<b<<std::endl;
-                    dbg<<"ix,iy = "<<ix<<','<<iy<<"  x,y = "<<x<<','<<y<<std::endl;
-                    set_verbose(2);
-                    bool off_edge;
-                    insidePixel(ix, iy, x, y, zconv, target, &off_edge);
-                    searchNeighbors(*this, ix, iy, x, y, zconv, target, step);
-                    set_verbose(1);
-                    ++misscount;
-#endif
-                    int n = (pixelNotFoundRandom[i] > 0.5) ? 0 : step;
-                    ix = ix + xoff[n];
-                    iy = iy + yoff[n];
-                }
-
-                if (b.includes(ix,iy)) {
-#ifdef DEBUGLOGGING
-                    double rsq = (ix+0.5)*(ix+0.5)+(iy+0.5)*(iy+0.5);
-                    Irr += flux * rsq;
-                    rsq = (ix0+0.5)*(ix0+0.5)+(iy0+0.5)*(iy0+0.5);
-                    Irr0 += flux * rsq;
-#endif
-#ifdef _OPENMP
-#pragma omp atomic
-#endif
-                    _delta(ix,iy) += flux;
-#ifdef _OPENMP
-#pragma omp atomic
-#endif
-                    addedFlux += flux;
-                }
-            }
+            addedFlux += accumulate1(photons, i1, i2, rng, target);
 
             // Update shapes every _nrecalc electrons
             if (addedFlux > next_recalc) {
@@ -1023,11 +909,11 @@ namespace galsim {
                 next_recalc = addedFlux + _nrecalc;
             }
 
-            startPhoton = photonsUntilRecalc;
+            i1 = i2;
         }
 
         // No need to update the distortions again, but we do need to add the delta image.
-        target += _delta;
+        addDelta(target);
         _resume_next_recalc = next_recalc - addedFlux;
         dbg<<"All done.  Added flux "<<addedFlux<<".  Save next_recalc = "<<_resume_next_recalc<<std::endl;
 
@@ -1040,6 +926,158 @@ namespace galsim {
         dbg << " not in any pixel\n" << std::endl;
 #endif
         return addedFlux;
+    }
+
+    template <typename T>
+    double Silicon::accumulate1(const PhotonArray& photons, int i1, int i2,
+                                BaseDeviate rng, ImageView<T> target)
+    {
+        const int nphotons = i2 - i1;
+
+        // Generate random numbers in advance
+        std::vector<double> conversionDepthRandom(nphotons);
+        std::vector<double> pixelNotFoundRandom(nphotons);
+        std::vector<double> diffStepRandom(nphotons * 2);
+
+        UniformDeviate ud(rng);
+        GaussianDeviate gd(ud, 0, 1);
+
+        for (int i=0; i<nphotons; i++) {
+            diffStepRandom[i*2] = gd();
+            diffStepRandom[i*2+1] = gd();
+            pixelNotFoundRandom[i] = ud();
+            conversionDepthRandom[i] = ud();
+        }
+
+        const double invPixelSize = 1./_pixelSize; // pixels/micron
+        const double diffStep_pixel_z = _diffStep / (_sensorThickness * _pixelSize);
+        Bounds<int> b = target.getBounds();
+        double addedFlux = 0.;
+
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+        for (int i=i1; i<i2; i++) {
+            // Get the location where the photon strikes the silicon:
+            double x0 = photons.getX(i); // in pixels
+            double y0 = photons.getY(i); // in pixels
+            xdbg<<"x0,y0 = "<<x0<<','<<y0;
+
+            double dz = calculateConversionDepth(photons, i, conversionDepthRandom[i-i1]);
+            if (photons.hasAllocatedAngles()) {
+                double dxdz = photons.getDXDZ(i);
+                double dydz = photons.getDYDZ(i);
+                double dz_pixel = dz * invPixelSize;
+                x0 += dxdz * dz_pixel; // dx in pixels
+                y0 += dydz * dz_pixel; // dy in pixels
+            }
+            xdbg<<" => "<<x0<<','<<y0;
+            // This is the reverse of depth. zconv is how far above the substrate the e- converts.
+            double zconv = _sensorThickness - dz;
+            if (zconv < 0.0) continue; // Throw photon away if it hits the bottom
+            // TODO: Do something more realistic if it hits the bottom.
+
+            // Now we add in a displacement due to diffusion
+            if (_diffStep != 0.) {
+                double diffStep = std::max(0.0, diffStep_pixel_z * std::sqrt(zconv * _sensorThickness));
+                x0 += diffStep * diffStepRandom[(i-i1)*2];
+                y0 += diffStep * diffStepRandom[(i-i1)*2+1];
+            }
+            xdbg<<" => "<<x0<<','<<y0<<std::endl;
+            double flux = photons.getFlux(i);
+
+#ifdef DEBUGLOGGING
+            if (i % 1000 == 0) {
+                xdbg<<"diffStep = "<<_diffStep<<std::endl;
+                xdbg<<"zconv = "<<zconv<<std::endl;
+                xdbg<<"x0 = "<<x0<<std::endl;
+                xdbg<<"y0 = "<<y0<<std::endl;
+            }
+#endif
+
+            // Now we find the undistorted pixel
+            int ix = int(floor(x0 + 0.5));
+            int iy = int(floor(y0 + 0.5));
+
+#ifdef DEBUGLOGGING
+            int ix0 = ix;
+            int iy0 = iy;
+#endif
+
+            double x = x0 - ix + 0.5;
+            double y = y0 - iy + 0.5;
+            // (ix,iy) are the undistorted pixel coordinates.
+            // (x,y) are the coordinates within the pixel, centered at the lower left
+
+            // First check the obvious choice, since this will usually work.
+            bool off_edge;
+            bool foundPixel;
+            foundPixel = insidePixel(ix, iy, x, y, zconv, target, &off_edge);
+#ifdef DEBUGLOGGING
+            if (foundPixel) ++zerocount;
+#endif
+
+            // If the nominal position is on the edge of the image, off_edge reports whether
+            // the photon has fallen off the edge of the image. In this case, we won't find it in
+            // any of the neighbors either.  Just let the photon fall off the edge in this case.
+            if (!foundPixel && off_edge) continue;
+
+            // Then check neighbors
+            int step;  // We might need this below, so let searchNeighbors return it.
+            if (!foundPixel) {
+                foundPixel = searchNeighbors(*this, ix, iy, x, y, zconv, target, step);
+#ifdef DEBUGLOGGING
+                if (foundPixel) ++neighborcount;
+#endif
+            }
+
+            // Rarely, we won't find it in the undistorted pixel or any of the neighboring pixels.
+            // If we do arrive here due to roundoff error of the pixel boundary, put the electron
+            // in the undistorted pixel or the nearest neighbor with equal probability.
+            if (!foundPixel) {
+#ifdef DEBUGLOGGING
+                dbg<<"Not found in any pixel\n";
+                dbg<<"x0,y0 = "<<x0<<','<<y0<<std::endl;
+                dbg<<"b = "<<b<<std::endl;
+                dbg<<"ix,iy = "<<ix<<','<<iy<<"  x,y = "<<x<<','<<y<<std::endl;
+                set_verbose(2);
+                bool off_edge;
+                insidePixel(ix, iy, x, y, zconv, target, &off_edge);
+                searchNeighbors(*this, ix, iy, x, y, zconv, target, step);
+                set_verbose(1);
+                ++misscount;
+#endif
+                int n = (pixelNotFoundRandom[i-i1] > 0.5) ? 0 : step;
+                ix = ix + xoff[n];
+                iy = iy + yoff[n];
+            }
+
+            if (b.includes(ix,iy)) {
+#ifdef DEBUGLOGGING
+                double rsq = (ix+0.5)*(ix+0.5)+(iy+0.5)*(iy+0.5);
+                Irr += flux * rsq;
+                rsq = (ix0+0.5)*(ix0+0.5)+(iy0+0.5)*(iy0+0.5);
+                Irr0 += flux * rsq;
+#endif
+#ifdef _OPENMP
+#pragma omp atomic
+#endif
+                _delta(ix,iy) += flux;
+#ifdef _OPENMP
+#pragma omp atomic
+#endif
+                addedFlux += flux;
+            }
+        }
+        return addedFlux;
+    }
+
+    template <typename T>
+    void Silicon::update(ImageView<T> target)
+    {
+        updatePixelDistortions(_delta.view());
+        target += _delta;
+        _delta.setZero();
     }
 
     int SetOMPThreads(int num_threads)
@@ -1074,12 +1112,23 @@ namespace galsim {
     template void Silicon::addTreeRingDistortions(ImageView<float> target,
                                                   Position<int> orig_center);
 
+    template void Silicon::subtractDelta(ImageView<double> target);
+    template void Silicon::subtractDelta(ImageView<float> target);
+    template void Silicon::addDelta(ImageView<double> target);
+    template void Silicon::addDelta(ImageView<float> target);
+
+    template void Silicon::initialize(ImageView<double> target, Position<int> orig_center);
+    template void Silicon::initialize(ImageView<float> target, Position<int> orig_center);
+
     template double Silicon::accumulate(const PhotonArray& photons, BaseDeviate rng,
                                         ImageView<double> target, Position<int> orig_center,
                                         bool resume);
     template double Silicon::accumulate(const PhotonArray& photons, BaseDeviate rng,
                                         ImageView<float> target, Position<int> orig_center,
                                         bool resume);
+
+    template void Silicon::update(ImageView<double> target);
+    template void Silicon::update(ImageView<float> target);
 
     template void Silicon::fillWithPixelAreas(ImageView<double> target, Position<int> orig_center,
                                               bool);

--- a/src/Silicon.cpp
+++ b/src/Silicon.cpp
@@ -892,8 +892,9 @@ namespace galsim {
 
             // count up how many photos we can use before recalc is needed
             int photonsUntilRecalc = startPhoton;
-            while ((photonsUntilRecalc < nphotons) && (addedFlux <= next_recalc)) {
-                addedFlux += photons.getFlux(photonsUntilRecalc);
+            double addedFlux1 = addedFlux;
+            while ((photonsUntilRecalc < nphotons) && (addedFlux1 <= next_recalc)) {
+                addedFlux1 += photons.getFlux(photonsUntilRecalc);
                 photonsUntilRecalc++;
             }
 
@@ -1006,8 +1007,10 @@ namespace galsim {
 #pragma omp atomic
 #endif
                     _delta(ix,iy) += flux;
-
-                    // no longer need to update addedFlux as it's done before this loop
+#ifdef _OPENMP
+#pragma omp atomic
+#endif
+                    addedFlux += flux;
                 }
             }
 

--- a/tests/run_examples.py
+++ b/tests/run_examples.py
@@ -325,11 +325,17 @@ def test_des():
     run to completion without errors.
     """
     original_dir = os.getcwd()
+
     try:
         os.chdir('des')
         new_dir = os.getcwd()
         if new_dir not in sys.path:
             sys.path.append(new_dir)
+
+        if not os.path.exists('des_data'):
+            print('The des tests require the des_data directory.')
+            print('Download from http://www.sas.upenn.edu/~mjarvis/des_data.tar.gz')
+            return
 
         import draw_psf
         print('Running draw_psf.py')


### PR DESCRIPTION
This PR moves all the logic of when to do the pixel updates from the C++ accumulate function to the python layer function.

This should make it much simpler for us to adjust how this is done when we are accumulating over the whole image at once rather than just doing one object at a time.  But so far I haven't changed any logic -- just made the appropriate hooks available in python.