### PR TITLE
Persist pupil samples uv in photon array

### DIFF
--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -586,7 +586,7 @@ class ChromaticObject:
         if not photon_array.hasAllocatedWavelengths():
             raise GalSimError("Using ChromaticObject as a PhotonOp requires wavelengths be set")
         p1 = PhotonArray(len(photon_array))
-        p1.wavelength = photon_array.wavelength
+        p1._wave = photon_array._wave
         obj = local_wcs.toImage(self) if local_wcs is not None else self
         rng = BaseDeviate(rng)
         obj._shoot(p1, rng)

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -1566,8 +1566,9 @@ class PhaseScreenPSF(GSObject):
         ud.generate(pick)
         pick *= len(u)
         pick = pick.astype(int)
-        u = u[pick]
-        v = v[pick]
+        # abuse dxdz and dydz to persist u and v
+        u = photons.dxdz = u[pick]
+        v = photons.dydz = v[pick]
 
         # This is where the screens need to be instantiated for drawing with geometric photon
         # shooting.

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -1566,9 +1566,8 @@ class PhaseScreenPSF(GSObject):
         ud.generate(pick)
         pick *= len(u)
         pick = pick.astype(int)
-        # abuse dxdz and dydz to persist u and v
-        u = photons.dxdz = u[pick]
-        v = photons.dydz = v[pick]
+        u = photons.pupil_u = u[pick]
+        v = photons.pupil_v = v[pick]
 
         # This is where the screens need to be instantiated for drawing with geometric photon
         # shooting.

--- a/galsim/photon_array.py
+++ b/galsim/photon_array.py
@@ -331,6 +331,15 @@ class PhotonArray:
         if rhs.size() != self.size():
             raise GalSimIncompatibleValuesError("PhotonArray.convolve with unequal size arrays",
                                                 self_pa=self, rhs=rhs)
+        if rhs.hasAllocatedAngles():
+            if self.hasAllocatedAngles():
+                raise GalSimIncompatibleValuesError(
+                    "PhotonArray.convolve with doubly assigned angles"
+                )
+            else:
+                self.dxdz = rhs.dxdz
+                self.dydz = rhs.dydz
+
         rng = BaseDeviate(rng)
         self._pa.convolve(rhs._pa, rng._rng)
 

--- a/galsim/photon_array.py
+++ b/galsim/photon_array.py
@@ -340,6 +340,15 @@ class PhotonArray:
                 self.dxdz = rhs.dxdz
                 self.dydz = rhs.dydz
 
+        if rhs.hasAllocatedWavelengths():
+            if self.hasAllocatedWavelengths():
+                if self._wave is not rhs._wave:
+                    raise GalSimIncompatibleValuesError(
+                        "PhotonArray.convolve with doubly assigned wavelengths"
+                    )
+            else:
+                self.wavelength = rhs.wavelength
+
         rng = BaseDeviate(rng)
         self._pa.convolve(rhs._pa, rng._rng)
 

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -1465,14 +1465,16 @@ def test_uv_persistence():
             diam=diam, obscuration=obscuration, nstruts=nstruts, strut_thick=strut_thick,
             strut_angle=strut_angle, pupil_plane_scale=diam/20
         )
-
-        allowed = set(zip(aper.u_illuminated, aper.v_illuminated))
+        with assert_warns(galsim.GalSimWarning):
+            allowed = set(zip(aper.u_illuminated, aper.v_illuminated))
 
         psf = galsim.OpticalPSF(lam=500, diam=diam, aper=aper, geometric_shooting=True)
         photons = psf.drawImage(save_photons=True, method='phot', n_photons=1000000).photons
-        observed = set(zip(photons.dxdz, photons.dydz))
+        observed = set(zip(photons.pupil_u, photons.pupil_v))
 
         assert observed.issubset(allowed)
+
+        do_pickle(photons)
 
 
 if __name__ == "__main__":

--- a/tests/test_photon_array.py
+++ b/tests/test_photon_array.py
@@ -304,7 +304,7 @@ def test_convolve():
     pa4 = galsim.PhotonArray(50, pa1.x[:50], pa1.y[:50], pa1.flux[:50])
     assert_raises(galsim.GalSimError, pa1.convolve, pa4)
 
-    # Check propagation of dxdz, dydz
+    # Check propagation of dxdz, dydz, wavelength
     pa1 = obj.shoot(nphotons, rng)
     pa2 = obj.shoot(nphotons, rng)
     dxdz = np.linspace(-0.1, 0.1, nphotons)
@@ -316,6 +316,21 @@ def test_convolve():
     np.testing.assert_array_equal(pa2.dxdz, dxdz)
 
     # both have angles now...
+    with assert_raises(galsim.GalSimIncompatibleValuesError):
+        pa1.convolve(pa2)
+
+    # repeat for wavelengths
+    pa1 = obj.shoot(nphotons, rng)
+    pa2 = obj.shoot(nphotons, rng)
+    wavelength = np.linspace(500, 900, nphotons)
+    pa1.wavelength = wavelength
+    pa1.convolve(pa2)
+    np.testing.assert_array_equal(pa1.wavelength, wavelength)
+    assert not pa2.hasAllocatedWavelengths()
+    pa2.convolve(pa1)
+    np.testing.assert_array_equal(pa2.wavelength, wavelength)
+
+    # both have wavelengths now...
     with assert_raises(galsim.GalSimIncompatibleValuesError):
         pa1.convolve(pa2)
 

--- a/tests/test_photon_array.py
+++ b/tests/test_photon_array.py
@@ -304,6 +304,21 @@ def test_convolve():
     pa4 = galsim.PhotonArray(50, pa1.x[:50], pa1.y[:50], pa1.flux[:50])
     assert_raises(galsim.GalSimError, pa1.convolve, pa4)
 
+    # Check propagation of dxdz, dydz
+    pa1 = obj.shoot(nphotons, rng)
+    pa2 = obj.shoot(nphotons, rng)
+    dxdz = np.linspace(-0.1, 0.1, nphotons)
+    pa1.dxdz = dxdz
+    pa1.convolve(pa2)
+    np.testing.assert_array_equal(pa1.dxdz, dxdz)
+    assert not pa2.hasAllocatedAngles()
+    pa2.convolve(pa1)
+    np.testing.assert_array_equal(pa2.dxdz, dxdz)
+
+    # both have angles now...
+    with assert_raises(galsim.GalSimIncompatibleValuesError):
+        pa1.convolve(pa2)
+
 
 @timer
 def test_wavelength_sampler():


### PR DESCRIPTION
Abuses the `PhotonArray.dxdz` and `.dydz` attributes to hold onto pupil samples generated by `PhaseScreenPsf._shoot`.

I realized along the way that we may wish/need to propagate these values forwards through photon array convolutions, so the rule is if exactly 1 convolutant has `.dxdz` or `.dydz`, then the result will just get the same values.  If more than one convolutant has these attributes, then an exception is raised.

I went ahead and also implemented similar logic for wavelengths, except in this case, GalSim already had a case where two photon arrays with populated wavelength arrays would be convolved; in `ChromaticObject.applyTo`.  Here, it's actually innocuous, since the two photon arrays will have the _same_ wavelength arrays by construction.  So to allow this code to continue as is, I also decided to permit convolution of two photon arrays both with populated wavelength arrays as long as those arrays are identical (via the python `is` operator).