### PR TITLE
Add TimeSampler

### DIFF
--- a/galsim/__init__.py
+++ b/galsim/__init__.py
@@ -128,6 +128,7 @@ from .image import Image, ImageS, ImageI, ImageF, ImageD, ImageCF, ImageCD, Imag
 # PhotonArray
 from .photon_array import PhotonArray, PhotonOp, WavelengthSampler, FRatioAngles, PhotonDCR
 from .photon_array import Refraction, FocusDepth, PupilImageSampler, PupilAnnulusSampler
+from .photon_array import TimeSampler
 
 # Noise
 from .random import BaseDeviate, UniformDeviate, GaussianDeviate, PoissonDeviate, DistDeviate

--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -21,7 +21,7 @@ import numpy as np
 from .gsobject import GSObject
 from .sed import SED
 from .bandpass import Bandpass
-from .position import Position, PositionD, _PositionD
+from .position import Position, _PositionD
 from .utilities import lazy_property, doc_inherit
 from .gsparams import GSParams
 from .phase_psf import OpticalPSF, Aperture

--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -590,6 +590,8 @@ class ChromaticObject:
         if photon_array.hasAllocatedPupil():
             p1._pupil_u = photon_array._pupil_u
             p1._pupil_v = photon_array._pupil_v
+        if photon_array.hasAllocatedTimes():
+            p1._time = photon_array._time
         obj = local_wcs.toImage(self) if local_wcs is not None else self
         rng = BaseDeviate(rng)
         obj._shoot(p1, rng)

--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -2437,6 +2437,8 @@ class GSObject:
         if photon_array.hasAllocatedPupil():
             p1._pupil_u = photon_array._pupil_u
             p1._pupil_v = photon_array._pupil_v
+        if photon_array.hasAllocatedTimes():
+            p1._time = photon_array._time
         obj = local_wcs.toImage(self) if local_wcs is not None else self
         obj._shoot(p1, rng)
         photon_array.convolve(p1, rng)

--- a/tests/test_chromatic.py
+++ b/tests/test_chromatic.py
@@ -2190,15 +2190,7 @@ def test_phot():
         print('psf = ',psf)
         atol = 4.e-4
         if psf in [psf5, psf6]:
-            atol = 5.e-4  # OpticalPSF doesn't match quite as well as the others.
-                          # geometric_shooting=False does better, even with the larger aberrations,
-                          # but it doesn't reliably pass at 3e-4 under different random seeds,
-                          # so just leave this as 4e-4 too to be more future-proof to random
-                          # variations.
-                          # Bumped these to 4e-4, 5e-4 after introducing fft_sign kwarg to
-                          # OpticalPSF.  We effectively rotate the PSF 180 degrees here, but not the
-                          # galaxy, so we end up with a slightly different profile.  I (JM) think we
-                          # just got lucky before.
+            atol = 6e-4   # OpticalPSF doesn't match quite as well as the others.
         rng = galsim.BaseDeviate(1234)
 
         # First draw with FFT
@@ -2261,11 +2253,12 @@ def test_phot():
 
         # Finally, the chromatic drawImage function should handle the wavelength sampling for us.
         # First do this with just the galaxy as the driver.
-        # (Also add a gratuitous pupil_sampler to test the case where pupil_u,v are set.)
+        # (Also add a gratuitous pupil_sampler, time_sampler to test the case where u,v,t are set.)
         pupil_sampler = galsim.PupilImageSampler(diam=diam, lam=bandpass.effective_wavelength)
+        time_sampler = galsim.TimeSampler()
         t0 = time.time()
         im4 = gal.drawImage(bandpass, image=im1.copy(), method='phot', rng=rng,
-                            photon_ops=[pupil_sampler, psf])
+                            photon_ops=[pupil_sampler, time_sampler, psf])
         t1 = time.time()
         print('auto wave time = ',t1-t0)
         print('max diff/flux = ',np.max(np.abs(im1.array-im4.array)/flux))

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -1222,7 +1222,6 @@ def test_shared_memory():
         spd.append(u()*max_speed)
         dirn.append(u()*360*galsim.degrees)
         r0_500s.append(r0_500*weights[i]**(-3./5))
-    rng2 = rng.duplicate()
 
     if __name__ == "__main__":
         ctxs = [None, mp.get_context("fork"), mp.get_context("spawn"), "forkserver"]
@@ -1515,6 +1514,17 @@ def test_uv_persistence():
         assert np.max(mindist) < np.hypot(uscale, vscale)*0.5
 
         do_pickle(photons)
+
+
+def test_t_persistence():
+    rng = galsim.BaseDeviate(10)
+    atm = galsim.Atmosphere(screen_size=10.0, altitude=[0,1,2,3], r0_500=0.2, rng=rng)
+    psf = atm.makePSF(t0=10.0, lam=500.0, diam=1.0, exptime=15.0, time_step=0.025)
+    nphot = 1_000_000
+    photons = psf.drawImage(save_photons=True, method='phot', n_photons=nphot).photons
+    assert photons.hasAllocatedTimes()
+    assert np.min(photons.time) > 10.0
+    assert np.max(photons.time) < 25.0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Same idea here as #1176 where we factored out pupil sampling from `PhaseScreenPSF._shoot`.  This time, factor out the temporal sampling.  This isn't immediately useful for anything directly inside GalSim, but would likely be important if we want to rotate the diffraction spikes on an Alt-Az mounted telescope in the future, e.g..