### PR TITLE
Fix Scattered positions if world_pos is in the stamp field

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ API Changes
 Config Updates
 --------------
 
+- Fixed a bug in Scattered type, where it didn't respect world_pos being specified in the
+  stamp field, as it should.  (#1190)
 
 
 New Features

--- a/galsim/config/image_scattered.py
+++ b/galsim/config/image_scattered.py
@@ -108,7 +108,9 @@ class ScatteredImageBuilder(ImageBuilder):
                 "Both image_pos and world_pos specified for Scattered image.",
                 (config['image_pos'], config['world_pos']))
 
-        if 'image_pos' not in config and 'world_pos' not in config:
+        if ('image_pos' not in config and 'world_pos' not in config and
+                not ('stamp' in base and
+                    ('image_pos' in base['stamp'] or 'world_pos' in base['stamp']))):
             xmin = base['image_origin'].x
             xmax = xmin + full_xsize-1
             ymin = base['image_origin'].y

--- a/tests/test_config_image.py
+++ b/tests/test_config_image.py
@@ -948,6 +948,22 @@ def test_scattered():
             np.testing.assert_almost_equal(ixy, 0., decimal=3)
             np.testing.assert_almost_equal(iyy / (sigma/scale)**2, 1, decimal=1)
 
+            # Check that image_pos can be in a stamp field, rather than image.
+            config = galsim.config.CleanConfig(config)
+            config['stamp'] = { 'image_pos' : base_config['image']['image_pos'] }
+            del config['image']['image_pos']
+            image2 = galsim.config.BuildImage(config)
+            assert image == image2
+
+            # Can also use world_pos instead.
+            config = galsim.config.CleanConfig(config)
+            del config['stamp']['image_pos']
+            config['stamp']['world_pos'] = [ galsim.PositionD(x1*scale, y1*scale),
+                                             galsim.PositionD(x2*scale, y2*scale),
+                                             galsim.PositionD(x3*scale, y3*scale) ]
+            image2 = galsim.config.BuildImage(config)
+            assert image == image2
+
     config['image']['index_convention'] = 'invalid'
     with assert_raises(galsim.GalSimConfigError):
         galsim.config.BuildImage(config)


### PR DESCRIPTION
Josh discovered that the Scattered type doesn't respect `world_pos` if it's in the stamp field, as it should.  Instead it adds its own `image_pos` specification in the image field, which ends up taking precedence.

It turns out that an `image_pos` in the stamp field did work, kind of by accident, just because when we make the position, it checks stamp first, finds it, and uses it, and just ignores the default one that was made in the image field.  But now the Scattered function explicitly checks the stamp field and only makes the default if there are no other positions anywhere.