### PR TITLE
BUG return variance in ADU units for CCDNoise

### DIFF
--- a/docs/config_image.rst
+++ b/docs/config_image.rst
@@ -149,7 +149,7 @@ that are defined by GalSim are:
     * ``sky_level`` = *float_value* (default = 0.0)  The sky level in ADU/arcsec^2 to use for the noise.  If both this and ``image.sky_level`` are provided, then they will be added together for the purpose of the noise, but the background level in the final image will just be ``image.sky_level``.
     * ``sky_level_pixel`` = *float_value* (default = 0.0)  The sky level in ADU/pixel to use for the noise.  If both this and ``image.sky_level_pixel`` are provided, then they will be added together for the purpose of the noise, but the background level in the final image will just be ``image.sky_level_pixel``.
     * ``gain`` = *float_value* (default = 1.0)  The CCD gain in e-/ADU.
-    * ``read_noise`` = *float_value* (default = 0.0)  The CCD read noise in ADU.
+    * ``read_noise`` = *float_value* (default = 0.0)  The CCD read noise in e-.
 
 * 'COSMOS' provides spatially correlated noise of the sort found in the F814W HST COSMOS science images described by Leauthaud et al (2007).  The point variance (given by the zero distance correlation function value) may be normalized by the user as required, as well as the dimensions of the correlation function.
 
@@ -428,4 +428,3 @@ Then you can use this as a valid sensor type:
         sensor:
             type: CustomSensor
             ...
-

--- a/galsim/config/noise.py
+++ b/galsim/config/noise.py
@@ -458,6 +458,11 @@ class CCDNoiseBuilder(NoiseBuilder):
         sky = GetSky(base['image'], base, logger, full=True)
         extra_sky = GetSky(config, base, logger, full=True)
         total_sky = sky + extra_sky
+        if isinstance(total_sky, Image):
+            var_adu = np.mean(total_sky.array) / gain + read_noise_var / gain**2
+        else:
+            var_adu = total_sky / gain + read_noise_var / gain**2
+
 
         # If we already have some variance in the image (from whitening), then we try to subtract
         # it from the read noise if possible.  If not, we subtract the rest off of the sky level.
@@ -465,7 +470,7 @@ class CCDNoiseBuilder(NoiseBuilder):
         # Poisson, but it's the best we can do.
         if current_var:
             logger.debug('image %d, obj %d: Target variance is %f, current variance is %f',
-                        base.get('image_num',0),base.get('obj_num',0), var, current_var)
+                        base.get('image_num',0),base.get('obj_num',0), var_adu, current_var)
             read_noise_var_adu = read_noise_var / gain**2
             if isinstance(total_sky, Image):
                 test = np.any(total_sky.array/gain + read_noise_var_adu < current_var)
@@ -524,11 +529,6 @@ class CCDNoiseBuilder(NoiseBuilder):
 
         logger.debug('image %d, obj %d: Added CCD noise with gain = %f, read_noise = %f',
                      base.get('image_num',0),base.get('obj_num',0), gain, read_noise)
-
-        if isinstance(total_sky, Image):
-            var_adu = np.mean(total_sky.array) / gain + read_noise_var / gain**2
-        else:
-            var_adu = total_sky / gain + read_noise_var / gain**2
 
         return var_adu
 

--- a/galsim/config/noise.py
+++ b/galsim/config/noise.py
@@ -475,11 +475,10 @@ class CCDNoiseBuilder(NoiseBuilder):
             if isinstance(total_sky, Image):
                 test = np.any(total_sky.array/gain + read_noise_var_adu < current_var)
             else:
-                target_var = total_sky / gain + read_noise_var_adu
                 logger.debug('image %d, obj %d: Target variance is %f, current variance is %f',
                              base.get('image_num',0),base.get('obj_num',0),
-                             target_var, current_var)
-                test = target_var < current_var
+                             var_adu, current_var)
+                test = var_adu < current_var
             if test:
                 raise GalSimConfigError(
                     "Whitening already added more noise than the requested CCD noise.")

