### PR TITLE
#1067 Enable galsim.BaseDeviate to be used as a numpy.Generator

### DIFF
--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -629,27 +629,15 @@ class Aperture:
         n_photons = len(photons)
         u = self.u_illuminated
         v = self.v_illuminated
-        ud = UniformDeviate(rng)
-        pick = np.empty((n_photons,), dtype=float)
-        ud.generate(pick)
-        pick *= len(u)
-        pickint = pick.astype(int)
-        photons.pupil_u = u[pickint]
-        photons.pupil_v = v[pickint]
+        gen = rng.as_numpy_generator()
+        pick = gen.choice(len(u), size=n_photons).astype(int)
+        photons.pupil_u = u[pick]
+        photons.pupil_v = v[pick]
         # Make continuous by adding +/- 0.5 pixels shifts.
         uscale = self.u[0, 1] - self.u[0, 0]
         vscale = self.v[1, 0] - self.v[0, 0]
-        # Reuse pick but rename for clarity
-        du = pick
-        ud.generate(du)
-        du -= 0.5
-        du *= uscale
-        photons.pupil_u += du
-        dv = pick
-        ud.generate(dv)
-        dv -= 0.5
-        dv *= vscale
-        photons.pupil_v += dv
+        photons.pupil_u += gen.uniform(-uscale/2.,uscale/2.,size=n_photons)
+        photons.pupil_v += gen.uniform(-vscale/2.,vscale/2.,size=n_photons)
 
     # Some quick notes for Josh:
     # - Relation between real-space grid with size theta and pitch dtheta (dimensions of angle)

--- a/galsim/random.py
+++ b/galsim/random.py
@@ -119,6 +119,34 @@ class BaseDeviate:
         """
         self._rng = self._rng_type(rng._rng, *self._rng_args)
 
+    @property
+    def np(self):
+        """Shorthand for self.as_numpy_generator()
+        """
+        return self.as_numpy_generator()
+
+    def as_numpy_generator(self):
+        """Return a numpy.random.Generator object that uses the current BaseDeviate for the
+        underlying bit generations.
+
+        This allows you to use the (probably) more familiar numpy functions, while maintaining
+        GalSim's guarantees about random number stability across platforms.
+
+        Example::
+
+            >>> rng = galsim.BaseDeviate(1234)
+            >>> gen = rng.as_numpy_generator()
+            >>> uniform = gen.uniform(1, 10, size=10)
+            >>> norm = gen.normal(0, 3, size=20)
+
+        There is also a shorthand syntax that may be convenient.
+        The property `np` is equivalent to this method, so you can also write::
+
+            >>> uniform = rng.np.uniform(1, 10, size=10)
+            >>> norm = rng.np.normal(0, 3, size=20)
+        """
+        return np.random.Generator(GalSimBitGenerator(self))
+
     def duplicate(self):
         """Create a duplicate of the current `BaseDeviate` object.
 
@@ -840,6 +868,18 @@ class DistDeviate(BaseDeviate):
                  self._interpolant == other._interpolant and
                  self._npoints == other._npoints))
 
+
+class GalSimBitGenerator(np.random.BitGenerator):
+    """A numpy.random.BitGenerator that uses the GalSim C++-layer random number generator
+    for the random bit generation.
+
+    Parameters:
+        rng:    The galsim.BaseDeviate object to use for the underlying bit generation.
+    """
+    def __init__(self, rng):
+        super().__init__(0)
+        self.rng = rng
+        self.rng._rng.setup_bitgen(self.capsule)
 
 def permute(rng, *args):
     """Randomly permute one or more lists.

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -1715,6 +1715,38 @@ def test_int64():
         rng2 = galsim.BaseDeviate(i)
         assert rng2 == rng1
 
+@timer
+def test_numpy_generator():
+    rng = galsim.BaseDeviate(1234)
+    gen = galsim.BaseDeviate(1234).as_numpy_generator()
+
+    # The regular (and somewhat cumbersome) GalSim way:
+    a1 = np.empty(10, dtype=float)
+    galsim.UniformDeviate(rng).generate(a1)
+    a1 *= 9.
+    a1 += 1.
+
+    # The nicer numpy syntax
+    a2 = gen.uniform(1.,10., size=10)
+    print('a1 = ',a1)
+    print('a2 = ',a1)
+    np.testing.assert_allclose(a1, a2, atol=1.e-8)  # Small rounding differences
+
+    # Can also use the np property as a quick shorthand
+    a1 = rng.np.normal(0, 10, size=20)
+    a2 = gen.normal(0, 10, size=20)
+    print('a1 = ',a1)
+    print('a2 = ',a1)
+    np.testing.assert_array_equal(a1, a2)
+
+    # Check that normal gives statistically the right mean/var.
+    # (Numpy's normal uses the next_uint64 function, so this is a non-trivial test of that
+    # code, which I originally got wrong.)
+    a3 = gen.normal(17, 23, size=1_000_000)
+    print('mean = ',np.mean(a3))
+    print('std = ',np.std(a3))
+    assert np.isclose(np.mean(a3), 17, rtol=1.e-3)
+    assert np.isclose(np.std(a3), 23, rtol=3.e-3)
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]


### PR DESCRIPTION
This PR adds the ability to recast a `galsim.BaseDeviate` object as a `numpy.Generator`.  I allow this via `rng.as_numpy_generator()`, for people who prefer verbose methods for this kind of thing.  And a quick and dirty `rng.np` property for people who prefer an abbreviated syntax.  I think I'll prefer the latter, but they do the same thing, so to each their own.

This took me a while to figure out, since the documentation for making your own numpy.random.BitGenerator is pretty spare.  And the primary source for all this is done in cython, which I didn't want to deal with on our end.  

But it turns out not to be that hard once I figured out how everything works.  You basically just let the numpy base class make all the initial stuff.  Then you overwrite the elements of the `capsule`'s `bitgen_t` struct with the functions you actually want to use.  And there are only three functions returning `uint32_t`, `uint64_t` and `double`.  So those are pretty easy.  I was almost surprised when it actually worked for me.  (To be fair, this was attempt number 30 or so, so I'd gotten used to failing by that point.)

I also updated a few places in the code to use the new numpy syntax, where I thought the numpy syntax was clearly superior.  (Including the recent PR's of @jmeyers314 which prompted this effort.)