### PR TITLE
Add ability to project shear to and from world coordinates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,9 @@ New Features
 - Added `Image.depixelize` and ``depixelize=True`` option for `InterpolatedImage`. (#1154)
 - Let `expand` method of a `galsim.Bounds` instance take an optional second argument to scale
   differently in different directions. (#1155)
+- Added `BaseWCS.shearToWorld` and `BaseWCS.shearToImage` along with overloading
+  `BaseWCS.toWorld` and `BaseWCS.toImage` to mean the same thing when the argument is a
+  `Shear` value. (#1158)
 
 
 Performance Improvements


### PR DESCRIPTION
This is a quick feature addition requested by @beckermr.  It's actually code that I have copied around a few places when I needed to do this, and he pointed out that it is probably widely useful enough to be put into GalSim.

Basically, `wcs.toWorld(shear)` will now return the equivalent shear in world coordinates when the input is the measured shear in image coordinates (e.g. from HSM).