### PR TITLE
Improve checks in GSParams.checks

### DIFF
--- a/galsim/gsparams.py
+++ b/galsim/gsparams.py
@@ -181,7 +181,13 @@ class GSParams:
         (GSParams.default if no other default specified).
         """
         if gsparams is None:
-            gsparams = default if default is not None else GSParams.default
+            if default is not None:
+                if isinstance(default, GSParams):
+                    gsparams = default 
+                else:
+                    TypeError("Invalid default GSParams: %s"%default)
+            else:
+                gsparams = GSParams.default
         elif not isinstance(gsparams, GSParams):
             raise TypeError("Invalid GSParams: %s"%gsparams)
         return gsparams.withParams(**kwargs)

--- a/galsim/gsparams.py
+++ b/galsim/gsparams.py
@@ -185,7 +185,7 @@ class GSParams:
                 if isinstance(default, GSParams):
                     gsparams = default 
                 else:
-                    TypeError("Invalid default GSParams: %s"%default)
+                    raise TypeError("Invalid default GSParams: %s"%default)
             else:
                 gsparams = GSParams.default
         elif not isinstance(gsparams, GSParams):


### PR DESCRIPTION
While working on https://github.com/GalSim-developers/JAX-GalSim/pull/7 @ismael-mendoza found that the following would trigger an exception, not correctly captured:
```python
import galsim
galsim.GSParams.check(None, default="anything not a GSParams")
```
This small PR adds a check that the default is indeed a GSParams instance. 

I would have added a test for this, but I couldn't find a file with dedicated gsparams tests, what would be a good place for that?
