### PR TITLE
#1148 Fix PhotonDCR config layer bugs, along with a number of other edge cases it turned up.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,8 @@ Config Updates
 - Added option to specify a dtype other than np.float32 for images built by config. (#1148)
 - Added option to specify a dtype other than np.float32 for images built by config. (#1160)
 - Fixed inconsistent behavior of image.world_pos in image type=Single. (#1160)
+- Let a flux item for an object with an SED normalize the SED for the bandpass being
+  simulated. (#1160)
 - Changed the way the internal random number sequence works so that running multiple simulations
   with sequential random seed values doesn't end up with duplicated random values across the
   two (or more) simulations. (#1169)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -72,3 +72,5 @@ Bug Fixes
 - Fixed error in InterpolatedImage.withGSParams not correctly updating stepk and maxk
   if the updated parameters merited it. (#1154)
 - Fix error in ChromaticSum photon shooting when n_photons is explicitly given. (#1156)
+- Fixed some rounding errors that could happen when rendering integer-typed images
+  (e.g. ImageI) that could cause values to be off by 1.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,8 @@ Config Updates
 - Added galaxy_sample input type with corresponding SampleGalaxy GSObject type. (#731)
 - Added COSMOSValue and SampleValue value types. (#954)
 - Added option to specify a dtype other than np.float32 for images built by config. (#1148)
+- Added option to specify a dtype other than np.float32 for images built by config. (#1160)
+- Fixed inconsistent behavior of image.world_pos in image type=Single. (#1160)
 - Changed the way the internal random number sequence works so that running multiple simulations
   with sequential random seed values doesn't end up with duplicated random values across the
   two (or more) simulations. (#1169)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,7 @@ Config Updates
 - Added Correlated noise type as a generalization of the more specific COSMOS noise type. (#731)
 - Added galaxy_sample input type with corresponding SampleGalaxy GSObject type. (#731)
 - Added COSMOSValue and SampleValue value types. (#954)
+- Added option to specify a dtype other than np.float32 for images built by config. (#1148)
 - Changed the way the internal random number sequence works so that running multiple simulations
   with sequential random seed values doesn't end up with duplicated random values across the
   two (or more) simulations. (#1169)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,7 @@ Config Updates
 - Added galaxy_sample input type with corresponding SampleGalaxy GSObject type. (#731)
 - Added COSMOSValue and SampleValue value types. (#954)
 - Added option to specify a dtype other than np.float32 for images built by config. (#1148)
+- Fixed some errors in PhotonDCR usage in the config layer. (#1148)
 - Added option to specify a dtype other than np.float32 for images built by config. (#1160)
 - Fixed inconsistent behavior of image.world_pos in image type=Single. (#1160)
 - Let a flux item for an object with an SED normalize the SED for the bandpass being

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,7 @@ Config Updates
 - Fixed inconsistent behavior of image.world_pos in image type=Single. (#1160)
 - Let a flux item for an object with an SED normalize the SED for the bandpass being
   simulated. (#1160)
+- Fixed some edge cases where the created image could not have the requested wcs. (#1160)
 - Changed the way the internal random number sequence works so that running multiple simulations
   with sequential random seed values doesn't end up with duplicated random values across the
   two (or more) simulations. (#1169)
@@ -75,6 +76,6 @@ Bug Fixes
 
 - Fixed error in InterpolatedImage.withGSParams not correctly updating stepk and maxk
   if the updated parameters merited it. (#1154)
-- Fix error in ChromaticSum photon shooting when n_photons is explicitly given. (#1156)
+- Fixed error in ChromaticSum photon shooting when n_photons is explicitly given. (#1156)
 - Fixed some rounding errors that could happen when rendering integer-typed images
   (e.g. ImageI) that could cause values to be off by 1.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,7 +40,6 @@ Config Updates
 - Added Correlated noise type as a generalization of the more specific COSMOS noise type. (#731)
 - Added galaxy_sample input type with corresponding SampleGalaxy GSObject type. (#731)
 - Added COSMOSValue and SampleValue value types. (#954)
-- Added option to specify a dtype other than np.float32 for images built by config. (#1148)
 - Fixed some errors in PhotonDCR usage in the config layer. (#1148)
 - Added option to specify a dtype other than np.float32 for images built by config. (#1160)
 - Fixed inconsistent behavior of image.world_pos in image type=Single. (#1160)

--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -550,7 +550,7 @@ class ChromaticObject:
         if add_to_image:
             image += image_int
         else:
-            image.copyFrom(image_int)
+            image._copyFrom(image_int)
         return image
 
     def evaluateAtWavelength(self, wave):

--- a/galsim/config/extra_psf.py
+++ b/galsim/config/extra_psf.py
@@ -25,7 +25,7 @@ from .stamp import valid_draw_methods
 from .value import ParseValue, GetCurrentValue
 from .util import GetRNG
 from .noise import CalculateNoiseVariance, AddNoise
-from ..image import ImageF
+from ..image import Image
 from ..position import PositionD
 from ..errors import GalSimConfigValueError, GalSimConfigError
 
@@ -58,7 +58,7 @@ def DrawPSFStamp(psf, config, base, bounds, offset, method, logger):
         n_photons = 0
 
     wcs = base['wcs'].local(base['image_pos'])
-    im = ImageF(bounds, wcs=wcs)
+    im = Image(bounds, wcs=wcs, dtype=base['current_stamp'].dtype)
     im = psf.drawImage(image=im, offset=offset, method=method, rng=rng, n_photons=n_photons)
 
     if 'signal_to_noise' in config:
@@ -131,7 +131,8 @@ class ExtraPSFBuilder(ExtraOutputBuilder):
 
     # The function to call at the end of building each image
     def processImage(self, index, obj_nums, config, base, logger):
-        image = ImageF(base['image_bounds'], wcs=base['wcs'], init_value=0.)
+        image = Image(base['image_bounds'], wcs=base['wcs'], init_value=0.,
+                      dtype=base['current_image'].dtype)
         # Make sure to only use the stamps for objects in this image.
         for obj_num in obj_nums:
             stamp = self.scratch[obj_num]

--- a/galsim/config/gsobject.py
+++ b/galsim/config/gsobject.py
@@ -198,6 +198,15 @@ def BuildGSObject(config, key, base=None, gsparams={}, logger=None):
     gsobject, safe1 = ApplyRedshift(gsobject, param, base, logger)
     safe = safe and safe1
 
+    if 'flux' in param:
+        flux, safe1 = ParseValue(param, 'flux', base, float)
+        logger.debug('obj %d: flux == %f',base.get('obj_num',0),flux)
+        if 'sed' in param and 'bandpass' in base:
+            gsobject = gsobject.withFlux(flux, bandpass=base['bandpass'])
+        else:
+            gsobject = gsobject.withFlux(flux)
+        safe = safe and safe1
+
     # If this is a psf, try to save the half_light_radius in case gal uses resolution.
     if key == 'psf':
         try:
@@ -338,12 +347,6 @@ def _BuildAdd(config, base, ignore, gsparams, logger):
         else: gsparams = None
         gsobject = Add(gsobjects,gsparams=gsparams)
 
-    if 'flux' in config:
-        flux, safe1 = ParseValue(config, 'flux', base, float)
-        logger.debug('obj %d: flux == %f',base.get('obj_num',0),flux)
-        gsobject = gsobject.withFlux(flux)
-        safe = safe and safe1
-
     return gsobject, safe
 
 def _BuildConvolve(config, base, ignore, gsparams, logger):
@@ -373,12 +376,6 @@ def _BuildConvolve(config, base, ignore, gsparams, logger):
         else: gsparams = None
         gsobject = Convolve(gsobjects,gsparams=gsparams)
 
-    if 'flux' in config:
-        flux, safe1 = ParseValue(config, 'flux', base, float)
-        logger.debug('obj %d: flux == %f',base.get('obj_num',0),flux)
-        gsobject = gsobject.withFlux(flux)
-        safe = safe and safe1
-
     return gsobject, safe
 
 def _BuildList(config, base, ignore, gsparams, logger):
@@ -401,12 +398,6 @@ def _BuildList(config, base, ignore, gsparams, logger):
 
     gsobject, safe1 = BuildGSObject(items, index, base, gsparams, logger)
     safe = safe and safe1
-
-    if 'flux' in config:
-        flux, safe1 = ParseValue(config, 'flux', base, float)
-        logger.debug('obj %d: flux == %f',base.get('obj_num',0),flux)
-        gsobject = gsobject.withFlux(flux)
-        safe = safe and safe1
 
     return gsobject, safe
 

--- a/galsim/config/image.py
+++ b/galsim/config/image.py
@@ -31,7 +31,7 @@ from ..errors import GalSimConfigError, GalSimConfigValueError
 from ..position import PositionI, PositionD
 from ..bounds import BoundsI
 from ..celestial import CelestialCoord
-from ..image import ImageF
+from ..image import Image
 from ..noise import VariableGaussianNoise
 
 # This file handles the building of an image by parsing config['image'].
@@ -357,7 +357,7 @@ def FlattenNoiseVariance(config, full_image, stamps, current_vars, logger):
         # Then there was whitening applied in the individual stamps.
         # But there could be a different variance in each postage stamp, so the first
         # thing we need to do is bring everything up to a common level.
-        noise_image = ImageF(full_image.bounds)
+        noise_image = Image(bounds=full_image.bounds, dtype=full_image.dtype)
         for k in range(nobjects):
             if stamps[k] is None: continue
             b = stamps[k].bounds & full_image.bounds

--- a/galsim/config/image.py
+++ b/galsim/config/image.py
@@ -445,11 +445,6 @@ class ImageBuilder:
             raise GalSimConfigError(
                 "Both (or neither) of image.xsize and image.ysize need to be defined and != 0.")
 
-        # We allow world_pos to be in config[image], but we don't want it to lead to a final_shift
-        # in BuildStamp.  To mark this, we set image_pos to (0,0)
-        if 'world_pos' in config and 'image_pos' not in config:
-            config['image_pos'] = PositionD(0,0)
-
         return xsize, ysize
 
     def buildBandpass(self, config, base, image_num, obj_num, logger):

--- a/galsim/config/image.py
+++ b/galsim/config/image.py
@@ -508,6 +508,8 @@ class ImageBuilder:
 
         image, current_var = BuildStamp(
                 base, obj_num=obj_num, xsize=xsize, ysize=ysize, do_noise=True, logger=logger)
+        if image is not None:
+            image.wcs = base['wcs']   # in case stamp has a local jacobian.
         return image, current_var
 
     def makeTasks(self, config, base, jobs, logger):

--- a/galsim/config/image_scattered.py
+++ b/galsim/config/image_scattered.py
@@ -17,14 +17,15 @@
 #
 
 import logging
+import numpy as np
 
 from .image import ImageBuilder, FlattenNoiseVariance, RegisterImageType
 from .value import ParseValue, GetAllParams
-from .stamp import BuildStamps
+from .stamp import BuildStamps, _ParseDType
 from .noise import AddSky, AddNoise
 from .input import ProcessInputNObjects
 from ..errors import GalSimConfigError, GalSimConfigValueError
-from ..image import ImageF
+from ..image import Image
 
 # This file adds image type Scattered, which places individual stamps at arbitrary
 # locations on a larger image.
@@ -57,7 +58,7 @@ class ScatteredImageBuilder(ImageBuilder):
         # These are allowed for Scattered, but we don't use them here.
         extra_ignore = [ 'image_pos', 'world_pos', 'stamp_size', 'stamp_xsize', 'stamp_ysize',
                          'nobjects' ]
-        opt = { 'size' : int , 'xsize' : int , 'ysize' : int }
+        opt = { 'size' : int , 'xsize' : int , 'ysize' : int, 'dtype': None }
         params = GetAllParams(config, base, opt=opt, ignore=ignore+extra_ignore)[0]
 
         size = params.get('size',0)
@@ -95,7 +96,8 @@ class ScatteredImageBuilder(ImageBuilder):
         full_ysize = base['image_ysize']
         wcs = base['wcs']
 
-        full_image = ImageF(full_xsize, full_ysize)
+        dtype = _ParseDType(config, base)
+        full_image = Image(full_xsize, full_ysize, dtype=dtype)
         full_image.setOrigin(base['image_origin'])
         full_image.wcs = wcs
         full_image.setZero()

--- a/galsim/config/image_tiled.py
+++ b/galsim/config/image_tiled.py
@@ -17,14 +17,15 @@
 #
 
 import logging
+import numpy as np
 
 from .image import ImageBuilder, FlattenNoiseVariance, RegisterImageType
 from .util import GetRNG
 from .value import ParseValue, GetAllParams
-from .stamp import BuildStamps
+from .stamp import BuildStamps, _ParseDType
 from .noise import AddSky, AddNoise
 from ..errors import GalSimConfigError, GalSimConfigValueError
-from ..image import ImageF
+from ..image import Image
 from .. import random
 
 # This file adds image type Tiled, which builds a larger image by tiling nx x ny individual
@@ -118,7 +119,8 @@ class TiledImageBuilder(ImageBuilder):
         full_ysize = base['image_ysize']
         wcs = base['wcs']
 
-        full_image = ImageF(full_xsize, full_ysize)
+        dtype = _ParseDType(config, base)
+        full_image = Image(full_xsize, full_ysize, dtype=dtype)
         full_image.setOrigin(base['image_origin'])
         full_image.wcs = wcs
         full_image.setZero()

--- a/galsim/config/photon_ops.py
+++ b/galsim/config/photon_ops.py
@@ -217,7 +217,8 @@ class PhotonDCRBuilder(PhotonOpBuilder):
     def buildPhotonOp(self, config, base, logger):
         req, opt, single, takes_rng = get_cls_params(PhotonDCR)
         kwargs, safe = GetAllParams(config, base, req, opt, single)
-        kwargs['obj_coord'] = base['sky_pos']
+        if 'sky_pos' in base:
+            kwargs['obj_coord'] = base['sky_pos']
         return PhotonDCR(**kwargs)
 
 class ListPhotonOpBuilder(PhotonOpBuilder):

--- a/galsim/config/stamp.py
+++ b/galsim/config/stamp.py
@@ -584,7 +584,10 @@ def _ParseDType(config, base):
             gdict = globals().copy()
             exec('import numpy', gdict)
             exec('import numpy as np', gdict)
-            dtype = eval(dtype, gdict)
+            try:
+                dtype = eval(dtype, gdict)
+            except Exception:
+                dtype = np.dtype(dtype).type
         except Exception:
             raise GalSimConfigValueError("dtype = %s is invalid."%dtype, Image.valid_dtypes)
     if dtype is None and base.get('current_image', None) is not None:

--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -1805,7 +1805,7 @@ class GSObject:
                     # Need a temporary
                     im1 = ImageD(bounds=imview.bounds)
                     added_photons = sensor.accumulate(photons, im1, orig_center)
-                    imview.array[:,:] += im1.array.astype(imview.dtype, copy=False)
+                    imview += im1
 
         image.added_flux = added_photons / flux_scale
         if save_photons:
@@ -1854,9 +1854,9 @@ class GSObject:
                 im1 = ImageF(bounds=image.bounds, scale=image.scale)
             self._drawReal(im1)
             if add_to_image:
-                image.array[:,:] += im1.array.astype(image.dtype, copy=False)
+                image += im1
             else:
-                image.array[:,:] = im1.array
+                image._copyFrom(im1)
             return im1.array.sum(dtype=float)
 
     def _drawReal(self, image, jac=None, offset=(0.,0.), flux_scaling=1.):
@@ -1982,7 +1982,7 @@ class GSObject:
         if add_to_image:
             image += temp
         else:
-            image.copyFrom(temp)
+            image._copyFrom(temp)
         added_photons = temp.array.sum(dtype=float)
         return added_photons
 
@@ -2373,7 +2373,7 @@ class GSObject:
                 # Need a temporary
                 im1 = ImageD(bounds=image.bounds)
                 added_flux += sensor.accumulate(photons, im1, orig_center)
-                image.array[:,:] += im1.array.astype(image.dtype, copy=False)
+                image += im1
 
             Nleft -= thisN
 

--- a/galsim/photon_array.py
+++ b/galsim/photon_array.py
@@ -841,10 +841,10 @@ class PhotonDCR(PhotonOp):
         H2O_pressure:       Water vapor pressure in kiloPascals.  [default: 1.067 kPa]
     """
     _req_params = { 'base_wavelength' : float }
-    _opt_params = { 'scale_units' : str, 'alpha' : float,
+    _opt_params = { 'scale_unit' : str, 'alpha' : float,
                     'parallactic_angle' : Angle, 'latitude' : Angle,
                     'pressure' : float, 'temperature' : float, 'H2O_pressure' : float }
-    _single_params = [ { 'zenith_angle' : Angle, 'HA' : Angle, 'zenit_coord' : CelestialCoord } ]
+    _single_params = [ { 'zenith_angle' : Angle, 'HA' : Angle, 'zenith_coord' : CelestialCoord } ]
 
     def __init__(self, base_wavelength, scale_unit=arcsec, **kwargs):
         from . import dcr

--- a/tests/test_config_image.py
+++ b/tests/test_config_image.py
@@ -2685,6 +2685,26 @@ def test_chromatic():
     psf1 = galsim.Moffat(fwhm=0.5, beta=2.5)
     final = galsim.Convolve(gal, psf1)
     image1 = final.drawImage(nx=64, ny=64, scale=0.2, bandpass=bandpass)
+    print('image.sum = ',image.array.sum())
+    print('image1.sum = ',image1.array.sum())
+    np.testing.assert_allclose(image.array, image1.array)
+
+    # Can also set a flux rather than normalize the sed.
+    config['gal']['sed'] = {
+        'file_name': 'CWW_E_ext.sed',
+        'wave_type': 'Ang',
+        'flux_type': 'flambda',
+    }
+    config['gal']['flux'] = 500
+    del config['gal']['_get']
+    galsim.config.RemoveCurrent(config)
+    image = galsim.config.BuildImage(config)
+    sed = galsim.SED('CWW_E_ext.sed', 'Ang', 'flambda').atRedshift(0.8)
+    gal = (galsim.Exponential(half_light_radius=0.5, flux=500) * sed).withFlux(500, bandpass)
+    final = galsim.Convolve(gal, psf1)
+    image1 = final.drawImage(nx=64, ny=64, scale=0.2, bandpass=bandpass)
+    print('image.sum = ',image.array.sum())
+    print('image1.sum = ',image1.array.sum())
     np.testing.assert_allclose(image.array, image1.array)
 
     # Now check ChromaticAtmosphere

--- a/tests/test_config_image.py
+++ b/tests/test_config_image.py
@@ -148,7 +148,7 @@ def test_single():
     config['stamp'] = { 'dtype': 'invalid' }
     with assert_raises(galsim.GalSimConfigError):
         galsim.config.BuildImage(config)
-    config['stamp'] = { 'dtype': 'np.float128' }
+    config['stamp'] = { 'dtype': 'np.float100' }
     with assert_raises(galsim.GalSimConfigError):
         galsim.config.BuildImage(config)
     config['stamp'] = { 'n_photons' : 200 }    # These next few require draw_method = phot
@@ -952,7 +952,7 @@ def test_scattered():
     with assert_raises(galsim.GalSimConfigError):
         galsim.config.BuildImage(config)
     config['image'].pop('index_convention')
-    config['image']['dtype'] = 'np.float128'  # Invalid dtype
+    config['image']['dtype'] = 'np.float100'  # Invalid dtype
     with assert_raises(galsim.GalSimConfigError):
         galsim.config.BuildImage(config)
 
@@ -1409,7 +1409,7 @@ def test_tiled():
     config['image']['yborder'] = -yborder
 
     # Test invalid dtype
-    config['image']['dtype'] = 'np.float128'
+    config['image']['dtype'] = 'np.float100'
     with assert_raises(galsim.GalSimConfigError):
         galsim.config.BuildImage(config)
 

--- a/tests/test_config_image.py
+++ b/tests/test_config_image.py
@@ -1818,6 +1818,19 @@ def test_wcs():
             np.testing.assert_almost_equal(wcs.toImage(p).x, ref.toImage(p).x)
             np.testing.assert_almost_equal(wcs.toImage(p).y, ref.toImage(p).y)
 
+        # Check actually using the config to draw an image.
+        if key == 'scale1': continue
+        config1 = {
+            'gal': {'type': 'Gaussian', 'sigma': 3, 'flux': 100},
+            'image': {
+                'size': 64,
+                'wcs': config['image'][key],
+                'draw_method':'sb'
+            }
+        }
+        image = galsim.config.BuildImage(config1)
+        assert image.wcs == wcs
+
     # If we build something again with the same index, it should get the current value
     wcs = galsim.config.BuildWCS(config['image'], 'shear2', config)
     ref = reference['shear2']

--- a/tests/test_config_image.py
+++ b/tests/test_config_image.py
@@ -235,14 +235,12 @@ def test_positions():
     np.testing.assert_array_equal(im4.array, im1.array)
     assert im4.bounds == im1.bounds
 
-    # world_pos in image works slightly differently for image type = Single.
-    # The intent there is just to give the object a world position for values that might depend
-    # on it (e.g. NFWHalo shears)
+    # Can also set world_pos in image.
     config['image']['world_pos'] = config['stamp']['world_pos']
     del config['stamp']['world_pos']
     im5 = galsim.config.BuildImage(config, logger=logger)
     np.testing.assert_array_equal(im5.array, im1.array)
-    assert im5.bounds == galsim.BoundsI(-10,10,-10,10)
+    assert im5.bounds == im1.bounds
 
     # It is also valid to give both world_pos and image_pos in the image field for Single.
     config['image']['image_pos'] = config['image']['world_pos']

--- a/tests/test_config_image.py
+++ b/tests/test_config_image.py
@@ -148,7 +148,7 @@ def test_single():
     config['stamp'] = { 'dtype': 'invalid' }
     with assert_raises(galsim.GalSimConfigError):
         galsim.config.BuildImage(config)
-    config['stamp'] = { 'dtype': 'float64' }   # Need np. or numpy.
+    config['stamp'] = { 'dtype': 'np.float128' }
     with assert_raises(galsim.GalSimConfigError):
         galsim.config.BuildImage(config)
     config['stamp'] = { 'n_photons' : 200 }    # These next few require draw_method = phot
@@ -952,7 +952,7 @@ def test_scattered():
     with assert_raises(galsim.GalSimConfigError):
         galsim.config.BuildImage(config)
     config['image'].pop('index_convention')
-    config['image']['dtype'] = 'float32'  # numpy types need np. or numpy. prefix.
+    config['image']['dtype'] = 'np.float128'  # Invalid dtype
     with assert_raises(galsim.GalSimConfigError):
         galsim.config.BuildImage(config)
 
@@ -971,7 +971,7 @@ def test_scattered():
                                     galsim.PositionD(x2,y2),
                                     galsim.PositionD(x3,y3) ]
                       },
-        'dtype' : 'float',
+        'dtype' : 'float64',  # Can also use the type name without np if it's a valid numpy type.
         'nobjects' : 3
     }
 
@@ -1408,8 +1408,8 @@ def test_tiled():
         galsim.config.BuildImage(config)
     config['image']['yborder'] = -yborder
 
-    # numpy types need np. or numpy. prefix.
-    config['image']['dtype'] = 'float64'
+    # Test invalid dtype
+    config['image']['dtype'] = 'np.float128'
     with assert_raises(galsim.GalSimConfigError):
         galsim.config.BuildImage(config)
 

--- a/tests/test_config_output.py
+++ b/tests/test_config_output.py
@@ -861,6 +861,7 @@ def test_extra_psf_sn():
             'random_seed' : 1234,
             'pixel_scale' : 0.4,
             'size' : 64,
+            'dtype': 'float',
         },
         'gal' : {
             'type' : 'Gaussian',
@@ -879,6 +880,8 @@ def test_extra_psf_sn():
     # First pure psf image with no noise.
     gal_image = galsim.config.BuildImage(config)
     pure_psf_image = galsim.config.extra.GetFinalExtraOutput('psf', config)[0]
+    assert gal_image.dtype is np.float64
+    assert pure_psf_image.dtype is np.float64  # PSF gets dtype from main image
     np.testing.assert_almost_equal(pure_psf_image.array.sum(), 1., decimal=6)
 
     # Draw PSF at S/N = 100

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -1521,6 +1521,13 @@ def test_np_fft():
     assert_raises(ValueError, galsim.fft.irfft2, xar_oe)
     # eo is ok, since the second dimension is actually N/2+1
 
+def round_cast(array, dt):
+    # array.astype(dt) doesn't round to the nearest for integer types.
+    # This rounds first if dt is integer and then casts.
+    if dt(0.5) != 0.5:
+        array = np.around(array)
+    return array.astype(dt)
+
 @timer
 def test_types():
     """Test drawing onto image types other than float32, float64.
@@ -1544,13 +1551,13 @@ def test_types():
                                     "wrong scale when drawing onto dt=%s"%dt)
             np.testing.assert_equal(im.bounds, ref_im.bounds,
                                     "wrong bounds when drawing onto dt=%s"%dt)
-            np.testing.assert_almost_equal(im.array, ref_im.array.astype(dt), 6,
+            np.testing.assert_almost_equal(im.array, round_cast(ref_im.array, dt), 6,
                                            "wrong array when drawing onto dt=%s"%dt)
 
             if method == 'phot':
                 rng.reset(1234)
             obj.drawImage(im, method=method, add_to_image=True, rng=rng)
-            np.testing.assert_almost_equal(im.array, ref_im.array.astype(dt) * 2, 6,
+            np.testing.assert_almost_equal(im.array, round_cast(ref_im.array, dt) * 2, 6,
                                            "wrong array when adding to image with dt=%s"%dt)
 
 @timer

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1690,6 +1690,12 @@ def test_Image_inplace_add():
                 err_msg="Inplace add in Image class (dictionary call) does"
                 +" not match reference for dtype = "+str(types[i]))
 
+        # Check a calculation where we should expect some rounding errors.
+        # This is especially bad for integer types, since 5.9999999996 can become 5.
+        image3 = galsim.Image(ref_array.astype(types[i]))
+        image3 += (image2 / 17) * 17
+        np.testing.assert_allclose(image3.array, image1.array)
+
         # Then try using the eval command to mimic use via ImageD, ImageF etc.
         image_init_func = eval("galsim.Image"+tchar[i])
         slice_array = large_array.copy().astype(types[i])[::3,::2]
@@ -1727,6 +1733,11 @@ def test_Image_inplace_subtract():
                 err_msg="Inplace subtract in Image class (dictionary call) does"
                 +" not match reference for dtype = "+str(types[i]))
 
+        # Check a calculation where we should expect some rounding errors.
+        image3 = galsim.Image(2 * ref_array.astype(types[i]))
+        image3 -= (image2 / 17) * 17
+        np.testing.assert_allclose(image3.array, image1.array)
+
         # Then try using the eval command to mimic use via ImageD, ImageF etc.
         image_init_func = eval("galsim.Image"+tchar[i])
         slice_array = (2*large_array).astype(types[i])[::3,::2]
@@ -1763,6 +1774,11 @@ def test_Image_inplace_multiply():
         np.testing.assert_array_equal((2 * ref_array**2).astype(types[i]), image1.array,
                 err_msg="Inplace multiply in Image class (dictionary call) does"
                 +" not match reference for dtype = "+str(types[i]))
+
+        # Check a calculation where we should expect some rounding errors.
+        image3 = galsim.Image(ref_array.astype(types[i]))
+        image3 *= (image2 / 17) * 17
+        np.testing.assert_allclose(image3.array, image1.array)
 
         # Then try using the eval command to mimic use via ImageD, ImageF etc.
         image_init_func = eval("galsim.Image"+tchar[i])
@@ -1802,6 +1818,11 @@ def test_Image_inplace_divide():
                 decimal=decimal,
                 err_msg="Inplace divide in Image class (dictionary call) does"
                 +" not match reference for dtype = "+str(types[i]))
+
+        # Check a calculation where we should expect some rounding errors.
+        image3 = galsim.Image((2 * (ref_array + 1)**2).astype(types[i]))
+        image3 /= (image2 / 17) * 17
+        np.testing.assert_allclose(image3.array, image1.array)
 
         # Then try using the eval command to mimic use via ImageD, ImageF etc.
         image_init_func = eval("galsim.Image"+tchar[i])
@@ -1854,6 +1875,11 @@ def test_Image_inplace_scalar_add():
         np.testing.assert_array_equal((ref_array + 1).astype(types[i]), image1.array,
                 err_msg="Inplace scalar add in Image class (dictionary "
                 +"call) does not match reference for dtype = "+str(types[i]))
+
+        image3 = galsim.Image(ref_array.astype(types[i]))
+        image3 += 1.
+        np.testing.assert_allclose(image3.array, image1.array)
+
         # Then try using the eval command to mimic use via ImageD, ImageF etc.
         image_init_func = eval("galsim.Image"+tchar[i])
         slice_array = large_array.copy().astype(types[i])[::3,::2]
@@ -1875,6 +1901,11 @@ def test_Image_inplace_scalar_subtract():
         np.testing.assert_array_equal((ref_array - 1).astype(types[i]), image1.array,
                 err_msg="Inplace scalar subtract in Image class (dictionary "
                 +"call) does not match reference for dtype = "+str(types[i]))
+
+        image3 = galsim.Image(ref_array.astype(types[i]))
+        image3 -= 1.
+        np.testing.assert_allclose(image3.array, image1.array)
+
         # Then try using the eval command to mimic use via ImageD, ImageF etc.
         image_init_func = eval("galsim.Image"+tchar[i])
         slice_array = large_array.copy().astype(types[i])[::3,::2]
@@ -1897,6 +1928,11 @@ def test_Image_inplace_scalar_multiply():
         np.testing.assert_array_equal(image1.array, image2.array,
                 err_msg="Inplace scalar multiply in Image class (dictionary "
                 +"call) does not match reference for dtype = "+str(types[i]))
+
+        image3 = galsim.Image(ref_array.astype(types[i]))
+        image3 *= 2.
+        np.testing.assert_allclose(image3.array, image1.array)
+
         # Then try using the eval command to mimic use via ImageD, ImageF etc.
         image_init_func = eval("galsim.Image"+tchar[i])
         slice_array = large_array.copy().astype(types[i])[::3,::2]
@@ -1920,6 +1956,11 @@ def test_Image_inplace_scalar_divide():
         np.testing.assert_array_equal(image1.array, image2.array,
                 err_msg="Inplace scalar divide in Image class (dictionary "
                 +"call) does not match reference for dtype = "+str(types[i]))
+
+        image3 = galsim.Image((2 * ref_array).astype(types[i]))
+        image3 /= 2.
+        np.testing.assert_allclose(image3.array, image2.array)
+
         # Then try using the eval command to mimic use via ImageD, ImageF etc.
         image_init_func = eval("galsim.Image"+tchar[i])
         slice_array = (2*large_array).astype(types[i])[::3,::2]
@@ -1942,6 +1983,10 @@ def test_Image_inplace_scalar_pow():
         np.testing.assert_array_almost_equal(image1.array, image2.array, decimal=4,
             err_msg="Inplace scalar pow in Image class (dictionary "
             +"call) does not match reference for dtype = "+str(types[i]))
+
+        image3 = galsim.Image(ref_array.astype(types[i]))
+        image3 **= 2.
+        np.testing.assert_allclose(image3.array, image1.array)
 
         # Then try using the eval command to mimic use via ImageD, ImageF etc.
         image_init_func = eval("galsim.Image"+tchar[i])

--- a/tests/test_photon_array.py
+++ b/tests/test_photon_array.py
@@ -583,10 +583,12 @@ def test_dcr():
     sed = galsim.SED('CWW_E_ext.sed', wave_type='ang', flux_type='flambda')
 
     flux = 1.e6
-    base_PSF = galsim.Kolmogorov(fwhm=0.3)
+    fwhm = 0.3
+    base_PSF = galsim.Kolmogorov(fwhm=fwhm)
 
     # Use ChromaticAtmosphere
-    im1 = galsim.ImageD(50, 50, scale=pixel_scale)
+    # Note, somewhat gratuitous check that ImageI works with dtype=int in config below.
+    im1 = galsim.ImageI(50, 50, scale=pixel_scale)
     star = galsim.DeltaFunction() * sed
     star = star.withFlux(flux, bandpass=bandpass)
     chrom_PSF = galsim.ChromaticAtmosphere(base_PSF,
@@ -598,7 +600,7 @@ def test_dcr():
     chrom.drawImage(bandpass, image=im1)
 
     # Use PhotonDCR
-    im2 = galsim.ImageD(50, 50, scale=pixel_scale)
+    im2 = galsim.ImageI(50, 50, scale=pixel_scale)
     dcr = galsim.PhotonDCR(base_wavelength=base_wavelength,
                            zenith_angle=zenith_angle,
                            parallactic_angle=parallactic_angle,
@@ -611,23 +613,21 @@ def test_dcr():
 
     do_pickle(dcr)
 
-    im1 /= flux  # Divide by flux, so comparison is on a relative basis.
-    im2 /= flux
     printval(im2, im1, show=False)
-    np.testing.assert_almost_equal(im2.array, im1.array, decimal=4,
-                                   err_msg="PhotonDCR didn't match ChromaticAtmosphere")
+    # tolerace for photon shooting is ~sqrt(flux) = 1.e3
+    np.testing.assert_allclose(im2.array, im1.array, atol=1.e3,
+                               err_msg="PhotonDCR didn't match ChromaticAtmosphere")
 
     # Use ChromaticAtmosphere in photon_ops
-    im3 = galsim.ImageD(50, 50, scale=pixel_scale)
+    im3 = galsim.ImageI(50, 50, scale=pixel_scale)
     photon_ops = [chrom_PSF]
     star.drawImage(bandpass, image=im3, method='phot', rng=rng, photon_ops=photon_ops)
-    im3 /= flux
     printval(im3, im1, show=False)
-    np.testing.assert_almost_equal(im3.array, im1.array, decimal=4,
-                                   err_msg="ChromaticAtmosphere in photon_ops didn't match")
+    np.testing.assert_allclose(im3.array, im1.array, atol=1.e3,
+                               err_msg="ChromaticAtmosphere in photon_ops didn't match")
 
     # Repeat with thinned bandpass and SED to check that thin still works well.
-    im3 = galsim.ImageD(50, 50, scale=pixel_scale)
+    im3 = galsim.ImageI(50, 50, scale=pixel_scale)
     thin = 0.1  # Even higher also works.  But this is probably enough.
     thin_bandpass = bandpass.thin(thin)
     thin_sed = sed.thin(thin)
@@ -637,13 +637,12 @@ def test_dcr():
     photon_ops = [wave_sampler, dcr]
     achrom.drawImage(image=im3, method='phot', rng=rng, photon_ops=photon_ops)
 
-    im3 /= flux
     printval(im3, im1, show=False)
-    np.testing.assert_almost_equal(im3.array, im1.array, decimal=4,
-                                   err_msg="thinning factor %f led to 1.e-4 level inaccuracy"%thin)
+    np.testing.assert_allclose(im3.array, im1.array, atol=1.e3,
+                               err_msg="thinning factor %f led to 1.e-4 level inaccuracy"%thin)
 
     # Check scale_unit
-    im4 = galsim.ImageD(50, 50, scale=pixel_scale/60)
+    im4 = galsim.ImageI(50, 50, scale=pixel_scale/60)
     dcr = galsim.PhotonDCR(base_wavelength=base_wavelength,
                            zenith_angle=zenith_angle,
                            parallactic_angle=parallactic_angle,
@@ -651,10 +650,9 @@ def test_dcr():
                            alpha=alpha)
     photon_ops = [wave_sampler, dcr]
     achrom.dilate(1./60).drawImage(image=im4, method='phot', rng=rng, photon_ops=photon_ops)
-    im4 /= flux
     printval(im4, im1, show=False)
-    np.testing.assert_almost_equal(im4.array, im1.array, decimal=4,
-                                   err_msg="PhotonDCR with scale_unit=arcmin, didn't match")
+    np.testing.assert_allclose(im4.array, im1.array, atol=1.e3,
+                               err_msg="PhotonDCR with scale_unit=arcmin, didn't match")
 
     # Check some other valid options
     # alpha = 0 means don't do any size scaling.
@@ -669,7 +667,7 @@ def test_dcr():
     lsst_long = galsim.Angle.from_dms('-70:44:34.67')
     local_sidereal_time = 3.14 * galsim.hours  # Not pi. This is the time for this observation.
 
-    im5 = galsim.ImageD(50, 50, wcs=wcs)
+    im5 = galsim.ImageI(50, 50, wcs=wcs)
     obj_coord = wcs.toWorld(im5.true_center)
     base_PSF = galsim.Kolmogorov(fwhm=0.9)
     achrom = base_PSF.withFlux(flux)
@@ -686,7 +684,7 @@ def test_dcr():
 
     do_pickle(dcr)
 
-    im6 = galsim.ImageD(50, 50, wcs=wcs)
+    im6 = galsim.ImageI(50, 50, wcs=wcs)
     star = galsim.DeltaFunction() * sed
     star = star.withFlux(flux, bandpass=bandpass)
     chrom_PSF = galsim.ChromaticAtmosphere(base_PSF,
@@ -701,39 +699,34 @@ def test_dcr():
     chrom = galsim.Convolve(star, chrom_PSF)
     chrom.drawImage(bandpass, image=im6)
 
-    im5 /= flux  # Divide by flux, so comparison is on a relative basis.
-    im6 /= flux
     printval(im5, im6, show=False)
-    np.testing.assert_almost_equal(im5.array, im6.array, decimal=3,
-                                   err_msg="PhotonDCR with alpha=0 didn't match")
+    np.testing.assert_allclose(im5.array, im6.array, atol=1.e3,
+                               err_msg="PhotonDCR with alpha=0 didn't match")
 
     # Use ChromaticAtmosphere in photon_ops
-    im7 = galsim.ImageD(50, 50, wcs=wcs)
+    im7 = galsim.ImageI(50, 50, wcs=wcs)
     photon_ops = [chrom_PSF]
     star.drawImage(bandpass, image=im7, method='phot', rng=rng, photon_ops=photon_ops)
-    im7 /= flux
     printval(im7, im6, show=False)
-    np.testing.assert_almost_equal(im7.array, im6.array, decimal=3,
-                                   err_msg="ChromaticAtmosphere in photon_ops didn't match")
+    np.testing.assert_allclose(im7.array, im6.array, atol=1.e3,
+                               err_msg="ChromaticAtmosphere in photon_ops didn't match")
 
     # ChromaticAtmosphere in photon_ops is almost trivially equal to base_psf and dcr in photon_ops.
-    im8 = galsim.ImageD(50, 50, wcs=wcs)
+    im8 = galsim.ImageI(50, 50, wcs=wcs)
     photon_ops = [base_PSF, dcr]
     star.drawImage(bandpass, image=im8, method='phot', rng=rng, photon_ops=photon_ops)
-    im8 /= flux
     printval(im8, im6, show=False)
-    np.testing.assert_almost_equal(im8.array, im6.array, decimal=3,
-                                   err_msg="base_psf + dcr in photon_ops didn't match")
+    np.testing.assert_allclose(im8.array, im6.array, atol=1.e3,
+                               err_msg="base_psf + dcr in photon_ops didn't match")
 
     # Including the wavelength sampler with chromatic drawing is redundant.
     # This raises a warning, not an error.
     photon_ops = [wave_sampler, base_PSF, dcr]
     with assert_warns(galsim.GalSimWarning):
         star.drawImage(bandpass, image=im8, method='phot', rng=rng, photon_ops=photon_ops)
-    im8 /= flux
     printval(im8, im6, show=False)
-    np.testing.assert_almost_equal(im8.array, im6.array, decimal=3,
-                                   err_msg="wave_sampler,base_psf,dcr in photon_ops didn't match")
+    np.testing.assert_allclose(im8.array, im6.array, atol=1.e3,
+                               err_msg="wave_sampler,base_psf,dcr in photon_ops didn't match")
 
     # Also check invalid parameters
     zenith_coord = galsim.CelestialCoord(13.54 * galsim.hours, lsst_lat)

--- a/tests/test_photon_array.py
+++ b/tests/test_photon_array.py
@@ -599,6 +599,25 @@ def test_dcr():
     chrom = galsim.Convolve(star, chrom_PSF)
     chrom.drawImage(bandpass, image=im1)
 
+    # Repeat with config
+    config = {
+        'psf': { 'type': 'ChromaticAtmosphere',
+                 'base_profile': { 'type': 'Kolmogorov', 'fwhm': fwhm },
+                 'base_wavelength': base_wavelength,
+                 'zenith_angle': zenith_angle,
+                 'parallactic_angle': parallactic_angle,
+                 'alpha': alpha
+               },
+        'gal': { 'type': 'DeltaFunction', 'flux': flux, 'sed': sed },
+        'image': { 'xsize': 50, 'ysize': 50, 'pixel_scale': pixel_scale,
+                   'bandpass': bandpass,
+                   'random_seed': 31415,
+                   'dtype': int,
+                 },
+    }
+    im1c = galsim.config.BuildImage(config)
+    assert im1c == im1
+
     # Use PhotonDCR
     im2 = galsim.ImageI(50, 50, scale=pixel_scale)
     dcr = galsim.PhotonDCR(base_wavelength=base_wavelength,
@@ -606,13 +625,41 @@ def test_dcr():
                            parallactic_angle=parallactic_angle,
                            alpha=alpha)
     achrom = base_PSF.withFlux(flux)
-    rng = galsim.BaseDeviate(31415)
+    # Because we'll be comparing to config version, get the rng the way it will do it.
+    rng = galsim.BaseDeviate(galsim.BaseDeviate(31415).raw()+1)
     wave_sampler = galsim.WavelengthSampler(sed, bandpass)
     photon_ops = [wave_sampler, dcr]
     achrom.drawImage(image=im2, method='phot', rng=rng, photon_ops=photon_ops)
 
     do_pickle(dcr)
 
+    # Repeat with config
+    config = {
+        'psf': { 'type': 'Kolmogorov', 'fwhm': fwhm },
+        'gal': { 'type': 'DeltaFunction', 'flux': flux },
+        'image': { 'xsize': 50, 'ysize': 50, 'pixel_scale': pixel_scale,
+                   'bandpass': bandpass,
+                   'random_seed': 31415,
+                   'dtype': 'np.int32',
+                 },
+        'stamp': {
+                   'draw_method': 'phot',
+                   'photon_ops': [
+                        { 'type': 'WavelengthSampler',
+                          'sed': sed },
+                        { 'type': 'PhotonDCR',
+                          'base_wavelength': base_wavelength,
+                          'zenith_angle': zenith_angle,
+                          'parallactic_angle': parallactic_angle,
+                          'alpha': alpha
+                        }
+                   ],
+                 },
+    }
+    im2c = galsim.config.BuildImage(config)
+    assert im2c == im2
+
+    # Compare ChromaticAtmosphere image with PhotonDCR image.
     printval(im2, im1, show=False)
     # tolerace for photon shooting is ~sqrt(flux) = 1.e3
     np.testing.assert_allclose(im2.array, im1.array, atol=1.e3,
@@ -643,16 +690,26 @@ def test_dcr():
 
     # Check scale_unit
     im4 = galsim.ImageI(50, 50, scale=pixel_scale/60)
+    wave_sampler = galsim.WavelengthSampler(sed, bandpass)
     dcr = galsim.PhotonDCR(base_wavelength=base_wavelength,
                            zenith_angle=zenith_angle,
                            parallactic_angle=parallactic_angle,
                            scale_unit='arcmin',
                            alpha=alpha)
     photon_ops = [wave_sampler, dcr]
+    rng = galsim.BaseDeviate(galsim.BaseDeviate(31415).raw()+1)
     achrom.dilate(1./60).drawImage(image=im4, method='phot', rng=rng, photon_ops=photon_ops)
     printval(im4, im1, show=False)
     np.testing.assert_allclose(im4.array, im1.array, atol=1.e3,
                                err_msg="PhotonDCR with scale_unit=arcmin, didn't match")
+
+    galsim.config.RemoveCurrent(config)
+    del config['stamp']['photon_ops'][1]['_get']
+    config['stamp']['photon_ops'][1]['scale_unit'] = 'arcmin'
+    config['image']['pixel_scale'] = pixel_scale/60
+    config['psf']['fwhm'] = fwhm/60
+    im4c = galsim.config.BuildImage(config)
+    assert im4c == im4
 
     # Check some other valid options
     # alpha = 0 means don't do any size scaling.
@@ -671,7 +728,7 @@ def test_dcr():
     obj_coord = wcs.toWorld(im5.true_center)
     base_PSF = galsim.Kolmogorov(fwhm=0.9)
     achrom = base_PSF.withFlux(flux)
-    dcr = galsim.PhotonDCR(base_wavelength=bandpass.effective_wavelength,
+    dcr = galsim.PhotonDCR(base_wavelength=base_wavelength,
                            obj_coord=obj_coord,
                            HA=local_sidereal_time-obj_coord.ra,
                            latitude=lsst_lat,
@@ -679,10 +736,51 @@ def test_dcr():
                            temperature=290,     # default is 293.15
                            H2O_pressure=0.9)    # default is 1.067
                            #alpha=0)            # default is 0, so don't need to set it.
+    wave_sampler = galsim.WavelengthSampler(sed, bandpass)
     photon_ops = [wave_sampler, dcr]
+    rng = galsim.BaseDeviate(galsim.BaseDeviate(31415).raw()+1)
     achrom.drawImage(image=im5, method='phot', rng=rng, photon_ops=photon_ops)
 
     do_pickle(dcr)
+
+    galsim.config.RemoveCurrent(config)
+    config['psf']['fwhm'] = 0.9
+    config['image'] = {
+        'xsize': 50,
+        'ysize': 50,
+        'wcs': { 'type': 'Fits', 'file_name': 'des_data/DECam_00154912_12_header.fits' },
+        'bandpass': bandpass,
+        'random_seed': 31415,
+        'dtype': 'np.int32',
+        'world_pos': obj_coord,
+    }
+    config['stamp']['photon_ops'][1] = {
+        'type': 'PhotonDCR',
+        'base_wavelength': base_wavelength,
+        'HA': local_sidereal_time-obj_coord.ra,
+        'latitude': '-30:14:23.76 deg',
+        'pressure': 72,
+        'temperature': 290,
+        'H2O_pressure': 0.9,
+    }
+    im5c = galsim.config.BuildImage(config)
+    assert im5c == im5
+
+    # Also one using zenith_coord = (lst, lat)
+    config['stamp']['photon_ops'][1] = {
+        'type': 'PhotonDCR',
+        'base_wavelength': base_wavelength,
+        'zenith_coord': {
+            'type': 'RADec',
+            'ra': local_sidereal_time,
+            'dec': lsst_lat,
+        },
+        'pressure': 72,
+        'temperature': 290,
+        'H2O_pressure': 0.9,
+    }
+    im5d = galsim.config.BuildImage(config)
+    assert im5d == im5
 
     im6 = galsim.ImageI(50, 50, wcs=wcs)
     star = galsim.DeltaFunction() * sed


### PR DESCRIPTION
@jmeyers314 noticed some clear typos in the PhotonDCR `opt_params` class variable, which made it obvious that we don't have any unit tests testing the various ways to make a PhotonDCR object in the config layer.  So this PR adds some.

Along the way, I discovered the following minor bugs and a few features I thought we should have, so I fixed them as well:

* There was no way to specify the dtype of the image made by config processing.  Usually float32 is fine, but we should be able to specify something else if we want.  So now, the image field takes an optional `dtype`, which can be e.g. `np.float64', 'int', 'float', 'numpy.uint32', etc.  Basically all the types that images can be using either np or numpy prefixes where appropriate.
* When testing that feature with int images, I discovered that (completely unrelated to config-based usage) sometimes int images would have values 1 less than what they should be, even when photon shooting, so everything should be integer values.  This turned out to be due to numpy's `astype` not rounding when casting to integers as I think I always assumed.  Some bits of the calculation go through floats, so they could be e.g. 29.99999999999974, which became 29, not 30.  So now GalSim.Image has a `_safe_cast` method that rounds if casting to an integer value before doing `astype`.
* Image type Single had a non-standard usage of world_pos, which I think used to have a rationale a long time ago, but the reason for it has been superseded by `sky_pos`.  This "feature" also wasn't documented anywhere other than in a unit test that confirms it works in that non-standard way.  So I considered it a bug, and I fixed it to work the normal way.
* I wanted to set a flux for an object with an SED, which wasn't (easily) possible in config.  So I added a feature that if you set both flux and sed, it will apply the SED and then call `withFlux(flux, bandpass)` to normalize to that flux value, which seems intuitive.
* I discovered that for image type=Single, sometimes the wcs in the final image would be a Jacobian at the local image pos, rather than the intended wcs.  So I fixed that.
* Finally, there were the typos Josh noticed for PhotonDCR, and also it assumed sky_pos always exists when using it for obj_coord, which isn't true, so now I check for it.