### PR TITLE
Add feature to allow registration of templates

### DIFF
--- a/galsim/config/process.py
+++ b/galsim/config/process.py
@@ -170,7 +170,13 @@ def ProcessTemplate(config, base, logger=None):
         # Copy over the template config into this one.
         new_params = config.copy()  # N.B. Already popped config['template'].
         config.clear()
+
         config.update(template)
+
+        if 'modules' in config:
+            # We want to keep all the modules from either place in the config dict
+            # so things like Eval can import everything that might be needed.
+            config['modules'].extend(new_params.pop('modules', []))
 
         # Update the config with the requested changes
         UpdateConfig(config, new_params)

--- a/galsim/config/process.py
+++ b/galsim/config/process.py
@@ -140,10 +140,18 @@ def ProcessTemplate(config, base, logger=None):
         base:           The base configuration dict.
         logger:         If given, a logger object to log progress. [default: None]
     """
+    from .value_eval import _GenerateFromEval
+
     logger = LoggerWrapper(logger)
     if 'template' in config:
         template_string = config.pop('template')
         logger.debug("Processing template specified as %s",template_string)
+
+        # Allow it to be an Eval.  We don't have much set up yet in the config dict,
+        # but really simple Eval strings should still be workable.
+        if template_string[0] == '$':
+            temp_config = { 'type': 'Eval', 'str': template_string[1:] }
+            template_string = _GenerateFromEval(temp_config, base, str)[0]
 
         # Parse the template string
         if ':' in template_string:

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -1,12 +1,6 @@
 [run]
 branch = True
 
-include = *galsim/*
-
-omit =
-    # This is a utility for tracking down OSErrors.  Don't include in coverage.
-    *fds_test.py
-
 # Without this, coverage misses anything that is only run in multiprocessing mode.
 concurrency = multiprocessing
 

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -1,6 +1,8 @@
 [run]
 branch = True
 
+include = *galsim/*
+
 # Without this, coverage misses anything that is only run in multiprocessing mode.
 concurrency = multiprocessing
 

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,4 +1,4 @@
-.coverage
+.coverage*
 output_fits
 output_psf
 test.pstats

--- a/tests/config_input/multirng.yaml
+++ b/tests/config_input/multirng.yaml
@@ -17,6 +17,9 @@
 #
 
 
+modules:
+    - numpy
+
 psf:
     type: Moffat
     beta: 2

--- a/tests/template_register.py
+++ b/tests/template_register.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2012-2021 by the GalSim developers team on GitHub
+# https://github.com/GalSim-developers
+#
+# This file is part of GalSim: The modular galaxy image simulation toolkit.
+# https://github.com/GalSim-developers/GalSim
+#
+# GalSim is free software: redistribution and use in source and binary forms,
+# with or without modification, are permitted provided that the following
+# conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions, and the disclaimer given in the accompanying LICENSE
+#    file.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions, and the disclaimer given in the documentation
+#    and/or other materials provided with the distribution.
+#
+
+import galsim
+
+# Used by test_template in test_config_image.py
+galsim.config.RegisterTemplate('multirng', 'config_input/multirng.yaml')

--- a/tests/test_config_image.py
+++ b/tests/test_config_image.py
@@ -2237,7 +2237,7 @@ def test_template():
             ]
         }
     }
-    config = copy.deepcopy(config1)  # Leave config1 as the original given above.
+    config = config1.copy()  # Leave config1 as the original given above.
     config2 = galsim.config.ReadConfig('config_input/multirng.yaml')[0]
 
     galsim.config.ProcessAllTemplates(config)

--- a/tests/test_config_image.py
+++ b/tests/test_config_image.py
@@ -2207,6 +2207,9 @@ def test_template():
         # This copies everything, but we'll override a few things
         "template" : "config_input/multirng.yaml",
 
+        # Modules works differently from the others.  Here, we want to concatenate the lists.
+        "modules" : ["astropy"],
+
         # Specific fields can be overridden
         "output" : { "file_name" : "test_template.fits" },
 
@@ -2259,6 +2262,8 @@ def test_template():
                                           "ellip": { "type" : "PowerSpectrumShear", "num" : 0 } }
     assert config['psf']['items'][1] == { "type": "Gaussian", "sigma" : 0.3 }
     assert config['psf']['items'][2] == { "type": "Gaussian", "sigma" : 0.4 }
+
+    assert config['modules'] == ['numpy', 'astropy']
 
     # Test registering the template.
     galsim.config.RegisterTemplate('multirng', 'config_input/multirng.yaml')

--- a/tests/test_config_image.py
+++ b/tests/test_config_image.py
@@ -2203,7 +2203,7 @@ def test_template():
     """Test various uses of the template keyword
     """
     # Use the multirng.yaml config file from the above test as a convenient template source
-    config = {
+    config1 = {
         # This copies everything, but we'll override a few things
         "template" : "config_input/multirng.yaml",
 
@@ -2237,6 +2237,7 @@ def test_template():
             ]
         }
     }
+    config = copy.deepcopy(config1)  # Leave config1 as the original given above.
     config2 = galsim.config.ReadConfig('config_input/multirng.yaml')[0]
 
     galsim.config.ProcessAllTemplates(config)
@@ -2258,6 +2259,25 @@ def test_template():
                                           "ellip": { "type" : "PowerSpectrumShear", "num" : 0 } }
     assert config['psf']['items'][1] == { "type": "Gaussian", "sigma" : 0.3 }
     assert config['psf']['items'][2] == { "type": "Gaussian", "sigma" : 0.4 }
+
+    # Test registering the template.
+    galsim.config.RegisterTemplate('multirng', 'config_input/multirng.yaml')
+    config3 = config1.copy()
+    config3['template'] = 'multirng'
+
+    galsim.config.ProcessAllTemplates(config3)
+    assert config3 == config
+
+    # Make sure template works when registered in a user module
+    del galsim.config.process.valid_templates['multirng']
+    config4 = config1.copy()
+    config4['template'] = 'multirng'
+    config4['modules'] = ['template_register']
+    galsim.config.ImportModules(config4)
+    galsim.config.ProcessAllTemplates(config4)
+    for field in ['image', 'output', 'gal', 'psf']:
+        assert config4[field] == config[field]
+
 
 @timer
 def test_variable_cat_size():

--- a/tests/test_config_image.py
+++ b/tests/test_config_image.py
@@ -2283,6 +2283,13 @@ def test_template():
     for field in ['image', 'output', 'gal', 'psf']:
         assert config4[field] == config[field]
 
+    # Check a simple Eval string
+    config5 = config1.copy()
+    config5['template'] = '$"gnritlum"[::-1]'
+    galsim.config.ProcessAllTemplates(config5)
+    for key in config:
+        assert config5[key] == config[key]
+
 
 @timer
 def test_variable_cat_size():


### PR DESCRIPTION
This PR adds the option to register template names, so people can use that rather than a file name.

The target use case is imSim, so it can register names like 'dc2_image' or 'flat_field', etc., which could point to a config file in the imSim repo.  This file location is likely to be slightly obscure, so having a comprehensible alias would be both easier for the user and more portable across platforms.