### PR TITLE
Implement OpenMP for random deviate generate functions

### DIFF
--- a/docs/misc.rst
+++ b/docs/misc.rst
@@ -13,6 +13,16 @@ Decorators
 .. autoclass:: galsim.utilities.doc_inherit
 
 
+OpenMP Utilties
+---------------
+
+.. autofunction:: galsim.utilities.get_omp_threads
+
+.. autofunction:: galsim.utilities.set_omp_threads
+
+.. autoclass:: galsim.utilities.single_threaded
+
+
 LRU Cache
 ---------
 

--- a/galsim/random.py
+++ b/galsim/random.py
@@ -172,6 +172,33 @@ class BaseDeviate:
         """
         self._rng.discard(int(n))
 
+    @property
+    def has_reliable_discard(self):
+        """Indicates whether the generator always uses 1 rng per value.
+
+        If it does, then `discard` can reliably be used to keep two generators in sync when one
+        of them generated some values and the other didn't.
+
+        This is False for PoissonDeviate, Chi2Deviate, and GammaDeviate.
+
+        See also `generates_in_pairs`.
+        """
+        return True
+
+    @property
+    def generates_in_pairs(self):
+        """Indicates whether the generator uses 2 rngs values per 2 returned values.
+
+        GaussianDeviate has a slight wrinkle to the `has_reliable_discard` story.
+        It always uses two rng values to generate two Gaussian deviates.  So if the number of
+        generated values is even, then discard can keep things in sync.  However, if an odd
+        number of values are generated, then you to generate one more value (and discard it)
+        to keep things synced up.
+
+        This is only True for GaussianDeviate.
+        """
+        return False
+
     def raw(self):
         """Generate the next pseudo-random number and rather than return the appropriate kind
         of random deviate for this class, just return the raw integer value that would have been
@@ -302,6 +329,10 @@ class GaussianDeviate(BaseDeviate):
         """
         return self._rng_args[1]
 
+    @property
+    def generates_in_pairs(self):
+        return True
+
     def __call__(self):
         """Draw a new random number from the distribution.
 
@@ -415,6 +446,10 @@ class PoissonDeviate(BaseDeviate):
         """The mean of the distribution.
         """
         return self._rng_args[0]
+
+    @property
+    def has_reliable_discard(self):
+        return False
 
     def __call__(self):
         """Draw a new random number from the distribution.
@@ -538,6 +573,10 @@ class GammaDeviate(BaseDeviate):
         """
         return self._rng_args[1]
 
+    @property
+    def has_reliable_discard(self):
+        return False
+
     def __call__(self):
         """Draw a new random number from the distribution.
 
@@ -585,6 +624,10 @@ class Chi2Deviate(BaseDeviate):
         """The number of degrees of freedom.
         """
         return self._rng_args[0]
+
+    @property
+    def has_reliable_discard(self):
+        return False
 
     def __call__(self):
         """Draw a new random number from the distribution.

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -1869,7 +1869,7 @@ class single_threaded:
     Parameters:
         num_threads:    The number of threads you want during the context [default: 1]
     """
-    def __init__(self, num_threads=1):
+    def __init__(self, *, num_threads=1):
         # Get the current number of threads here, so we can set it back when we're done.
         self.orig_num_threads = get_omp_threads()
         self.temp_num_threads = num_threads

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -1866,6 +1866,28 @@ def get_omp_threads():
 class single_threaded:
     """A context manager that turns off (or down) OpenMP threading e.g. during multiprocessing.
 
+    Usage:
+
+    .. code::
+
+        with single_threaded():
+            # Code where you don't want to use any OpenMP threads in the C++ layer
+            # E.g. starting a multiprocessing pool, where you don't want each process
+            # to use multiple threads, potentially ending up with n_cpu^2 threads
+            # running at once, which would generally be bad for performance.
+
+    .. note::
+
+        This is especaily important when your compiler is gcc and you are using the
+        "fork" context in multiprocessing.  There is a bug in gcc that can cause an
+        OpenMP parallel block to hang after forking.
+        cf. `make it possible to use OMP on both sides of a fork <https://patchwork.ozlabs.org/project/gcc/patch/CAPJVwBkOF5GnrMr=4d1ehEKRGkY0tHzJzfXAYBguawu9y5wxXw@mail.gmail.com/#712883>`_
+        for more discussion about this issue.
+
+    It can also be used to set a particular number of threads other than 1, using the
+    optional parameter ``num_threads``, although the original intent of this class is
+    to leave that as 1 (the default).
+
     Parameters:
         num_threads:    The number of threads you want during the context [default: 1]
     """

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -1862,3 +1862,33 @@ def get_omp_threads():
     :returns: num_threads
     """
     return _galsim.GetOMPThreads()
