### PR TITLE
Make it possible to delete items from a config list

### DIFF
--- a/galsim/config/process.py
+++ b/galsim/config/process.py
@@ -187,7 +187,7 @@ def ProcessTemplate(config, base, logger=None):
             config['modules'].extend(new_params.pop('modules', []))
 
         # Update the config with the requested changes
-        UpdateConfig(config, new_params)
+        UpdateConfig(config, new_params, logger)
 
 
 def ProcessAllTemplates(config, logger=None, base=None):
@@ -254,7 +254,7 @@ def Process(config, logger=None, njobs=1, job=1, new_params=None, except_abort=F
 
     # Update using any new_params that are given:
     if new_params is not None:
-        UpdateConfig(config, new_params)
+        UpdateConfig(config, new_params, logger)
 
     # Do this again in case any new modules were added by the templates or command line params.
     ImportModules(config)

--- a/galsim/config/util.py
+++ b/galsim/config/util.py
@@ -591,7 +591,7 @@ def GetFromConfig(config, key):
             "Unable to parse extended key %s.  Field %s is invalid."%(key,k)) from None
     return value
 
-def SetInConfig(config, key, value):
+def SetInConfig(config, key, value, logger=None):
     """Set the value of a (possibly extended) key in a config dict.
 
     If key is a simple string, then this is equivalent to config[key] = value.
@@ -608,7 +608,17 @@ def SetInConfig(config, key, value):
     d, k = ParseExtendedKey(config, key)
     if value == '':
         # This means remove it, if it is there.
-        d.pop(k,None)
+        try:
+            d.pop(k,None)
+        except TypeError:
+            # Then d was really a list.
+            # This has some potentially counter-intuitive consequences, so let the user
+            # know about them.
+            if logger:
+                logger.warning("Warnign: Removing item %d from %s. "%(k,key[:key.rfind('.')]) +
+                               "Any further adjustments to this list must use the new "+
+                               "list index values, not the original indices.")
+            del d[k]
     else:
         try:
             d[k] = value
@@ -617,7 +627,7 @@ def SetInConfig(config, key, value):
                 "Unable to parse extended key %s.  Field %s is invalid."%(key,k)) from None
 
 
-def UpdateConfig(config, new_params):
+def UpdateConfig(config, new_params, logger=None):
     """Update the given config dict with additional parameters/values.
 
     Parameters:
@@ -627,7 +637,7 @@ def UpdateConfig(config, new_params):
                         parsed to update config['gal']['first']['dilate'].
     """
     for key, value in new_params.items():
-        SetInConfig(config, key, value)
+        SetInConfig(config, key, value, logger)
 
 
 def MultiProcess(nproc, config, job_func, tasks, item, logger=None, timeout=900,

--- a/galsim/config/util.py
+++ b/galsim/config/util.py
@@ -615,7 +615,7 @@ def SetInConfig(config, key, value, logger=None):
             # This has some potentially counter-intuitive consequences, so let the user
             # know about them.
             if logger:
-                logger.warning("Warnign: Removing item %d from %s. "%(k,key[:key.rfind('.')]) +
+                logger.warning("Warning: Removing item %d from %s. "%(k,key[:key.rfind('.')]) +
                                "Any further adjustments to this list must use the new "+
                                "list index values, not the original indices.")
             del d[k]


### PR DESCRIPTION
@g-braeunlich found that the current syntax for deleting an item from the config doesn't work to delete things from a list.  This PR remedies this.

The one potentially confusing thing that can result from this is if the user also wants to modify other items in the same list.  Once an item is deleted, these would need to use the new indices, not the original ones.  This seems enough error-prone that I emit a logger warning.

I've targeted this to releases/2.4.  I think this can count as a bug, so could go into a bugfix release.