### PR TITLE
Fix hsm assert when step or stride is < 0

### DIFF
--- a/include/galsim/Image.h
+++ b/include/galsim/Image.h
@@ -188,6 +188,13 @@ namespace galsim {
         const T* getData() const { return _data; }
         const T* getMaxPtr() const { return _maxptr; }
 
+        /// Check that the ptr is valid, properly accounting for step, stride
+        // Normally (if step, stride > 0), this check is just _data <= p < _maxptr.
+        // If either step or stride is negative, then p can be > _maxptr and still be valid.
+        // TODO: For now, we punt on this if step or stride is < 0.
+        //       Maybe worth making this more rigorous?
+        bool ok_ptr(const T* p) const { return p < _maxptr || _step < 0 || _stride < 0; }
+
         /**
          *  @brief Return how many data elements are currently allocated in memory.
          *

--- a/include/galsim/Image.h
+++ b/include/galsim/Image.h
@@ -191,8 +191,9 @@ namespace galsim {
         /// Check that the ptr is valid, properly accounting for step, stride
         // Normally (if step, stride > 0), this check is just _data <= p < _maxptr.
         // If either step or stride is negative, then p can be > _maxptr and still be valid.
-        // TODO: For now, we punt on this if step or stride is < 0.
-        //       Maybe worth making this more rigorous?
+        // For now, we punt on this if step or stride is < 0.
+        // Also, don't bother checking p >= _data, since that's usually not an issue.
+        // TODO: Maybe worth making this more rigorous at some point?
         bool ok_ptr(const T* p) const { return p < _maxptr || _step < 0 || _stride < 0; }
 
         /**

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -325,7 +325,7 @@ const T& BaseImage<T>::at(const int xpos, const int ypos) const
     if (!_data) throw ImageError("Attempt to access values of an undefined image");
     if (!this->_bounds.includes(xpos, ypos)) throw ImageBoundsError(xpos, ypos, this->_bounds);
     ptrdiff_t addr = addressPixel(xpos, ypos);
-    assert(_data + addr < _maxptr);
+    assert(ok_ptr(_data + addr));
     return _data[addr];
 }
 
@@ -335,7 +335,7 @@ T& ImageView<T>::at(const int xpos, const int ypos)
     if (!this->_data) throw ImageError("Attempt to access values of an undefined image");
     if (!this->_bounds.includes(xpos, ypos)) throw ImageBoundsError(xpos, ypos, this->_bounds);
     ptrdiff_t addr = this->addressPixel(xpos, ypos);
-    assert(this->_data + addr < this->_maxptr);
+    assert(this->ok_ptr(this->_data + addr));
     return this->_data[addr];
 }
 
@@ -345,7 +345,7 @@ T& ImageAlloc<T>::at(const int xpos, const int ypos)
     if (!this->_data) throw ImageError("Attempt to access values of an undefined image");
     if (!this->_bounds.includes(xpos, ypos)) throw ImageBoundsError(xpos, ypos, this->_bounds);
     ptrdiff_t addr = this->addressPixel(xpos, ypos);
-    assert(this->_data + addr < this->_maxptr);
+    assert(this->ok_ptr(this->_data + addr));
     return this->_data[addr];
 }
 
@@ -355,7 +355,7 @@ const T& ImageAlloc<T>::at(const int xpos, const int ypos) const
     if (!this->_data) throw ImageError("Attempt to access values of an undefined image");
     if (!this->_bounds.includes(xpos, ypos)) throw ImageBoundsError(xpos, ypos, this->_bounds);
     ptrdiff_t addr = this->addressPixel(xpos, ypos);
-    assert(this->_data + addr < this->_maxptr);
+    assert(this->ok_ptr(this->_data + addr));
     return this->_data[addr];
 }
 
@@ -371,7 +371,7 @@ ConstImageView<T> BaseImage<T>::subImage(const Bounds<int>& bounds) const
     ptrdiff_t off = (bounds.getYMin() - this->_bounds.getYMin()) * _stride
         + (bounds.getXMin() - this->_bounds.getXMin()) * _step;
     T* newdata = _data + off;
-    assert(newdata < _maxptr);
+    assert(ok_ptr(newdata));
     return ConstImageView<T>(newdata,_maxptr,0,_owner,_step,_stride,bounds);
 }
 
@@ -387,7 +387,7 @@ ImageView<T> ImageView<T>::subImage(const Bounds<int>& bounds)
     ptrdiff_t off = (bounds.getYMin() - this->_bounds.getYMin()) * this->_stride
         + (bounds.getXMin() - this->_bounds.getXMin()) * this->_step;
     T* newdata = this->_data + off;
-    assert(newdata < this->_maxptr);
+    assert(this->ok_ptr(newdata));
     return ImageView<T>(newdata,this->_maxptr,0,this->_owner,this->_step,this->_stride,bounds);
 }
 
@@ -785,8 +785,8 @@ void rfft(const BaseImage<T>& in, ImageView<std::complex<double> > out,
                     *xptr++ = REAL(*ptr);
         }
     }
-    assert(xptr-3 < (double*)(out.getMaxPtr()));
-    assert(ptr-in.getStep()-skip < in.getMaxPtr());
+    assert(out.ok_ptr((std::complex<double>*)(xptr-3)));
+    assert(in.ok_ptr(ptr-in.getStep()-skip));
 
     fftw_complex* kdata = reinterpret_cast<fftw_complex*>(out.getData());
     double* xdata = reinterpret_cast<double*>(out.getData());
@@ -805,7 +805,7 @@ void rfft(const BaseImage<T>& in, ImageView<std::complex<double> > out,
         for (int j=Ny; j; --j, fac=(extra_flip?-fac:fac))
             for (int i=Nxo2+1; i; --i, fac=-fac)
                 *kptr++ *= fac;
-        assert(kptr-1 < out.getMaxPtr());
+        assert(out.ok_ptr(kptr-1));
     }
 }
 
@@ -895,8 +895,8 @@ void irfft(const BaseImage<T>& in, ImageView<double> out, bool shift_in, bool sh
                     *kptr++ = fac * *ptr;
         }
     }
-    assert(kptr-1 < (std::complex<double>*)(out.getMaxPtr()));
-    assert(ptr-in.getStep()-skip < in.getMaxPtr());
+    assert(out.ok_ptr((double*) (kptr-1)));
+    assert(in.ok_ptr(ptr-in.getStep()-skip));
 
     double* xdata = out.getData();
     fftw_complex* kdata = reinterpret_cast<fftw_complex*>(xdata);
@@ -971,8 +971,8 @@ void cfft(const BaseImage<T>& in, ImageView<std::complex<double> > out,
                     *kptr++ = *ptr;
         }
     }
-    assert(kptr-1 < out.getMaxPtr());
-    assert(ptr-in.getStep()-skip < in.getMaxPtr());
+    assert(out.ok_ptr(kptr-1));
+    assert(in.ok_ptr(ptr-in.getStep()-skip));
 
     fftw_complex* kdata = reinterpret_cast<fftw_complex*>(out.getData());
 
@@ -988,7 +988,7 @@ void cfft(const BaseImage<T>& in, ImageView<std::complex<double> > out,
         for (int j=Ny; j; --j, fac=-fac)
             for (int i=Nx; i; --i, fac=-fac)
                 *kptr++ *= fac;
-        assert(kptr-1 < out.getMaxPtr());
+        assert(out.ok_ptr(kptr-1));
     }
 }
 

--- a/tests/test_hsm.py
+++ b/tests/test_hsm.py
@@ -919,6 +919,20 @@ def test_very_small():
     assert "Object is too small" in mom.error_message
 
 
+def test_negative_stepstride():
+    """In response to #1185, check that hsm works for arrays with negative step or stride.
+    """
+    img = galsim.Gaussian(fwhm=1).drawImage()
+    result1 = galsim.hsm.FindAdaptiveMom(img)
+    result2 = galsim.hsm.FindAdaptiveMom(galsim.Image(img.array[::-1]))
+    result3 = galsim.hsm.FindAdaptiveMom(galsim.Image(img.array[:,::-1]))
+    result4 = galsim.hsm.FindAdaptiveMom(galsim.Image(img.array[::-1,::-1]))
+
+    assert np.isclose(result1.moments_sigma, result2.moments_sigma)
+    assert np.isclose(result1.moments_sigma, result3.moments_sigma)
+    assert np.isclose(result1.moments_sigma, result4.moments_sigma)
+
+
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
     for testfn in testfns:

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -19,6 +19,7 @@
 import numpy as np
 import os
 import sys
+import platform
 
 import galsim
 from galsim_test_helpers import *
@@ -1772,18 +1773,22 @@ def test_depixelize():
     # Second time with the same size image is much faster, since uses a cache.
     nopix_image2 = im1.depixelize(x_interpolant=interp)
     t8 = time.time()
-    assert t8-t7 < (t3-t2)/10
+    if platform.python_implementation() != 'PyPy':
+        # PyPy timings can be fairly arbitrary at times.
+        assert t8-t7 < (t3-t2)/10
 
     # Even if the image is different.
     nopix_image3 = im4.depixelize(x_interpolant=interp)
     t9 = time.time()
-    assert t9-t8 < (t3-t2)/10
+    if platform.python_implementation() != 'PyPy':
+        assert t9-t8 < (t3-t2)/10
 
     # But not if you clear the cache.
     galsim.Image.clear_depixelize_cache()
     nopix_image4 = im4.depixelize(x_interpolant=interp)
     t10 = time.time()
-    assert t10-t9 > (t3-t2)/10
+    if platform.python_implementation() != 'PyPy':
+        assert t10-t9 > (t3-t2)/10
 
     print('times:')
     print('make ii_with_pixel: ',t1-t0)


### PR DESCRIPTION
The asserts in the hsm code are not correct when either step or stride is negative.  For now, just skip these checks when either step or stride is negative.  But possibly down the line we might want to make this check more rigorous to include the case of negative steps or strides.