+
+class single_threaded:
+    """A context manager that turns off (or down) OpenMP threading e.g. during multiprocessing.
+
+    Parameters:
+        num_threads:    The number of threads you want during the context [default: 1]
+    """
+    def __init__(self, num_threads=1):
+        # Get the current number of threads here, so we can set it back when we're done.
+        self.orig_num_threads = get_omp_threads()
+        self.temp_num_threads = num_threads
+
+        # If threadpoolctl is installed, use that too, since it will set blas libraries to
+        # be single threaded too. This makes it so you don't need to set the environment
+        # variables OPENBLAS_NUM_THREAD=1 or MKL_NUM_THREADS=1, etc.
+        try:
+            import threadpoolctl
+        except ImportError:
+            self.tpl = None
+        else:  # pragma: no cover  (Not installed on GHA currently.)
+            self.tpl = threadpoolctl.threadpool_limits(num_threads)
+
+    def __enter__(self):
+        set_omp_threads(self.temp_num_threads)
+        return self
+
+    def __exit__(self, type, value, traceback):
+        set_omp_threads(self.orig_num_threads)
+        if self.tpl is not None:  # pragma: no cover
+            self.tpl.unregister()

--- a/galsim/wcs.py
+++ b/galsim/wcs.py
@@ -1844,9 +1844,9 @@ class JacobianWCS(LocalWCS):
         e1 = image_shear.e1
         e2 = image_shear.e2
 
-        M = np.matrix([[1+e1, e2], [e2, 1-e1]])
+        M = np.array([[1+e1, e2], [e2, 1-e1]])
         J = self.getMatrix()
-        M = J * M * J.T
+        M = J.dot(M).dot(J.T)
 
         e1 = (M[0,0] - M[1,1]) / (M[0,0] + M[1,1])
         e2 = (2.*M[0,1]) / (M[0,0] + M[1,1])

