### PR TITLE
Fix bug in how input fields check when they are current

### DIFF
--- a/galsim/config/input_powerspectrum.py
+++ b/galsim/config/input_powerspectrum.py
@@ -78,12 +78,13 @@ class PowerSpectrumLoader(InputLoader):
                         'ips_index' : config['index'] })
             config['rng_num'] = len(rs) - 1
             base['image']['random_seed'] = rs
+            orig_index_key = base.get('index_key', 'file_num')
             base['index_key'] = 'file_num'
             SetupConfigRNG(base, logger=logger)
             if image_num is not None:
                 base['index_key'] = 'image_num'
                 SetupConfigRNG(base, logger=logger)
-            base['index_key'] = 'file_num'  # This is what we want to leave it as.
+            base['index_key'] = orig_index_key
             base['obj_num'] = obj_num
             base['image_num'] = image_num
             base['file_num'] = file_num

--- a/tests/test_config_image.py
+++ b/tests/test_config_image.py
@@ -2538,9 +2538,6 @@ def test_variable_cat_size():
     galsim.config.Process(config1, logger=logger)
     cfg_images2 = galsim.fits.readMulti('output/test_variable_input.fits')
     assert cfg_images2[0] == ref_images[0]
-    cfg_images2[0].write('junk0.fits')
-    cfg_images2[1].write('junk1.fits')
-    ref_images[1].write('junk2.fits')
     assert cfg_images2[1] == ref_images[1]
 
 


### PR DESCRIPTION
This fixes another bug discovered during imSim development.  @jchiang87 found that sometimes the skycatalog input object wasn't being loaded correctly when there were multiple ccds being rendered in the same config run.  It took me a while to figure out the problem, but it stemmed from how the `current` item was being set (and checked), which was different from how I do that for regular (non-input) values.  It mostly worked, but wasn't quite correct, leading to the bug that Jim found.

Anyway, this mostly just switches over the current checks there to more closely mimic the way I do it elsewhere.  And I added a unit test that fails for the old code, but works now.  

TBH, I feel a little silly about not already having written this test, which would have found the error sooner.  It's sort of an obvious extension to a test that we already had, but which skipped running things the normal way using Process, so it managed to not hit the code paths that had the error.