### PR TITLE
Add option to have InterpolatedImage de-pixelize the image

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,8 +26,6 @@ API Changes
 
 - Changed SincInterpolant.ixrange to be consistent with the value of xrange, rather than inf.
   (#1154)
-- Let `expand` method of a `galsim.Bounds` instance take an optional second argument to scale
-  differently in different directions. (#1155)
 
 
 Config Updates
@@ -38,7 +36,11 @@ Config Updates
 New Features
 ------------
 
-- Added Image methods: tranpose, flip_ud, flip_lr, rot_cw, rot_ccw, rot_180. (#1139)
+- Added methods `Image.tranpose`, `Image.flip_ud`, `Image.flip_lr`, `Image.rot_cw`,
+  `Image.rot_ccw`, and `Image.rot_180`. (#1139)
+- Added `Image.depixelize` and ``depixelize=True`` option for `InterpolatedImage`. (#1154)
+- Let `expand` method of a `galsim.Bounds` instance take an optional second argument to scale
+  differently in different directions. (#1155)
 
 
 Performance Improvements

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,9 +24,10 @@ Dependency Changes
 API Changes
 -----------
 
+- Changed SincInterpolant.ixrange to be consistent with the value of xrange, rather than inf.
+  (#1154)
 - Let `expand` method of a `galsim.Bounds` instance take an optional second argument to scale
   differently in different directions. (#1155)
-
 
 
 Config Updates

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,8 @@ Dependency Changes
 API Changes
 -----------
 
-- `expand` method of a `galsim.Bounds` instance can take an optional second argument and scale differently in different directions. (#1155)
+- Let `expand` method of a `galsim.Bounds` instance take an optional second argument to scale
+  differently in different directions. (#1155)
 
 
 
@@ -47,4 +48,6 @@ Performance Improvements
 Bug Fixes
 ---------
 
+- Fixed error in InterpolatedImage.withGSParams not correctly updating stepk and maxk
+  if the updated parameters merited it. (#1154)
 - Fix error in ChromaticSum photon shooting when n_photons is explicitly given. (#1156)

--- a/galsim/gsparams.py
+++ b/galsim/gsparams.py
@@ -199,6 +199,7 @@ class GSParams:
                 if not hasattr(ret, '_' + k):
                     raise TypeError('parameter %s is invalid'%k)
                 setattr(ret, '_' + k, kwargs[k])
+            ret._gsp = _galsim.GSParams(*ret._getinitargs())
             return ret
 
     @staticmethod
@@ -230,7 +231,7 @@ class GSParams:
 
     # Define once the order of args in __init__, since we use it a few times.
     def _getinitargs(self):
-        return (self.minimum_fft_size, self.maximum_fft_size,
+        return (int(self.minimum_fft_size), int(self.maximum_fft_size),
                 self.folding_threshold, self.stepk_minimum_hlr, self.maxk_threshold,
                 self.kvalue_accuracy, self.xvalue_accuracy, self.table_spacing,
                 self.realspace_relerr, self.realspace_abserr,

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -1875,15 +1875,28 @@ class Image:
     def depixelize(self, x_interpolant):
         """Return a depixelized version of the image.
 
-        Specifically, this function creates an image that could be used with InterpolatedImage
+        Specifically, this function creates an image that could be used with `InterpolatedImage`
         with the given x_interpolant, which when drawn with method=auto would produce the
         current image.
 
             >>> alt_image = image.depixelize(x_interpolant)
             >>> ii = galsim.InterpolatedImage(alt_image, x_interpolant=x_interpolant)
-            >>> image2 = ii.drawImage(image.copy())
+            >>> image2 = ii.drawImage(image.copy(), method='auto')
 
         image2 will end up approximately equalt to the original image.
+
+        .. warning::
+
+            This function is fairly expensive, both in memory and CPU time, so it should
+            only be called on fairly small images (~100x100 or smaller typically).
+            The memory requirement scales as Npix^2, and the execution time scales as Npix^3.
+
+        Parameters:
+            x_interpolant:  The `Interpolant` to use in the `InterpolatedImage` to describe
+                            how the profile should be interpolated between the pixel centers.
+
+        Returns:
+            an `Image` representing the underlying profile without the pixel convolution.
         """
         ny, nx = self.array.shape
         npix = nx * ny

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -1902,12 +1902,12 @@ class Image:
         npix = nx * ny
 
         # Each kernel is the integral of the interpolant over 1 pixel.
-        kernels = x_interpolant.unit_integrals(max_len=max(nx,ny))
+        unit_integrals = x_interpolant.unit_integrals(max_len=max(nx,ny))
 
         # The rest of the implementation is done in C++.  cf. src/Image.cpp
         im2 = self.copy()
-        _kernels = kernels.__array_interface__['data'][0]
-        _galsim.depixelizeImage(im2._image, _kernels, kernels.size)
+        _unit_integrals = unit_integrals.__array_interface__['data'][0]
+        _galsim.depixelizeImage(im2._image, _unit_integrals, unit_integrals.size)
         return im2
 
     def __eq__(self, other):

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -1883,7 +1883,7 @@ class Image:
             >>> ii = galsim.InterpolatedImage(alt_image, x_interpolant=x_interpolant)
             >>> image2 = ii.drawImage(image.copy(), method='auto')
 
-        image2 will end up approximately equalt to the original image.
+        image2 will end up approximately equal to the original image.
 
         .. warning::
 

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -1885,56 +1885,17 @@ class Image:
 
         image2 will end up approximately equalt to the original image.
         """
-        import time
-        t0 = time.time()
         ny, nx = self.array.shape
         npix = nx * ny
 
         # kernel is the integral of the interpolant over 1 pixel.
         kernel = x_interpolant.unit_integrals(max_len=max(nx,ny))
 
-        # Matrix equation A x = b.
-        # b are the given pixel values in the input image.
-        # x are the desired pixel values in the returned image.
-        # The elements of A are the integral of the interpolant over x and y directions
-        # for pixels that are within ixrange in both directions.
-        A = np.zeros((npix, npix))
-        nk = len(kernel)
-        for row in range(npix):
-            h = row % nx
-            k = row // nx
-            for q in range(k-nk+1, k+nk):
-                if q < 0 or q >= ny: continue
-                for p in range(h-nk+1, h+nk):
-                    if p < 0 or p >= nx: continue
-                    col = q*nx + p
-                    A[row, col] += kernel[abs(p-h)] * kernel[abs(q-k)]
-                    #print(h,k,p,q,row,col,A[row,col])
-            #print('b: ',h,k,self.array.ravel()[row])
-
-        # Solve for x.
-        x = np.linalg.solve(A, self.array.ravel())
-        for row in range(npix):
-            h = row % nx
-            k = row // nx
-            #print('final: ',h,k,x[row])
-
-        t1 = time.time()
+        # The rest of the implementation is done in C++.  cf. src/Image.cpp
         im2 = self.copy()
-        #print('kernel.dtype = ',kernel.dtype)
-        #print('kernel = ',kernel)
         _kernel = kernel.__array_interface__['data'][0]
         _galsim.depixelizeImage(im2._image, _kernel, kernel.size)
-        #print('x = ',x)
-        #print('x2 = ',im2.array.ravel())
-        #print('x[mid] = ',x[npix//2-5:npix//2+5])
-        #print('x2[mid] = ',im2.array.ravel()[npix//2-5:npix//2+5])
-        t2 = time.time()
-        print('times: ',t1-t0,t2-t1)
         return im2
-
-        # Return the result as an Image with the same bounds, wcs as self.
-        return _Image(x.reshape(self.array.shape), self.bounds, self.wcs)
 
     def __eq__(self, other):
         # Note that numpy.array_equal can return True if the dtypes of the two arrays involved are

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -1900,7 +1900,7 @@ class Image:
         rev = dict(zip(zip(allh,allk), range(npix)))
 
         # kernel is the integral of the interpolant over 1 pixel.
-        n = min((x_interpolant.ixrange+1)//2, nx, ny)
+        n = (x_interpolant.ixrange+1)//2
         kernel = np.zeros(n+1)
         for i in range(n+1):
             kernel[i] = int1d(x_interpolant.xval, i-0.5, i+0.5)

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -1813,6 +1813,14 @@ class Image:
 
     __ror__ = __or__
 
+    def __ior__(self, other):
+        self.check_image_consistency(other, integer=True)
+        try:
+            self.array[:,:] |= other.array
+        except AttributeError:
+            self.array[:,:] |= other
+        return self
+
     def transpose(self):
         """Return the tranpose of the image.
 
@@ -1863,14 +1871,6 @@ class Image:
         If you care about the wcs, you will need to set it yourself.
         """
         return _Image(self.array[::-1,::-1], self._bounds, None)
-
-    def __ior__(self, other):
-        self.check_image_consistency(other, integer=True)
-        try:
-            self.array[:,:] |= other.array
-        except AttributeError:
-            self.array[:,:] |= other
-        return self
 
     def __eq__(self, other):
         # Note that numpy.array_equal can return True if the dtypes of the two arrays involved are

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -1891,6 +1891,15 @@ class Image:
             only be called on fairly small images (~100x100 or smaller typically).
             The memory requirement scales as Npix^2, and the execution time scales as Npix^3.
 
+            However, the expensive part of the calculation is independent of the image values.
+            It only depends on the size of the image and interpolant being used.  So this part
+            of the calculation is cached and reused if possible.  If you make repeated calls
+            to depixelize using the same image size and interpolant, it will be much faster
+            after the first call.
+
+            If you need to release the cache (since it can be a non-trivial amount of memory),
+            you may do so using `Image.clear_depixelize_cache`.
+
         Parameters:
             x_interpolant:  The `Interpolant` to use in the `InterpolatedImage` to describe
                             how the profile should be interpolated between the pixel centers.
@@ -1909,6 +1918,12 @@ class Image:
         _unit_integrals = unit_integrals.__array_interface__['data'][0]
         _galsim.depixelizeImage(im2._image, _unit_integrals, unit_integrals.size)
         return im2
+
+    @staticmethod
+    def clear_depixelize_cache():
+        """Release the cached solver used by depixelize to make repeated calls more efficient.
+        """
+        _galsim.ClearDepixelizeCache()
 
     def __eq__(self, other):
         # Note that numpy.array_equal can return True if the dtypes of the two arrays involved are

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -1885,7 +1885,6 @@ class Image:
 
         image2 will end up approximately equalt to the original image.
         """
-        from .integ import int1d
 
         nx, ny = self.array.shape
 
@@ -1900,10 +1899,7 @@ class Image:
         rev = dict(zip(zip(allh,allk), range(npix)))
 
         # kernel is the integral of the interpolant over 1 pixel.
-        n = (x_interpolant.ixrange+1)//2
-        kernel = np.zeros(n+1)
-        for i in range(n+1):
-            kernel[i] = int1d(x_interpolant.xval, i-0.5, i+0.5)
+        kernel = x_interpolant.unit_integrals(max_len=max(nx,ny))
 
         # Matrix equation A x = b.
         # b are the given pixel values in the input image.
@@ -1911,12 +1907,13 @@ class Image:
         # The elements of A are the integral of the interpolant over x and y directions
         # for pixels that are within ixrange in both directions.
         A = np.zeros((npix, npix))
+        n = len(kernel)
         for row in range(npix):
             h = allh[row]
             k = allk[row]
-            for p in range(h-n, h+n+1):
+            for p in range(h-n+1, h+n):
                 if p < 0 or p >= nx: continue
-                for q in range(k-n, k+n+1):
+                for q in range(k-n+1, k+n):
                     if q < 0 or q >= ny: continue
                     A[row, rev[(p,q)]] += kernel[abs(p-h)] * kernel[abs(q-k)]
 

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -1888,13 +1888,13 @@ class Image:
         ny, nx = self.array.shape
         npix = nx * ny
 
-        # kernel is the integral of the interpolant over 1 pixel.
-        kernel = x_interpolant.unit_integrals(max_len=max(nx,ny))
+        # Each kernel is the integral of the interpolant over 1 pixel.
+        kernels = x_interpolant.unit_integrals(max_len=max(nx,ny))
 
         # The rest of the implementation is done in C++.  cf. src/Image.cpp
         im2 = self.copy()
-        _kernel = kernel.__array_interface__['data'][0]
-        _galsim.depixelizeImage(im2._image, _kernel, kernel.size)
+        _kernels = kernels.__array_interface__['data'][0]
+        _galsim.depixelizeImage(im2._image, _kernels, kernels.size)
         return im2
 
     def __eq__(self, other):

--- a/galsim/interpolant.py
+++ b/galsim/interpolant.py
@@ -192,7 +192,7 @@ class Interpolant:
     def unit_integrals(self, max_len=None):
         """Compute the unit integrals of the real-space kernel.
 
-        ret[i] = int(xval(xval, i-0.5, i+0.5)
+        integrals[i] = int(xval(xval, i-0.5, i+0.5)
 
         Parameters:
             max_len:    The maximum length of the returned array.  This is usually only relevant
@@ -264,7 +264,7 @@ class Delta(Interpolant):
     def unit_integrals(self, max_len=None):
         """Compute the unit integrals of the real-space kernel.
 
-        ret[i] = int(xval(xval, i-0.5, i+0.5)
+        integrals[i] = int(xval(xval, i-0.5, i+0.5)
 
         Parameters:
             max_len:    The maximum length of the returned array. (ignored)
@@ -326,7 +326,7 @@ class Nearest(Interpolant):
     def unit_integrals(self, max_len=None):
         """Compute the unit integrals of the real-space kernel.
 
-        ret[i] = int(xval(xval, i-0.5, i+0.5)
+        integrals[i] = int(xval(xval, i-0.5, i+0.5)
 
         Parameters:
             max_len:    The maximum length of the returned array. (ignored)
@@ -390,7 +390,7 @@ class SincInterpolant(Interpolant):
     def unit_integrals(self, max_len=None):
         """Compute the unit integrals of the real-space kernel.
 
-        ret[i] = int(xval(xval, i-0.5, i+0.5)
+        integrals[i] = int(xval(xval, i-0.5, i+0.5)
 
         Parameters:
             max_len:    The maximum length of the returned array.
@@ -458,7 +458,7 @@ class Linear(Interpolant):
     def unit_integrals(self, max_len=None):
         """Compute the unit integrals of the real-space kernel.
 
-        ret[i] = int(xval(xval, i-0.5, i+0.5)
+        integrals[i] = int(xval(xval, i-0.5, i+0.5)
 
         Parameters:
             max_len:    The maximum length of the returned array.  This is usually only relevant
@@ -523,18 +523,7 @@ class Cubic(Interpolant):
     def unit_integrals(self, max_len=None):
         """Compute the unit integrals of the real-space kernel.
 
-        ret[i] = int(xval(xval, i-0.5, i+0.5)
-
-        Parameters:
-            max_len:    The maximum length of the returned array.  This is usually only relevant
-                        for SincInterpolant, where xrange = inf.
-        Returns:
-            integrals:  An array of unit integrals of length max_len or smaller.
-        """
-    def unit_integrals(self, max_len=None):
-        """Compute the unit integrals of the real-space kernel.
-
-        ret[i] = int(xval(xval, i-0.5, i+0.5)
+        integrals[i] = int(xval(xval, i-0.5, i+0.5)
 
         Parameters:
             max_len:    The maximum length of the returned array.  This is usually only relevant

--- a/galsim/interpolant.py
+++ b/galsim/interpolant.py
@@ -192,7 +192,7 @@ class Interpolant:
     def unit_integrals(self, max_len=None):
         """Compute the unit integrals of the real-space kernel.
 
-        integrals[i] = int(xval(xval, i-0.5, i+0.5)
+        integrals[i] = int(xval(x), i-0.5, i+0.5)
 
         Parameters:
             max_len:    The maximum length of the returned array.  This is usually only relevant
@@ -264,7 +264,7 @@ class Delta(Interpolant):
     def unit_integrals(self, max_len=None):
         """Compute the unit integrals of the real-space kernel.
 
-        integrals[i] = int(xval(xval, i-0.5, i+0.5)
+        integrals[i] = int(xval(x), i-0.5, i+0.5)
 
         Parameters:
             max_len:    The maximum length of the returned array. (ignored)
@@ -326,7 +326,7 @@ class Nearest(Interpolant):
     def unit_integrals(self, max_len=None):
         """Compute the unit integrals of the real-space kernel.
 
-        integrals[i] = int(xval(xval, i-0.5, i+0.5)
+        integrals[i] = int(xval(x), i-0.5, i+0.5)
 
         Parameters:
             max_len:    The maximum length of the returned array. (ignored)
@@ -390,7 +390,7 @@ class SincInterpolant(Interpolant):
     def unit_integrals(self, max_len=None):
         """Compute the unit integrals of the real-space kernel.
 
-        integrals[i] = int(xval(xval, i-0.5, i+0.5)
+        integrals[i] = int(xval(x), i-0.5, i+0.5)
 
         Parameters:
             max_len:    The maximum length of the returned array.
@@ -458,7 +458,7 @@ class Linear(Interpolant):
     def unit_integrals(self, max_len=None):
         """Compute the unit integrals of the real-space kernel.
 
-        integrals[i] = int(xval(xval, i-0.5, i+0.5)
+        integrals[i] = int(xval(x), i-0.5, i+0.5)
 
         Parameters:
             max_len:    The maximum length of the returned array.  This is usually only relevant
@@ -523,7 +523,7 @@ class Cubic(Interpolant):
     def unit_integrals(self, max_len=None):
         """Compute the unit integrals of the real-space kernel.
 
-        integrals[i] = int(xval(xval, i-0.5, i+0.5)
+        integrals[i] = int(xval(x), i-0.5, i+0.5)
 
         Parameters:
             max_len:    The maximum length of the returned array.  This is usually only relevant

--- a/galsim/interpolant.py
+++ b/galsim/interpolant.py
@@ -189,6 +189,27 @@ class Interpolant:
             self._i.uvalMany(_u, len(u))
             return u
 
+    def unit_integrals(self, max_len=None):
+        """Compute the unit integrals of the real-space kernel.
+
+        ret[i] = int(xval(xval, i-0.5, i+0.5)
+
+        Parameters:
+            max_len:    The maximum length of the returned array.  This is usually only relevant
+                        for SincInterpolant, where xrange = inf.
+        Returns:
+            integrals:  An array of unit integrals of length max_len or smaller.
+        """
+        from .integ import int1d
+        # Note: This is pretty fast, but subclasses may choose to override this if there
+        # is an analytic integral to avoud the int1d call.
+        n = (self.ixrange+1)//2 + 1
+        n = n if max_len is None else min(n, max_len)
+        integrals = np.zeros(n)
+        for i in range(n):
+            integrals[i] = int1d(self.xval, i-0.5, i+0.5)
+        return integrals
+
     # Sub-classes should define _i property, repr, and str
 
 

--- a/galsim/interpolant.py
+++ b/galsim/interpolant.py
@@ -197,6 +197,7 @@ class Interpolant:
         Parameters:
             max_len:    The maximum length of the returned array.  This is usually only relevant
                         for SincInterpolant, where xrange = inf.
+
         Returns:
             integrals:  An array of unit integrals of length max_len or smaller.
         """
@@ -266,12 +267,12 @@ class Delta(Interpolant):
         ret[i] = int(xval(xval, i-0.5, i+0.5)
 
         Parameters:
-            max_len:    The maximum length of the returned array.  This is usually only relevant
-                        for SincInterpolant, where xrange = inf.
+            max_len:    The maximum length of the returned array. (ignored)
+
         Returns:
             integrals:  An array of unit integrals of length max_len or smaller.
         """
-        return np.array([1])
+        return np.array([1], dtype=float)
 
 
 class Nearest(Interpolant):
@@ -328,12 +329,12 @@ class Nearest(Interpolant):
         ret[i] = int(xval(xval, i-0.5, i+0.5)
 
         Parameters:
-            max_len:    The maximum length of the returned array.  This is usually only relevant
-                        for SincInterpolant, where xrange = inf.
+            max_len:    The maximum length of the returned array. (ignored)
+
         Returns:
             integrals:  An array of unit integrals of length max_len or smaller.
         """
-        return np.array([1])
+        return np.array([1], dtype=float)
 
 
 class SincInterpolant(Interpolant):
@@ -392,8 +393,8 @@ class SincInterpolant(Interpolant):
         ret[i] = int(xval(xval, i-0.5, i+0.5)
 
         Parameters:
-            max_len:    The maximum length of the returned array.  This is usually only relevant
-                        for SincInterpolant, where xrange = inf.
+            max_len:    The maximum length of the returned array.
+
         Returns:
             integrals:  An array of unit integrals of length max_len or smaller.
         """
@@ -469,7 +470,7 @@ class Linear(Interpolant):
         #    = 3/4
         # i1 = int(1-x, x=0.5..1)
         #    = 1/8
-        return np.array([0.75, 0.125])
+        return np.array([0.75, 0.125], dtype=float)
 
 
 class Cubic(Interpolant):
@@ -547,7 +548,7 @@ class Cubic(Interpolant):
         #    = 47/384 - 11/384 = 3/32
         # i2 = -int(1/2 (x-1)*(x-2)^2, x=1.5..2)
         #    = -5/384
-        return np.array([161./192, 3./32, -5./384])
+        return np.array([161./192, 3./32, -5./384], dtype=float)
 
 
 class Quintic(Interpolant):

--- a/galsim/interpolant.py
+++ b/galsim/interpolant.py
@@ -331,7 +331,7 @@ class SincInterpolant(Interpolant):
     def ixrange(self):
         """The total integral range of the interpolant.  Typically 2 * xrange.
         """
-        return np.inf
+        return 2*int(np.ceil(self.xrange))
 
     @property
     def krange(self):

--- a/galsim/interpolatedimage.py
+++ b/galsim/interpolatedimage.py
@@ -65,10 +65,11 @@ class InterpolatedImage(GSObject):
     However, if you want to try to remove the effect of the pixel and have the `InterpolatedImage`
     model the pre-pixelized profile, then you can set ``depixelize=True``.  This will call
     `Image.depixelize` on the image automatically to try to remove the effect of the pixelization.
-    This step can be rather slow and memory-demanding, so use this with caution.  But if
-    used, the resulting profile represents the true underlying profile, without the pixel
-    convolution.  It can therefore be rotated, sheared, etc.  And when rendering, one should
-    use the methods that do involve integration over the pixel: ``auto``, ``phot``, etc.
+    We recommend using a Lanczos interpolant with this option for best results.  (Higher order
+    tends to work better here.) This step can be rather slow and memory-demanding, so use this
+    with caution.  But if used, the resulting profile represents the true underlying profile,
+    without the pixel convolution.  It can therefore be rotated, sheared, etc.  And when rendering,
+    one should use the methods that do involve integration over the pixel: ``auto``, ``phot``, etc.
 
     .. warning ::
 

--- a/galsim/interpolatedimage.py
+++ b/galsim/interpolatedimage.py
@@ -70,6 +70,12 @@ class InterpolatedImage(GSObject):
     convolution.  It can therefore be rotated, sheared, etc.  And when rendering, one should
     use the methods that do involve integration over the pixel: ``auto``, ``phot``, etc.
 
+    .. warning ::
+
+        Input images that are undersampled and/or noisy may not necessarily work well with the
+        ``depixelize=True`` option.  Users should treat this option with some care and validate
+        that the results are sufficiently accurate for your particular use case.
+
     If the input `Image` has a ``scale`` or ``wcs`` associated with it, then there is no need to
     specify one as a parameter here.  But if one is provided, that will override any ``scale`` or
     ``wcs`` that is native to the `Image`.

--- a/galsim/interpolatedimage.py
+++ b/galsim/interpolatedimage.py
@@ -59,7 +59,8 @@ class InterpolatedImage(GSObject):
     is equivalent to integration over the pixel).  This is often acceptable, and the resulting
     `InterpolatedImage` object can be convolved by other profiles as usual.  One just needs to
     remember to draw the final convolved profile using ``method='no_pixel'`` to avoid including
-    the pixel convolution a second time.
+    the pixel convolution a second time.  In particular, one should not use it in conjunction
+    with photon shooting, for the same reason.
 
     However, if you want to try to remove the effect of the pixel and have the `InterpolatedImage`
     model the pre-pixelized profile, then you can set ``depixelize=True``.  This will call
@@ -67,7 +68,7 @@ class InterpolatedImage(GSObject):
     This step can be rather slow and memory-demanding, so use this with caution.  But if
     used, the resulting profile represents the true underlying profile, without the pixel
     convolution.  It can therefore be rotated, sheared, etc.  And when rendering, one should
-    use the normal methods: ``auto``, ``phot``, etc.
+    use the methods that do involve integration over the pixel: ``auto``, ``phot``, etc.
 
     If the input `Image` has a ``scale`` or ``wcs`` associated with it, then there is no need to
     specify one as a parameter here.  But if one is provided, that will override any ``scale`` or

--- a/galsim/interpolatedimage.py
+++ b/galsim/interpolatedimage.py
@@ -342,6 +342,8 @@ class InterpolatedImage(GSObject):
 
         # Process the different options for flux, stepk, maxk
         self._flux = self._getFlux(flux, normalization)
+        self._calculate_stepk = calculate_stepk
+        self._calculate_maxk = calculate_maxk
         self._stepk = self._getStepK(calculate_stepk, _force_stepk)
         self._maxk = self._getMaxK(calculate_maxk, _force_maxk)
 
@@ -353,6 +355,10 @@ class InterpolatedImage(GSObject):
         ret._gsparams = GSParams.check(gsparams, self.gsparams, **kwargs)
         ret._x_interpolant = self._x_interpolant.withGSParams(ret._gsparams, **kwargs)
         ret._k_interpolant = self._k_interpolant.withGSParams(ret._gsparams, **kwargs)
+        if ret._gsparams.folding_threshold != self._gsparams.folding_threshold:
+            ret._stepk = ret._getStepK(self._calculate_stepk, 0.)
+        if ret._gsparams.maxk_threshold != self._gsparams.maxk_threshold:
+            ret._maxk = ret._getMaxK(self._calculate_maxk, 0.)
         return ret
 
     @lazy_property

--- a/galsim/interpolatedimage.py
+++ b/galsim/interpolatedimage.py
@@ -260,6 +260,12 @@ class InterpolatedImage(GSObject):
         gsparams:           An optional `GSParams` argument. [default: None]
         hdu:                When reading in an `Image` from a file, this parameter can be used to
                             select a particular HDU in the file. [default: None]
+        _force_stepk:       Override the normal stepk calculation (using gsparams.folding_threshold)
+                            and force stepk to the given value. [default: 0]
+        _force_maxk:        Override the normal maxk calculation (using gsparams.maxk_threshold)
+                            and force maxk to the given value.  This option in particular can help
+                            reduce FFT artifacts in a manner than is currently unobtainable by
+                            lowering maxk_threshold. [default: 0]
     """
     _req_params = { 'image' : str }
     _opt_params = {

--- a/galsim/interpolatedimage.py
+++ b/galsim/interpolatedimage.py
@@ -264,7 +264,7 @@ class InterpolatedImage(GSObject):
                             and force stepk to the given value. [default: 0]
         _force_maxk:        Override the normal maxk calculation (using gsparams.maxk_threshold)
                             and force maxk to the given value.  This option in particular can help
-                            reduce FFT artifacts in a manner than is currently unobtainable by
+                            reduce FFT artifacts in a manner that is currently unobtainable by
                             lowering maxk_threshold. [default: 0]
     """
     _req_params = { 'image' : str }

--- a/include/galsim/Image.h
+++ b/include/galsim/Image.h
@@ -531,6 +531,11 @@ namespace galsim {
         void invertSelf();
 
         /**
+        *  @brief Make a depixelized version of the image
+        */
+        void depixelizeSelf(const double* kernels, const int nk);
+
+        /**
          *  @brief Return a pointer to the first pixel in the image.
          *
          *  This overrides the version in BaseImage, since this one returns a non-const
@@ -877,9 +882,6 @@ namespace galsim {
      */
     template <typename T>
     PUBLIC_API void invertImage(ImageView<T> im);
-
-
-
 
 } // namespace galsim
 

--- a/include/galsim/Image.h
+++ b/include/galsim/Image.h
@@ -883,6 +883,11 @@ namespace galsim {
     template <typename T>
     PUBLIC_API void invertImage(ImageView<T> im);
 
+    /**
+     *  @brief Clear the cached solver used for depixelizing images
+     */
+    PUBLIC_API void ClearDepixelizeCache();
+
 } // namespace galsim
 
 #include "ImageArith.h"

--- a/include/galsim/Image.h
+++ b/include/galsim/Image.h
@@ -533,7 +533,7 @@ namespace galsim {
         /**
         *  @brief Make a depixelized version of the image
         */
-        void depixelizeSelf(const double* unit_integrals, const int nk);
+        void depixelizeSelf(const double* unit_integrals, const int n);
 
         /**
          *  @brief Return a pointer to the first pixel in the image.

--- a/include/galsim/Image.h
+++ b/include/galsim/Image.h
@@ -533,7 +533,7 @@ namespace galsim {
         /**
         *  @brief Make a depixelized version of the image
         */
-        void depixelizeSelf(const double* kernels, const int nk);
+        void depixelizeSelf(const double* unit_integrals, const int nk);
 
         /**
          *  @brief Return a pointer to the first pixel in the image.

--- a/include/galsim/Interpolant.h
+++ b/include/galsim/Interpolant.h
@@ -310,7 +310,7 @@ namespace galsim {
         ~SincInterpolant() {}
 
         double xrange() const { return 1./(M_PI*_gsparams.kvalue_accuracy); }
-        int ixrange() const { return 0; }
+        int ixrange() const { return 2*int(ceil(xrange())); }
         double urange() const { return 0.5; }
 
         double xval(double x) const;

--- a/include/galsim/ProbabilityTree.h
+++ b/include/galsim/ProbabilityTree.h
@@ -222,7 +222,7 @@ namespace galsim {
             ~Element()
             {
                 if (_left) {
-                    xassert(_right);
+                    //xassert(_right);
                     delete _left;
                     delete _right;
                 }

--- a/pysrc/Image.cpp
+++ b/pysrc/Image.cpp
@@ -36,10 +36,10 @@ namespace galsim {
     }
 
     template <typename T>
-    static void DepixelizeImage(ImageView<T> im, size_t ikernels, const int nk)
+    static void DepixelizeImage(ImageView<T> im, size_t iunit_integrals, const int nk)
     {
-        const double* kernels = reinterpret_cast<const double*>(ikernels);
-        im.depixelizeSelf(kernels, nk);
+        const double* unit_integrals = reinterpret_cast<const double*>(iunit_integrals);
+        im.depixelizeSelf(unit_integrals, nk);
     }
 
     template <typename T>

--- a/pysrc/Image.cpp
+++ b/pysrc/Image.cpp
@@ -36,10 +36,10 @@ namespace galsim {
     }
 
     template <typename T>
-    static void DepixelizeImage(ImageView<T> im, size_t iunit_integrals, const int nk)
+    static void DepixelizeImage(ImageView<T> im, size_t iunit_integrals, const int n)
     {
         const double* unit_integrals = reinterpret_cast<const double*>(iunit_integrals);
-        im.depixelizeSelf(unit_integrals, nk);
+        im.depixelizeSelf(unit_integrals, n);
     }
 
     template <typename T>

--- a/pysrc/Image.cpp
+++ b/pysrc/Image.cpp
@@ -36,6 +36,13 @@ namespace galsim {
     }
 
     template <typename T>
+    static void DepixelizeImage(ImageView<T> im, size_t ikernels, const int nk)
+    {
+        const double* kernels = reinterpret_cast<const double*>(ikernels);
+        im.depixelizeSelf(kernels, nk);
+    }
+
+    template <typename T>
     static void WrapImage(py::module& _galsim, const std::string& suffix)
     {
         py::class_<BaseImage<T> >(_galsim, ("BaseImage" + suffix).c_str());
@@ -58,6 +65,9 @@ namespace galsim {
 
         typedef void (*invert_func_type)(ImageView<T>);
         _galsim.def("invertImage", invert_func_type(&invertImage));
+
+        typedef void (*depix_func_type)(ImageView<T>, size_t, const int);
+        _galsim.def("depixelizeImage", depix_func_type(&DepixelizeImage));
     }
 
     void pyExportImage(py::module& _galsim)

--- a/pysrc/Image.cpp
+++ b/pysrc/Image.cpp
@@ -82,6 +82,7 @@ namespace galsim {
         WrapImage<std::complex<float> >(_galsim, "CF");
 
         _galsim.def("goodFFTSize", &goodFFTSize);
+        _galsim.def("ClearDepixelizeCache", &ClearDepixelizeCache);
     }
 
 } // namespace galsim

--- a/setup.py
+++ b/setup.py
@@ -368,7 +368,7 @@ def find_eigen_dir(output=False):
             print("Previous attempt to download eigen found. Deleting and trying again.")
             shutil.rmtree(dir)
         os.mkdir(dir)
-        url = 'https://gitlab.com/libeigen/eigen/-/archive/3.3.4/eigen-3.3.4.tar.bz2'
+        url = 'https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.bz2'
         if output:
             print("Downloading eigen from ",url)
         # Unfortunately, gitlab doesn't allow direct downloads. We need to spoof the request

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ py_sources = all_files_from('pysrc', '.cpp')
 cpp_sources = all_files_from('src', '.cpp')
 test_sources = all_files_from('tests', '.cpp')
 headers = all_files_from('include')
+inst = all_files_from('src', '.inst')
 shared_data = all_files_from('share')
 
 copt =  {
@@ -1230,12 +1231,12 @@ class my_test(test):
 
 
 lib=("galsim", {'sources' : cpp_sources,
-                'depends' : headers,
+                'depends' : headers + inst,
                 'include_dirs' : ['include', 'include/galsim'],
                 'undef_macros' : undef_macros })
 ext=Extension("galsim._galsim",
               py_sources,
-              depends = cpp_sources + headers,
+              depends = cpp_sources + headers + inst,
               undef_macros = undef_macros)
 
 build_dep = ['setuptools>=38', 'pybind11>=2.2']

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -1011,7 +1011,8 @@ void ImageView<T>::depixelizeSelf(const double* kernels, const int nk)
     Matrix<typename ComplexHelper<T>::double_type, Dynamic, 1> b(npix);
 
     A.setZero();
-    auto bit = b.begin();
+    // Note: In Eigen 3.4, this can be b.begin()
+    auto bit = &b[0];
     for(int col=0; col<npix; ++col) {
         int h = col % nx;
         int k = col / nx;
@@ -1025,7 +1026,8 @@ void ImageView<T>::depixelizeSelf(const double* kernels, const int nk)
         for(int q=q1; q<q2; ++q) {
             int row = q*nx + p1;
             double kq = kernels[q-k];
-            auto Acolit = Acol.begin() + row;
+            // Note: In Eigen 3.4, this can be Acol.begin() + row
+            auto Acolit = &Acol[row];
             const double* kpit = kernels + (h-p1);
             // A(row,col) = kernels[std::abs(p-h)] * kernels[std::abs(q-k)];
             for(int p=p1; p<h; ++p) {
@@ -1048,7 +1050,7 @@ void ImageView<T>::depixelizeSelf(const double* kernels, const int nk)
 
     // Copy back to the image
     ptr = getData();
-    bit = b.begin();
+    bit = &b[0];
     for(int col=0; col<npix; ++col) *ptr++ = *bit++;
 }
 

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -30,6 +30,7 @@
 #pragma GCC diagnostic ignored "-Wint-in-bool-context"
 #endif
 #include "Eigen/Dense"
+#include "Eigen/Core"
 
 #include "Image.h"
 #include "ImageArith.h"

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -30,7 +30,6 @@
 #pragma GCC diagnostic ignored "-Wint-in-bool-context"
 #endif
 #include "Eigen/Dense"
-#include "Eigen/Core"
 
 #include "Image.h"
 #include "ImageArith.h"
@@ -1001,7 +1000,7 @@ template <typename T>
 void ImageView<T>::depixelizeSelf(const double* kernels, const int nk)
 {
     using Eigen::MatrixXd;
-    using Eigen::Vector;
+    using Eigen::Matrix;
     using Eigen::Dynamic;
 
     const int nx = this->getNCol();
@@ -1009,7 +1008,7 @@ void ImageView<T>::depixelizeSelf(const double* kernels, const int nk)
     T* ptr = getData();
     int npix = nx * ny;
     MatrixXd A(npix, npix);
-    Vector<typename ComplexHelper<T>::double_type, Dynamic> b(npix);
+    Matrix<typename ComplexHelper<T>::double_type, Dynamic, 1> b(npix);
 
     A.setZero();
     auto bit = b.begin();

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -1089,6 +1089,9 @@ void ImageView<T>::depixelizeSelf(const double* unit_integrals, const int nk)
     for(int col=0; col<npix; ++col) *ptr++ = *bit++;
 }
 
+void ClearDepixelizeCache()
+{ depixelize::_solver.reset(); }
+
 // The classes ConstReturn, ReturnInverse, and ReturnSecond are defined in ImageArith.h.
 
 // Helper function to set data to all zeros.  (memset doesn't like being called on complex<T>)

--- a/src/Interpolant.cpp
+++ b/src/Interpolant.cpp
@@ -400,8 +400,8 @@ namespace galsim {
         // f'(2)_left = f'(2)_right
         // f'(3)_left = 0
         // f''(0) = 0
-        // (*) f''(1)_left = f'(1)_right
-        // (*) f''(2)_left = f'(2)_right
+        // (*) f''(1)_left = f''(1)_right
+        // (*) f''(2)_left = f''(2)_right
         // (*) f''(3)_left = 0
         // f(x-3)+f(x-2) + f(x-1) + f(x) + f(x+1) + f(x+2) = 1 from 0..1
         // F'(j) = F''(j) = F'''(j) = F''''(j) = 0

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -1779,6 +1779,12 @@ def test_depixelize():
     t9 = time.time()
     assert t9-t8 < (t3-t2)/10
 
+    # But not if you clear the cache.
+    galsim.Image.clear_depixelize_cache()
+    nopix_image4 = im4.depixelize(x_interpolant=interp)
+    t10 = time.time()
+    assert t10-t9 > (t3-t2)/10
+
     print('times:')
     print('make ii_with_pixel: ',t1-t0)
     print('draw ii_with_pixel: ',t2-t1)
@@ -1789,6 +1795,7 @@ def test_depixelize():
     print('draw ii_without_pixel, high maxk: ',t7-t6)
     print('depixelize #2: ',t8-t7)
     print('depixelize #3: ',t9-t8)
+    print('depixelize #4: ',t10-t9)
 
     # Use the simpler API that we expect users to typically prefer.
     # Should be exactly equivalent to the above two-step process.

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -1726,7 +1726,7 @@ def test_depixelize():
     # The depixelize function is basically exact for real-space convolution.
     im3 = ii_without_pixel.drawImage(nx=nx, ny=ny, scale=scale, method='real_space')
     print('real-space drawing: max error = ',np.max(np.abs(im3.array-im1.array)))
-    np.testing.assert_allclose(im3.array, im1.array, atol=1.e-12)
+    np.testing.assert_allclose(im3.array, im1.array, atol=1.e-9)
     t5 = time.time()
 
     # With FFT convolution, it's not as close, but this is just due to the approximations that

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -1764,6 +1764,16 @@ def test_depixelize():
     print('draw ii_without_pixel, fft: ',t6-t5)
     print('draw ii_without_pixel, high maxk: ',t7-t6)
 
+    # Check with a non-trivial WCS
+    wcs = galsim.AffineTransform(0.07, -0.31, 0.33, 0.03,
+                                 galsim.PositionD(5.3,7.1), galsim.PositionD(293, 800))
+    im6 = true_prof.drawImage(nx=nx, ny=ny, wcs=wcs)
+    im6d = im6.depixelize(interp)
+    ii = galsim.InterpolatedImage(im6d, x_interpolant=interp, _force_maxk=50)
+    im7 = ii.drawImage(nx=nx, ny=ny, wcs=wcs, method='auto')
+    print('affine wcs max error = ',np.max(np.abs(im7.array-im6.array)),'  time = ',t2-t1)
+    np.testing.assert_allclose(im7.array, im6.array, atol=1.e-7)
+
     # Check a variety of interpolants.
     interps = [galsim.Delta(),
                galsim.Nearest(),
@@ -1783,9 +1793,10 @@ def test_depixelize():
                                       gsparams=interp.gsparams)
 
         im6 = ii.drawImage(nx=nx, ny=ny, scale=scale, method='auto')
+        # Most of these are better than 1.e-5, but Delta and Nearest are much worse.
+        # So just use tol=1.e-2 here.
         np.testing.assert_allclose(im6.array, im1.array, atol=1.e-2)
         print(interp,' max error = ',np.max(np.abs(im6.array-im1.array)),'  time = ',t2-t1)
-
 
 if __name__ == "__main__":
     setup()

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -130,6 +130,20 @@ def test_roundtrip():
             err_msg="Transposed array failed InterpolatedImage roundtrip.")
     check_basic(interp, "InterpolatedImage (Fortran ordering)", approx_maxsb=True)
 
+    # Check that folding_threshold and maxk_threshold update stepk and maxk
+    # Do this with the larger ref_image, since this one is too small to have any difference
+    # from different folding_threshold values.
+    scale = 0.3
+    ii1 = galsim.InterpolatedImage(ref_image, scale=scale)
+    gsp = galsim.GSParams(folding_threshold=1.e-4, maxk_threshold=1.e-4)
+    ii2 = galsim.InterpolatedImage(ref_image, scale=scale, gsparams=gsp)
+    assert ii2 == ii1.withGSParams(gsp)
+    assert ii2.stepk != ii1.stepk
+    assert ii2.maxk != ii1.maxk
+    assert ii2.stepk == ii1.withGSParams(folding_threshold=1.e-4).stepk
+    assert ii2.maxk == ii1.withGSParams(maxk_threshold=1.e-4).maxk
+
+
 @timer
 def test_interpolant():
     from scipy.special import sici

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -1719,8 +1719,8 @@ def test_depixelize():
                 galsim.Gaussian(sigma=0.4, flux=3).shift(0.1,-0.3)
 
     # Make these unequal to test indexing
-    nx = 52
-    ny = 45
+    nx = 32
+    ny = 25
     scale = 0.3
     im1 = true_prof.drawImage(nx=nx, ny=ny, scale=scale, dtype=float)
 

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -1714,9 +1714,12 @@ def test_quintic_glagn():
         gsobj.drawImage(method='phot', image=image, add_to_image=True)
 
 def test_depixelize():
-    # True, non-II profile.  Something not too symmetric.
-    true_prof = galsim.Gaussian(sigma=0.7, flux=10).shear(g1=0.1, g2=0.3) + \
-                galsim.Gaussian(sigma=0.4, flux=3).shift(0.1,-0.3)
+    # True, non-II profile.  Something not too symmetric or simple.
+    true_prof = galsim.Convolve(
+                    galsim.Kolmogorov(fwhm=1.1, flux=10).shear(g1=0.1, g2=0.2),
+                    galsim.OpticalPSF(lam_over_diam=0.6, obscuration=0.4, nstruts=4,
+                                      defocus=0.15, astig1=0.13, astig2=-0.14,
+                                      coma1=-0.06, trefoil1=-0.08))
 
     # Make these unequal to test indexing
     nx = 32

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -210,7 +210,7 @@ def test_interpolant():
     s = galsim.SincInterpolant()
     assert s.gsparams == galsim.GSParams()
     assert np.isclose(s.xrange, 1./(np.pi * s.gsparams.kvalue_accuracy))
-    assert s.ixrange == np.inf
+    assert s.ixrange == 2*np.ceil(s.xrange)
     assert np.isclose(s.krange, np.pi)
     assert np.isclose(s.krange, 2.*np.pi * s._i.urange())
     assert np.isclose(s.positive_flux, 3.18726437) # Empirical -- this is a regression test

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -1769,6 +1769,16 @@ def test_depixelize():
     np.testing.assert_allclose(im5.array, im1.array, atol=1.e-7)
     t7 = time.time()
 
+    # Second time with the same size image is much faster, since uses a cache.
+    nopix_image2 = im1.depixelize(x_interpolant=interp)
+    t8 = time.time()
+    assert t8-t7 < (t3-t2)/10
+
+    # Even if the image is different.
+    nopix_image3 = im4.depixelize(x_interpolant=interp)
+    t9 = time.time()
+    assert t9-t8 < (t3-t2)/10
+
     print('times:')
     print('make ii_with_pixel: ',t1-t0)
     print('draw ii_with_pixel: ',t2-t1)
@@ -1777,6 +1787,8 @@ def test_depixelize():
     print('draw ii_without_pixel, real: ',t5-t4)
     print('draw ii_without_pixel, fft: ',t6-t5)
     print('draw ii_without_pixel, high maxk: ',t7-t6)
+    print('depixelize #2: ',t8-t7)
+    print('depixelize #3: ',t9-t8)
 
     # Use the simpler API that we expect users to typically prefer.
     # Should be exactly equivalent to the above two-step process.

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -397,31 +397,44 @@ def test_unit_integrals():
                galsim.Lanczos(3, conserve_dc=False),
                galsim.Lanczos(17),
               ]
-    for i in interps:
-        print(str(i))
+    for interp in interps:
+        print(str(interp))
         # Compute directly with int1d
-        n = i.ixrange//2 + 1
+        n = interp.ixrange//2 + 1
         direct_integrals = np.zeros(n)
-        if isinstance(i, galsim.Delta):
+        if isinstance(interp, galsim.Delta):
             # int1d doesn't handle this well.
             direct_integrals[0] = 1
         else:
             for k in range(n):
-                direct_integrals[k] = galsim.integ.int1d(i.xval, k-0.5, k+0.5)
+                direct_integrals[k] = galsim.integ.int1d(interp.xval, k-0.5, k+0.5)
         print('direct: ',direct_integrals)
 
         # Get from unit_integrals method (sometimes using analytic formulas)
-        integrals = i.unit_integrals()
+        integrals = interp.unit_integrals()
         print('integrals: ',len(integrals),integrals)
 
         assert len(integrals) == n
         np.testing.assert_allclose(integrals, direct_integrals, atol=1.e-12)
 
         if n > 10:
-            print('n>10 for ',repr(i))
-            integrals2 = i.unit_integrals(max_len=10)
+            print('n>10 for ',repr(interp))
+            integrals2 = interp.unit_integrals(max_len=10)
             assert len(integrals2) == 10
             np.testing.assert_equal(integrals2, integrals[:10])
+
+    # Test making shorter versions before longer ones
+    interp = galsim.Lanczos(11)
+    short = interp.unit_integrals(max_len=5)
+    long = interp.unit_integrals(max_len=10)
+    med = interp.unit_integrals(max_len=8)
+    full = interp.unit_integrals()
+
+    assert len(full) > 10
+    np.testing.assert_equal(short, full[:5])
+    np.testing.assert_equal(med, full[:8])
+    np.testing.assert_equal(long, full[:10])
+
 
 @timer
 def test_fluxnorm():


### PR DESCRIPTION
One of the persistent issues with using PSF models such as those from PSFEx or Piff is that they generally model the "effective PSF", including the pixel convolution, rather than the underlying true PSF.  This means that any objects that use this PSF object have to be rendered with `method='no_pixel'`, rather than `'auto'`, or especially `'phot'`.  Using photon shooting would implicitly convolve a second pixel, so lead to significant biases in the resulting images.

This PR adds the capability of fitting for a "depixelized" image to input into `InterpolatedImage`, which would represent the underlying profile, without the pixel convolution.  The expected user API for this is simply to add the parameter `depixelize=True` to the `InterpolatedImage` constructor.  

Then, to use a Piff model, for instance, with photon shooting, one can draw it normally, and then model it as `InterpolatedImage(piff_image, depixelize=True)`.  Then convolve this by the galaxy profile and you can render the combination using `method='phot'`.

It's a big matrix equation, so it scales badly for large images, but for the kinds of images we usually have for PSFs, it takes around 0.1-0.2 seconds, which doesn't seem to bad for many use cases.  Especially if you're in a testing regime where you can treat the PSF as constant for a reasonable number of galaxies.