--- a/include/galsim/Random.h
+++ b/include/galsim/Random.h
@@ -219,7 +219,7 @@ namespace galsim {
          * @param N     The number of values to draw
          * @param data  The array into which to write the values
          */
-        void generate(int N, double* data);
+        void generate(long long N, double* data);
 
         /**
          * @brief Draw N new random numbers from the distribution and add them to the values in
@@ -228,7 +228,7 @@ namespace galsim {
          * @param N     The number of values to draw
          * @param data  The array into which to add the values
          */
-        void addGenerate(int N, double* data);
+        void addGenerate(long long N, double* data);
 
    protected:
         struct BaseDeviateImpl;
@@ -417,7 +417,7 @@ namespace galsim {
          * @param N     The number of values to draw
          * @param data  The array with the given variances to replace with Gaussian draws.
          */
-        void generateFromVariance(int N, double* data);
+        void generateFromVariance(long long N, double* data);
 
     protected:
         std::string make_repr(bool incl_seed);
@@ -617,7 +617,7 @@ namespace galsim {
          * @param N     The number of values to draw
          * @param data  The array with the given data to replace with Poisson draws.
          */
-        void generateFromExpectation(int N, double* data);
+        void generateFromExpectation(long long N, double* data);
 
 
     protected:

--- a/include/galsim/Random.h
+++ b/include/galsim/Random.h
@@ -121,6 +121,19 @@ namespace galsim {
         BaseDeviate duplicate();
 
         /**
+         * @brief Construct a pointer to a duplicate of this object.
+         *
+         * This is usually the version you want when working in C++.  It is a virtual function
+         * so it resolves to the right function call a compile time, but the return value is
+         * always a shared_ptr<BaseDeviate>.
+         *
+         * I couldn't figure out how to have only one of these two nearly identical bits of
+         * functionality work both in Python and C++ to do what we want.
+         */
+        virtual shared_ptr<BaseDeviate> duplicate_ptr()
+        { return std::make_shared<BaseDeviate>(duplicate()); }
+
+        /**
          * @brief Return a string that can act as the repr in python
          */
         std::string repr() { return make_repr(true); }
@@ -274,6 +287,12 @@ namespace galsim {
         { return UniformDeviate(BaseDeviate::duplicate()); }
 
         /**
+         * @brief Construct a pointer to a duplicate of this object.
+         */
+        virtual shared_ptr<BaseDeviate> duplicate_ptr()
+        { return std::make_shared<UniformDeviate>(duplicate()); }
+
+        /**
          * @brief Draw a new random number from the distribution
          *
          * @return A uniform deviate in the interval [0.,1.)
@@ -341,6 +360,12 @@ namespace galsim {
          */
         GaussianDeviate duplicate()
         { return GaussianDeviate(BaseDeviate::duplicate(), getMean(), getSigma()); }
+
+        /**
+         * @brief Construct a pointer to a duplicate of this object.
+         */
+        virtual shared_ptr<BaseDeviate> duplicate_ptr()
+        { return std::make_shared<GaussianDeviate>(duplicate()); }
 
         /**
          * @brief Draw a new random number from the distribution
@@ -453,6 +478,12 @@ namespace galsim {
         { return BinomialDeviate(BaseDeviate::duplicate(), getN(), getP()); }
 
         /**
+         * @brief Construct a pointer to a duplicate of this object.
+         */
+        virtual shared_ptr<BaseDeviate> duplicate_ptr()
+        { return std::make_shared<BinomialDeviate>(duplicate()); }
+
+        /**
          * @brief Draw a new random number from the distribution
          *
          * @return A binomial deviate with current N and p
@@ -555,6 +586,12 @@ namespace galsim {
         { return PoissonDeviate(BaseDeviate::duplicate(), getMean()); }
 
         /**
+         * @brief Construct a pointer to a duplicate of this object.
+         */
+        virtual shared_ptr<BaseDeviate> duplicate_ptr()
+        { return std::make_shared<PoissonDeviate>(duplicate()); }
+
+        /**
          * @brief Report current distribution mean
          *
          * @return Current mean value
@@ -645,6 +682,12 @@ namespace galsim {
          */
         WeibullDeviate duplicate()
         { return WeibullDeviate(BaseDeviate::duplicate(), getA(), getB()); }
+
+        /**
+         * @brief Construct a pointer to a duplicate of this object.
+         */
+        virtual shared_ptr<BaseDeviate> duplicate_ptr()
+        { return std::make_shared<WeibullDeviate>(duplicate()); }
 
         /**
          * @brief Draw a new random number from the distribution.
@@ -750,6 +793,12 @@ namespace galsim {
         { return GammaDeviate(BaseDeviate::duplicate(), getK(), getTheta()); }
 
         /**
+         * @brief Construct a pointer to a duplicate of this object.
+         */
+        virtual shared_ptr<BaseDeviate> duplicate_ptr()
+        { return std::make_shared<GammaDeviate>(duplicate()); }
+
+        /**
          * @brief Draw a new random number from the distribution.
          *
          * @return A Gamma deviate with current shape k and scale theta.
@@ -851,6 +900,12 @@ namespace galsim {
          */
         Chi2Deviate duplicate()
         { return Chi2Deviate(BaseDeviate::duplicate(), getN()); }
+
+        /**
+         * @brief Construct a pointer to a duplicate of this object.
+         */
+        virtual shared_ptr<BaseDeviate> duplicate_ptr()
+        { return std::make_shared<Chi2Deviate>(duplicate()); }
 
         /**
          * @brief Draw a new random number from the distribution.

--- a/include/galsim/Random.h
+++ b/include/galsim/Random.h
@@ -248,6 +248,20 @@ namespace galsim {
          */
         void seedurandom();
 
+        /**
+         * @brief Return whether the generator always uses 1 rng per value.
+         *
+         * Subclasses that do not, should override this to return false.
+         */
+        virtual bool has_reliable_discard() const { return true; }
+
+        /**
+         * @brief Return whether the generator uses 2 rngs values per 2 returned values.
+         *
+         * This is only true of GaussianDeviate, so it overrides this to return true.
+         */
+        virtual bool generates_in_pairs() const { return false; }
+
     private:
         BaseDeviate();  // Private no-action constructor used by duplicate().
     };
@@ -421,6 +435,8 @@ namespace galsim {
 
     protected:
         std::string make_repr(bool incl_seed);
+
+        virtual bool generates_in_pairs() const { return true; }
 
     private:
         struct GaussianDeviateImpl;
@@ -622,6 +638,8 @@ namespace galsim {
 
     protected:
         std::string make_repr(bool incl_seed);
+
+        virtual bool has_reliable_discard() const { return false; }
 
     private:
         struct PoissonDeviateImpl;
@@ -843,6 +861,8 @@ namespace galsim {
     protected:
         std::string make_repr(bool incl_seed);
 
+        virtual bool has_reliable_discard() const { return false; }
+
     private:
         // Note: confusingly, boost calls the internal values alpha and beta, even though they
         // don't conform to the normal beta=1/theta.  Rather, they have beta=theta.
@@ -936,6 +956,8 @@ namespace galsim {
 
     protected:
         std::string make_repr(bool incl_seed);
+
+        virtual bool has_reliable_discard() const { return false; }
 
     private:
 

--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -196,14 +196,14 @@ namespace galsim {
     long BaseDeviate::raw()
     { return (*_impl->_rng)(); }
 
-    void BaseDeviate::generate(int N, double* data)
+    void BaseDeviate::generate(long long N, double* data)
     {
-        for (int i=0; i<N; ++i) data[i] = (*this)();
+        for (long long i=0; i<N; ++i) data[i] = (*this)();
     }
 
-    void BaseDeviate::addGenerate(int N, double* data)
+    void BaseDeviate::addGenerate(long long N, double* data)
     {
-        for (int i=0; i<N; ++i) data[i] += (*this)();
+        for (long long i=0; i<N; ++i) data[i] += (*this)();
     }
 
     // Next two functions shamelessly stolen from
@@ -330,11 +330,11 @@ namespace galsim {
         return oss.str();
     }
 
-    void GaussianDeviate::generateFromVariance(int N, double* data)
+    void GaussianDeviate::generateFromVariance(long long N, double* data)
     {
         setMean(0.);
         setSigma(1.);
-        for (int i=0; i<N; ++i) {
+        for (long long i=0; i<N; ++i) {
             double sigma = std::sqrt(data[i]);
             data[i] = (*this)() * sigma;
         }
@@ -482,9 +482,9 @@ namespace galsim {
         return oss.str();
     }
 
-    void PoissonDeviate::generateFromExpectation(int N, double* data)
+    void PoissonDeviate::generateFromExpectation(long long N, double* data)
     {
-        for (int i=0; i<N; ++i) {
+        for (long long i=0; i<N; ++i) {
             double mean = data[i];
             if (mean > 0.) {
                 setMean(mean);

--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -332,12 +332,16 @@ namespace galsim {
 
     void GaussianDeviate::generateFromVariance(long long N, double* data)
     {
+        double old_mean = getMean();
+        double old_sigma = getSigma();
         setMean(0.);
         setSigma(1.);
         for (long long i=0; i<N; ++i) {
             double sigma = std::sqrt(data[i]);
             data[i] = (*this)() * sigma;
         }
+        setMean(old_mean);
+        setSigma(old_sigma);
     }
 
     struct BinomialDeviate::BinomialDeviateImpl

--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -488,6 +488,7 @@ namespace galsim {
 
     void PoissonDeviate::generateFromExpectation(long long N, double* data)
     {
+        double old_mean = getMean();
         for (long long i=0; i<N; ++i) {
             double mean = data[i];
             if (mean > 0.) {
@@ -495,6 +496,7 @@ namespace galsim {
                 data[i] = (*this)();
             }
         }
+        setMean(old_mean);
     }
 
     struct WeibullDeviate::WeibullDeviateImpl

--- a/tests/test_config_value.py
+++ b/tests/test_config_value.py
@@ -415,27 +415,28 @@ def test_float_value():
     np.testing.assert_almost_equal(ps1, ps.getMagnification((0.1,0.2)))
 
     # Beef up the amplitude to get strong lensing.
-    ps = galsim.PowerSpectrum(e_power_function='1000 * np.exp(-k**0.2)')
+    ps = galsim.PowerSpectrum(e_power_function='2000 * np.exp(-k**0.2)')
     ps.buildGrid(grid_spacing=10, ngrid=21, interpolant='linear', rng=rng)
 
     print("strong lensing mag = ",ps.getMagnification((0.1,0.2)))
     config = galsim.config.CleanConfig(config)
-    config['input']['power_spectrum']['e_power_function'] = '1000 * np.exp(-k**0.2)'
+    config['input']['power_spectrum']['e_power_function'] = '2000 * np.exp(-k**0.2)'
     with CaptureLog() as cl:
         galsim.config.SetupInputsForImage(config, logger=cl.logger)
         ps2a = galsim.config.ParseValue(config,'ps',config, float)[0]
     print(cl.output)
-    assert 'PowerSpectrum mu = -2.426205 means strong lensing. Using mu=25.000000' in cl.output
+    assert 'PowerSpectrum mu = -4.335137 means strong lensing. Using mu=25.000000' in cl.output
     np.testing.assert_almost_equal(ps2a, 25.)
 
     # Need a different point that happens to have strong lensing, since the PS realization changed.
-    config['uv_pos'] = galsim.PositionD(-60, -60)
+    ps.buildGrid(grid_spacing=10, ngrid=21, interpolant='linear', rng=rng)
+    config['uv_pos'] = galsim.PositionD(55,-25)
     galsim.config.RemoveCurrent(config)
     with CaptureLog() as cl:
         galsim.config.SetupInputsForImage(config, logger=cl.logger)
         ps2b = galsim.config.ParseValue(config, 'ps', config, float)[0]
     print(cl.output)
-    assert "PowerSpectrum mu = 29.760221 means strong lensing. Using mu=25.000000" in cl.output
+    assert "PowerSpectrum mu = 26.746296 means strong lensing. Using mu=25.000000" in cl.output
     np.testing.assert_almost_equal(ps2b, 25.)
 
     # Or set a different maximum
@@ -443,7 +444,7 @@ def test_float_value():
     config['ps']['max_mu'] = 30.
     del config['ps']['_get']
     ps3 = galsim.config.ParseValue(config,'ps',config, float)[0]
-    np.testing.assert_almost_equal(ps3, 29.760221039098028)
+    np.testing.assert_almost_equal(ps3, 26.7462955457826)
 
     # Negative max_mu is invalid.
     galsim.config.RemoveCurrent(config)

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -361,12 +361,18 @@ def test_gaussian():
             err_msg='Wrong Gaussian random number sequence from generate.')
 
     # Test generate_from_variance.
-    g2 = galsim.GaussianDeviate(testseed)
+    g2 = galsim.GaussianDeviate(testseed, mean=5, sigma=0.3)
+    g3 = galsim.GaussianDeviate(testseed, mean=5, sigma=0.3)
     test_array.fill(gSigma**2)
     g2.generate_from_variance(test_array)
     np.testing.assert_array_almost_equal(
             test_array, np.array(gResult)-gMean, precision,
             err_msg='Wrong Gaussian random number sequence from generate_from_variance.')
+    # After running generate_from_variance, it shoudl be back to using the specified mean, sigma.
+    # Note: need to round up to even number for discard, since gd generates 2 at a time.
+    g3.discard((len(test_array)+1)//2 * 2)
+    print('g2,g3 = ',g2(),g3())
+    assert g2() == g3()
 
     # Test generate with a float32 array.
     g.seed(testseed)

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -141,6 +141,8 @@ def test_uniform():
     v1, v2 = u(), u2()
     print('after %d vals, next one is %s, %s'%(nvals,v1,v2))
     assert v1 == v2
+    assert u.has_reliable_discard
+    assert not u.generates_in_pairs
 
     # Check seed, reset
     u.seed(testseed)
@@ -310,6 +312,8 @@ def test_gaussian():
     v1,v2 = g(),g2()
     print('after %d vals, next one is %s, %s'%(nvals+1,v1,v2))
     assert v1 != v2
+    assert g.has_reliable_discard
+    assert g.generates_in_pairs
 
     # Check seed, reset
     g.seed(testseed)
@@ -476,6 +480,8 @@ def test_binomial():
     v1,v2 = b(),b2()
     print('after %d vals, next one is %s, %s'%(nvals,v1,v2))
     assert v1 == v2
+    assert b.has_reliable_discard
+    assert not b.generates_in_pairs
 
     # Check seed, reset
     b.seed(testseed)
@@ -629,6 +635,8 @@ def test_poisson():
     v1,v2 = p(),p2()
     print('With mean = %d, after %d vals, next one is %s, %s'%(high_mean,nvals,v1,v2))
     assert v1 != v2
+    assert not p.has_reliable_discard
+    assert not p.generates_in_pairs
 
     # Check seed, reset
     p = galsim.PoissonDeviate(testseed, mean=pMean)
@@ -942,6 +950,8 @@ def test_weibull():
     v1,v2 = w(),w2()
     print('after %d vals, next one is %s, %s'%(nvals,v1,v2))
     assert v1 == v2
+    assert w.has_reliable_discard
+    assert not w.generates_in_pairs
 
     # Check seed, reset
     w.seed(testseed)
@@ -1082,6 +1092,8 @@ def test_gamma():
     print('after %d vals, next one is %s, %s'%(nvals,v1,v2))
     # Gamma uses at least 2 rngs per value, but can use arbitrarily more than this.
     assert v1 != v2
+    assert not g.has_reliable_discard
+    assert not g.generates_in_pairs
 
     # Check seed, reset
     g.seed(testseed)
@@ -1222,6 +1234,8 @@ def test_chi2():
     print('after %d vals, next one is %s, %s'%(nvals,v1,v2))
     # Chi2 uses at least 2 rngs per value, but can use arbitrarily more than this.
     assert v1 != v2
+    assert not c.has_reliable_discard
+    assert not c.generates_in_pairs
 
     # Check seed, reset
     c.seed(testseed)
@@ -1396,6 +1410,8 @@ def test_distfunction():
     v1,v2 = d(),d2()
     print('after %d vals, next one is %s, %s'%(nvals,v1,v2))
     assert v1 == v2
+    assert d.has_reliable_discard
+    assert not d.generates_in_pairs
 
     # Check seed, reset
     d.seed(testseed)
@@ -1573,6 +1589,8 @@ def test_distLookupTable():
     v1,v2 = d(),d2()
     print('after %d vals, next one is %s, %s'%(nvals,v1,v2))
     assert v1 == v2
+    assert d.has_reliable_discard
+    assert not d.generates_in_pairs
 
     # This should give the same values with only 5 points because of the particular nature
     # of these arrays.

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -325,12 +325,17 @@ def test_gaussian():
     assert v1 == v2
     # Note: For Gaussian, this only works if nvals is even.
     g2 = galsim.GaussianDeviate(testseed, mean=gMean, sigma=gSigma)
-    g2.discard(nvals+1)
+    g2.discard(nvals+1, suppress_warnings=True)
     v1,v2 = g(),g2()
     print('after %d vals, next one is %s, %s'%(nvals+1,v1,v2))
     assert v1 != v2
     assert g.has_reliable_discard
     assert g.generates_in_pairs
+
+    # If don't explicitly suppress the warning, then a warning is emitted when n is odd.
+    g2 = galsim.GaussianDeviate(testseed, mean=gMean, sigma=gSigma)
+    with assert_warns(galsim.GalSimWarning):
+        g2.discard(nvals+1)
 
     # Check seed, reset
     g.seed(testseed)
@@ -413,7 +418,7 @@ def test_gaussian():
     np.testing.assert_array_almost_equal(
             test_array, np.array(gResult)-gMean, precision,
             err_msg='Wrong Gaussian random number sequence from generate_from_variance.')
-    # After running generate_from_variance, it shoudl be back to using the specified mean, sigma.
+    # After running generate_from_variance, it should be back to using the specified mean, sigma.
     # Note: need to round up to even number for discard, since gd generates 2 at a time.
     g3.discard((len(test_array)+1)//2 * 2)
     print('g2,g3 = ',g2(),g3())
@@ -677,7 +682,7 @@ def test_poisson():
 
     # Check discard
     p2 = galsim.PoissonDeviate(testseed, mean=pMean)
-    p2.discard(nvals)
+    p2.discard(nvals, suppress_warnings=True)
     v1,v2 = p(),p2()
     print('With mean = %d, after %d vals, next one is %s, %s'%(pMean,nvals,v1,v2))
     assert v1 == v2
@@ -689,12 +694,17 @@ def test_poisson():
     p = galsim.PoissonDeviate(testseed, mean=high_mean)
     p2 = galsim.PoissonDeviate(testseed, mean=high_mean)
     vals = [p() for i in range(nvals)]
-    p2.discard(nvals)
+    p2.discard(nvals, suppress_warnings=True)
     v1,v2 = p(),p2()
     print('With mean = %d, after %d vals, next one is %s, %s'%(high_mean,nvals,v1,v2))
     assert v1 != v2
     assert not p.has_reliable_discard
     assert not p.generates_in_pairs
+
+    # Discard normally emits a warning for Poisson
+    p2 = galsim.PoissonDeviate(testseed, mean=pMean)
+    with assert_warns(galsim.GalSimWarning):
+        p2.discard(nvals)
 
     # Check seed, reset
     p = galsim.PoissonDeviate(testseed, mean=pMean)
@@ -879,7 +889,7 @@ def test_poisson_highmean():
 
         # Check discard
         p2 = galsim.PoissonDeviate(testseed, mean=mean)
-        p2.discard(nvals)
+        p2.discard(nvals, suppress_warnings=True)
         v1,v2 = p(),p2()
         print('after %d vals, next one is %s, %s'%(nvals,v1,v2))
         if mean > 2**30:
@@ -1178,13 +1188,18 @@ def test_gamma():
 
     # Check discard
     g2 = galsim.GammaDeviate(testseed, k=gammaK, theta=gammaTheta)
-    g2.discard(nvals)
+    g2.discard(nvals, suppress_warnings=True)
     v1,v2 = g(),g2()
     print('after %d vals, next one is %s, %s'%(nvals,v1,v2))
     # Gamma uses at least 2 rngs per value, but can use arbitrarily more than this.
     assert v1 != v2
     assert not g.has_reliable_discard
     assert not g.generates_in_pairs
+
+    # Discard normally emits a warning for Gamma
+    g2 = galsim.GammaDeviate(testseed, k=gammaK, theta=gammaTheta)
+    with assert_warns(galsim.GalSimWarning):
+        g2.discard(nvals)
 
     # Check seed, reset
     g.seed(testseed)
@@ -1320,13 +1335,18 @@ def test_chi2():
 
     # Check discard
     c2 = galsim.Chi2Deviate(testseed, n=chi2N)
-    c2.discard(nvals)
+    c2.discard(nvals, suppress_warnings=True)
     v1,v2 = c(),c2()
     print('after %d vals, next one is %s, %s'%(nvals,v1,v2))
     # Chi2 uses at least 2 rngs per value, but can use arbitrarily more than this.
     assert v1 != v2
     assert not c.has_reliable_discard
     assert not c.generates_in_pairs
+
+    # Discard normally emits a warning for Chi2
+    c2 = galsim.Chi2Deviate(testseed, n=chi2N)
+    with assert_warns(galsim.GalSimWarning):
+        c2.discard(nvals)
 
     # Check seed, reset
     c.seed(testseed)

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -650,14 +650,6 @@ def test_poisson():
             test_array, np.array(pResult), precision,
             err_msg='Wrong poisson random number sequence from generate.')
 
-    # Test generate_from_expectation
-    p.seed(testseed)
-    test_array = np.array([pMean]*3)
-    p.generate_from_expectation(test_array)
-    np.testing.assert_array_almost_equal(
-            test_array, np.array(pResult), precision,
-            err_msg='Wrong poisson random number sequence from generate_from_expectation.')
-
     # Test generate with an int array
     p.seed(testseed)
     test_array = np.empty(3, dtype=int)
@@ -667,12 +659,17 @@ def test_poisson():
             err_msg='Wrong poisson random number sequence from generate.')
 
     # Test generate_from_expectation
-    p.seed(testseed)
+    p2 = galsim.PoissonDeviate(testseed, mean=77)
     test_array = np.array([pMean]*3, dtype=int)
-    p.generate_from_expectation(test_array)
+    p2.generate_from_expectation(test_array)
     np.testing.assert_array_almost_equal(
             test_array, np.array(pResult), precisionI,
             err_msg='Wrong poisson random number sequence from generate_from_expectation.')
+    # After generating, it should be back to mean=77
+    test_array2 = np.array([p2() for i in range(100)])
+    print('test_array2 = ',test_array2)
+    print('mean = ',test_array2.mean())
+    assert np.isclose(test_array2.mean(), 77, atol=2)
 
     # Check picklability
     do_pickle(p, lambda x: (x.serialize(), x.mean))

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -23,6 +23,7 @@ import math
 
 import galsim
 from galsim_test_helpers import *
+from galsim.utilities import single_threaded
 
 
 #
@@ -240,6 +241,22 @@ def test_uniform():
             test_array, 2.*np.array(uResult), precisionF,
             err_msg='Wrong uniform random number sequence from generate.')
 
+    # Check that generated values are independent of number of threads.
+    u1 = galsim.UniformDeviate(testseed)
+    u2 = galsim.UniformDeviate(testseed)
+    v1 = np.empty(555)
+    v2 = np.empty(555)
+    with single_threaded():
+        u1.generate(v1)
+    with single_threaded(num_threads=10):
+        u2.generate(v2)
+    np.testing.assert_array_equal(v1, v2)
+    with single_threaded():
+        u1.add_generate(v1)
+    with single_threaded(num_threads=10):
+        u2.add_generate(v2)
+    np.testing.assert_array_equal(v1, v2)
+
     # Check picklability
     do_pickle(u, lambda x: x.serialize())
     do_pickle(u, lambda x: (x(), x(), x(), x()))
@@ -418,6 +435,31 @@ def test_gaussian():
             test_array, np.array(gResult)-gMean, precisionF,
             err_msg='Wrong Gaussian random number sequence from generate_from_variance.')
 
+    # Check that generated values are independent of number of threads.
+    g1 = galsim.GaussianDeviate(testseed, mean=53, sigma=1.3)
+    g2 = galsim.GaussianDeviate(testseed, mean=53, sigma=1.3)
+    v1 = np.empty(555)
+    v2 = np.empty(555)
+    with single_threaded():
+        g1.generate(v1)
+    with single_threaded(num_threads=10):
+        g2.generate(v2)
+    np.testing.assert_array_equal(v1, v2)
+    with single_threaded():
+        g1.add_generate(v1)
+    with single_threaded(num_threads=10):
+        g2.add_generate(v2)
+    np.testing.assert_array_equal(v1, v2)
+    ud = galsim.UniformDeviate(testseed + 3)
+    ud.generate(v1)
+    v1 += 6.7
+    v2[:] = v1
+    with single_threaded():
+        g1.generate_from_variance(v1)
+    with single_threaded(num_threads=10):
+        g2.generate_from_variance(v2)
+    np.testing.assert_array_equal(v1, v2)
+
     # Check picklability
     do_pickle(g, lambda x: (x.serialize(), x.mean, x.sigma))
     do_pickle(g, lambda x: (x(), x(), x(), x()))
@@ -562,6 +604,22 @@ def test_binomial():
     np.testing.assert_array_almost_equal(
             test_array, np.array(bResult), precisionI,
             err_msg='Wrong binomial random number sequence from generate.')
+
+    # Check that generated values are independent of number of threads.
+    b1 = galsim.BinomialDeviate(testseed, N=17, p=0.7)
+    b2 = galsim.BinomialDeviate(testseed, N=17, p=0.7)
+    v1 = np.empty(555)
+    v2 = np.empty(555)
+    with single_threaded():
+        b1.generate(v1)
+    with single_threaded(num_threads=10):
+        b2.generate(v2)
+    np.testing.assert_array_equal(v1, v2)
+    with single_threaded():
+        b1.add_generate(v1)
+    with single_threaded(num_threads=10):
+        b2.add_generate(v2)
+    np.testing.assert_array_equal(v1, v2)
 
     # Check picklability
     do_pickle(b, lambda x: (x.serialize(), x.n, x.p))
@@ -731,6 +789,23 @@ def test_poisson():
     print('test_array2 = ',test_array2)
     print('mean = ',test_array2.mean())
     assert np.isclose(test_array2.mean(), 77, atol=2)
+
+    # Check that generated values are independent of number of threads.
+    # This should be trivial, since Poisson disables multi-threading, but check anyway.
+    p1 = galsim.PoissonDeviate(testseed, mean=77)
+    p2 = galsim.PoissonDeviate(testseed, mean=77)
+    v1 = np.empty(555)
+    v2 = np.empty(555)
+    with single_threaded():
+        p1.generate(v1)
+    with single_threaded(num_threads=10):
+        p2.generate(v2)
+    np.testing.assert_array_equal(v1, v2)
+    with single_threaded():
+        p1.add_generate(v1)
+    with single_threaded(num_threads=10):
+        p2.add_generate(v2)
+    np.testing.assert_array_equal(v1, v2)
 
     # Check picklability
     do_pickle(p, lambda x: (x.serialize(), x.mean))
@@ -1030,6 +1105,22 @@ def test_weibull():
     np.testing.assert_array_almost_equal(
             test_array, np.array(wResult), precisionF,
             err_msg='Wrong weibull random number sequence from generate.')
+
+    # Check that generated values are independent of number of threads.
+    w1 = galsim.WeibullDeviate(testseed, a=3.1, b=7.3)
+    w2 = galsim.WeibullDeviate(testseed, a=3.1, b=7.3)
+    v1 = np.empty(555)
+    v2 = np.empty(555)
+    with single_threaded():
+        w1.generate(v1)
+    with single_threaded(num_threads=10):
+        w2.generate(v2)
+    np.testing.assert_array_equal(v1, v2)
+    with single_threaded():
+        w1.add_generate(v1)
+    with single_threaded(num_threads=10):
+        w2.add_generate(v2)
+    np.testing.assert_array_equal(v1, v2)
 
     # Check picklability
     do_pickle(w, lambda x: (x.serialize(), x.a, x.b))
@@ -1518,6 +1609,22 @@ def test_distfunction():
     np.testing.assert_array_almost_equal(
             test_array, 2*np.array(dFunctionResult), precisionF,
             err_msg='Wrong DistDeviate random number sequence from add_generate.')
+
+    # Check that generated values are independent of number of threads.
+    d1 = galsim.DistDeviate(testseed, function=lambda x: np.exp(-x**3), x_min=0, x_max=2)
+    d2 = galsim.DistDeviate(testseed, function=lambda x: np.exp(-x**3), x_min=0, x_max=2)
+    v1 = np.empty(555)
+    v2 = np.empty(555)
+    with single_threaded():
+        d1.generate(v1)
+    with single_threaded(num_threads=10):
+        d2.generate(v2)
+    np.testing.assert_array_equal(v1, v2)
+    with single_threaded():
+        d1.add_generate(v1)
+    with single_threaded(num_threads=10):
+        d2.add_generate(v2)
+    np.testing.assert_array_equal(v1, v2)
 
     # Check picklability
     do_pickle(d, lambda x: (x(), x(), x(), x()))


### PR DESCRIPTION
This is mostly an efficiency PR to speed up random number generation on large arrays.

When working on [this imSim PR](https://github.com/LSSTDESC/imSim/pull/284) involving raining lots of photons through a sensor object, I was finding that with the OpenMP stuff for the sensor, the pure random number generation was taking almost half the total clock time.  The `generate` calls were running on a single thread, and then the `accumulate` calls were being well parallelized.  My laptop can run 10 threads, so it made a big difference.

This PR enables OpenMP parallelization for the various kinds of RNG `generate` functions that we have.  In practice, it's mostly the `generate` call, but I did all of the various flavors.  

Some RNG types (most notably Poisson) don't reliably use 1 rng per generated value.  This causes problems for the way I am doing the parallelism, so I disable it for these types. We don't want the random number sequences to be dependent on how many threads are being used, and I don't see a different way that would be safe for them.  There's also some trickiness regarding GaussianDeviates, since they use up 2 rngs per 2 values, so odd/even array lengths matter for them.

The upshot is that the photon-based flat field generation went from taking 11 minutes per section down to 9.6 minutes, so 15% faster overall.  But more importantly, if you have a big beefy machine with lots of cores, it will scale better with the number of cores, rather than letting most of them sit idle half the time.  On my laptop, it was maintaining a load of about 7, so still not 100% parallelism, but a lot better than previously.  (I forgot to take note of it, but I think it was more like 4 previously.)

I also moved the `single_threaded` context that was in config/util.py into utilities.py to make it a bit more accessible.  We should highlight this helper class in the release notes for people who don't want any openmp stuff, due to already fully parallelizing with processes or other similar things.  But for most use cases, I think this change should be an improvement.