--- a/galsim/config/noise.py
+++ b/galsim/config/noise.py
@@ -66,6 +66,9 @@ def AddNoise(config, im, current_var=0., logger=None):
         im:             The image onto which to add the noise
         current_var:    The current noise variance present in the image already [default: 0]
         logger:         If given, a logger object to log progress. [default: None]
+
+    Returns:
+        Variance added to the image (units are ADU if gain != 1)
     """
     from .stamp import SetupConfigObjNum
 
@@ -110,7 +113,7 @@ def CalculateNoiseVariance(config, full=False):
                     noise variance at every pixel.  Otherwise, just return the value at the center.
 
     Returns:
-        the noise variance
+        the noise variance (units are ADU if gain != 1)
     """
     noise = config['image']['noise']
     if not isinstance(noise, dict):
@@ -145,7 +148,7 @@ def AddNoiseVariance(config, im, include_obj_var=False, logger=None):
         logger:             If given, a logger object to log progress. [default: None]
 
     Returns:
-        the variance in the image
+        the variance in the image (units are ADU if gain != 1)
     """
     logger = LoggerWrapper(logger)
     if 'noise' in config['image']:
@@ -260,6 +263,9 @@ class NoiseBuilder:
             current_var:    The current noise variance present in the image already.
             draw_method:    The method that was used to draw the objects on the image.
             logger:         If given, a logger object to log progress.
+
+        Returns:
+            the variance of the noise model (units are ADU if gain != 1)
         """
         raise NotImplementedError("The %s class has not overridden addNoise"%self.__class__)
 
@@ -274,7 +280,7 @@ class NoiseBuilder:
                         center.
 
         Returns:
-            the variance of the noise model
+            the variance of the noise model (units are ADU if gain != 1)
         """
         raise NotImplementedError("The %s class has not overridden addNoise"%self.__class__)
 

--- a/tests/test_config_noise.py
+++ b/tests/test_config_noise.py
@@ -784,7 +784,7 @@ def test_whiten():
     rng.reset(rng1.duplicate())
     im5a.addNoise(galsim.CCDNoise(sky_level=25, read_noise=rn, gain=gain, rng=rng))
     im5b, cv5b = galsim.config.BuildStamp(config)
-    np.testing.assert_almost_equal(cv5b, 25/3.7 + 25/3.7**2, decimal=5)
+    np.testing.assert_almost_equal(cv5b, 25/gain + 5**2/gain**2, decimal=5)
     np.testing.assert_almost_equal(im5b.array, im5a.array, decimal=5)
 
     # And again with a non-trivial sky image
@@ -803,7 +803,7 @@ def test_whiten():
     rn = math.sqrt(25 - cv5c*gain**2)
     im5c.addNoise(galsim.CCDNoise(sky_level=25, read_noise=rn, gain=gain, rng=rng))
     im5d, cv5d = galsim.config.BuildStamp(config2)
-    np.testing.assert_almost_equal(cv5d, 50 + mean_sky, decimal=4)
+    np.testing.assert_almost_equal(cv5d, mean_sky/gain + 5**2/gain**2, decimal=4)
     np.testing.assert_almost_equal(im5d.array, im5c.array, decimal=5)
 
     config['image']['noise']['sky_level_pixel'] = 1.e-5

--- a/tests/test_config_noise.py
+++ b/tests/test_config_noise.py
@@ -776,12 +776,13 @@ def test_whiten():
     np.testing.assert_almost_equal(im4b.array, im4a.array, decimal=5)
 
     # Repeat with gain != 1
-    config['image']['noise']['gain'] = 3.7
+    gain = 3.7
+    config['image']['noise']['gain'] = gain
     galsim.config.RemoveCurrent(config)
     im5a = im1a.copy()
-    rn = math.sqrt(25-cv1a * 3.7**2)
+    rn = math.sqrt((25/gain-cv1a) * gain**2)
     rng.reset(rng1.duplicate())
-    im5a.addNoise(galsim.CCDNoise(sky_level=25, read_noise=rn, gain=3.7, rng=rng))
+    im5a.addNoise(galsim.CCDNoise(sky_level=25, read_noise=rn, gain=gain, rng=rng))
     im5b, cv5b = galsim.config.BuildStamp(config)
     np.testing.assert_almost_equal(cv5b, 50, decimal=5)
     np.testing.assert_almost_equal(im5b.array, im5a.array, decimal=5)
@@ -799,8 +800,8 @@ def test_whiten():
     wcs.makeSkyImage(sky, 100)
     mean_sky = np.mean(sky.array)
     im5c += sky
-    rn = math.sqrt(25-cv5c * 3.7**2)
-    im5c.addNoise(galsim.CCDNoise(sky_level=25, read_noise=rn, gain=3.7, rng=rng))
+    rn = math.sqrt(((25/gain)-cv5c) * gain**2)
+    im5c.addNoise(galsim.CCDNoise(sky_level=25, read_noise=rn, gain=gain, rng=rng))
     im5d, cv5d = galsim.config.BuildStamp(config2)
     np.testing.assert_almost_equal(cv5d, 50 + mean_sky, decimal=4)
     np.testing.assert_almost_equal(im5d.array, im5c.array, decimal=5)

--- a/tests/test_config_noise.py
+++ b/tests/test_config_noise.py
@@ -784,7 +784,7 @@ def test_whiten():
     rng.reset(rng1.duplicate())
     im5a.addNoise(galsim.CCDNoise(sky_level=25, read_noise=rn, gain=gain, rng=rng))
     im5b, cv5b = galsim.config.BuildStamp(config)
-    np.testing.assert_almost_equal(cv5b, 50, decimal=5)
+    np.testing.assert_almost_equal(cv5b, 25/3.7 + 25/3.7**2, decimal=5)
     np.testing.assert_almost_equal(im5b.array, im5a.array, decimal=5)
 
     # And again with a non-trivial sky image

--- a/tests/test_config_noise.py
+++ b/tests/test_config_noise.py
@@ -803,7 +803,7 @@ def test_whiten():
     rn = math.sqrt(25 - cv5c*gain**2)
     im5c.addNoise(galsim.CCDNoise(sky_level=25, read_noise=rn, gain=gain, rng=rng))
     im5d, cv5d = galsim.config.BuildStamp(config2)
-    np.testing.assert_almost_equal(cv5d, mean_sky/gain + 5**2/gain**2, decimal=4)
+    np.testing.assert_almost_equal(cv5d, (25+mean_sky)/gain + 5**2/gain**2, decimal=4)
     np.testing.assert_almost_equal(im5d.array, im5c.array, decimal=5)
 
     config['image']['noise']['sky_level_pixel'] = 1.e-5

--- a/tests/test_config_noise.py
+++ b/tests/test_config_noise.py
@@ -780,7 +780,7 @@ def test_whiten():
     config['image']['noise']['gain'] = gain
     galsim.config.RemoveCurrent(config)
     im5a = im1a.copy()
-    rn = math.sqrt((25/gain-cv1a) * gain**2)
+    rn = math.sqrt(25 - cv1a*gain**2)
     rng.reset(rng1.duplicate())
     im5a.addNoise(galsim.CCDNoise(sky_level=25, read_noise=rn, gain=gain, rng=rng))
     im5b, cv5b = galsim.config.BuildStamp(config)
@@ -800,7 +800,7 @@ def test_whiten():
     wcs.makeSkyImage(sky, 100)
     mean_sky = np.mean(sky.array)
     im5c += sky
-    rn = math.sqrt(((25/gain)-cv5c) * gain**2)
+    rn = math.sqrt(25 - cv5c*gain**2)
     im5c.addNoise(galsim.CCDNoise(sky_level=25, read_noise=rn, gain=gain, rng=rng))
     im5d, cv5d = galsim.config.BuildStamp(config2)
     np.testing.assert_almost_equal(cv5d, 50 + mean_sky, decimal=4)

--- a/tests/test_config_noise.py
+++ b/tests/test_config_noise.py
@@ -695,6 +695,7 @@ def test_whiten():
     im2b, cv2b = galsim.config.BuildStamp(config)
     np.testing.assert_almost_equal(cv2b, 50)
     np.testing.assert_almost_equal(im2b.array, im2a.array, decimal=5)
+    np.testing.assert_allclose(cv2b, np.var(im2b.array - im1a.array), rtol=0.1)
 
     # If whitening already added too much noise, raise an exception
     config['image']['noise']['variance'] = 1.e-5
@@ -724,6 +725,7 @@ def test_whiten():
     im3b, cv3b = galsim.config.BuildStamp(config)
     np.testing.assert_almost_equal(cv3b, 50, decimal=5)
     np.testing.assert_almost_equal(im3b.array, im3a.array, decimal=5)
+    np.testing.assert_allclose(cv3b, np.var(im3b.array - im1a.array), rtol=0.1)
 
     # It's more complicated if the sky is quoted per arcsec and the wcs is not uniform.
     config2 = galsim.config.CopyConfig(config)
@@ -752,6 +754,7 @@ def test_whiten():
     im3d, cv3d = galsim.config.BuildStamp(config2)
     np.testing.assert_almost_equal(cv3d, 50 + mean_sky, decimal=4)
     np.testing.assert_almost_equal(im3d.array, im3c.array, decimal=5)
+    np.testing.assert_allclose(cv3d, np.var(im3d.array - im1a.array), rtol=0.1)
 
     config['image']['noise']['sky_level_pixel'] = 1.e-5
     with assert_raises(galsim.GalSimConfigError):
@@ -774,6 +777,7 @@ def test_whiten():
     im4b, cv4b = galsim.config.BuildStamp(config)
     np.testing.assert_almost_equal(cv4b, 50, decimal=5)
     np.testing.assert_almost_equal(im4b.array, im4a.array, decimal=5)
+    np.testing.assert_allclose(cv4b, np.var(im4b.array - im1a.array), rtol=0.1)
 
     # Repeat with gain != 1
     gain = 3.7
@@ -786,6 +790,7 @@ def test_whiten():
     im5b, cv5b = galsim.config.BuildStamp(config)
     np.testing.assert_almost_equal(cv5b, 25/gain + 5**2/gain**2, decimal=5)
     np.testing.assert_almost_equal(im5b.array, im5a.array, decimal=5)
+    np.testing.assert_allclose(cv5b, np.var(im5b.array - im1a.array), rtol=0.1)
 
     # And again with a non-trivial sky image
     galsim.config.RemoveCurrent(config2)
@@ -805,6 +810,7 @@ def test_whiten():
     im5d, cv5d = galsim.config.BuildStamp(config2)
     np.testing.assert_almost_equal(cv5d, (25+mean_sky)/gain + 5**2/gain**2, decimal=4)
     np.testing.assert_almost_equal(im5d.array, im5c.array, decimal=5)
+    np.testing.assert_allclose(cv5d, np.var(im5d.array - im1a.array), rtol=0.1)
 
     config['image']['noise']['sky_level_pixel'] = 1.e-5
     config['image']['noise']['read_noise'] = 0
@@ -829,6 +835,7 @@ def test_whiten():
     im6b, cv6b = galsim.config.BuildStamp(config)
     np.testing.assert_almost_equal(cv6b, 50, decimal=5)
     np.testing.assert_almost_equal(im6b.array, im6a.array, decimal=5)
+    np.testing.assert_allclose(cv6b, np.var(im6b.array - im1a.array), rtol=0.1)
 
     config['image']['noise']['variance'] = 1.e-5
     del config['_current_cn_tag']


### PR DESCRIPTION
This fixes a bug where the CCDNoise class does not return the variance in ADU units, matching the other methods that deal with variance. 

closes #1166 