### PR TITLE
Deprecate getter allocation in PhotonArray

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,12 @@ Changes from v2.4 to v2.5
 API Changes
 -----------
 
+- Deprecated automatic allocation of `PhotonArray` arrays via "get" access rather than
+  "set" access for the arrays that are not initially allocated.  E.g. writing
+  ``dxdz = photon_array.dxdz`` will emit a warning (and eventually this will be an error)
+  if the angle arrays have not been either set or explicitly allocated.  One should be sure
+  to either set them (e.g. using ``photon_array.dxdz = [...]``) or explicitly allocate
+  them (using ``photon_array.allocateAngles()``).  (#1191)
 
 
 Config Updates

--- a/galsim/photon_array.py
+++ b/galsim/photon_array.py
@@ -245,7 +245,13 @@ class PhotonArray:
     def dxdz(self):
         """The tangent of the inclination angles in the x direction: dx/dz.
         """
-        self.allocateAngles()
+        if not self.hasAllocatedAngles():
+            from .deprecated import depr
+            depr('dxdz accessed before being set.', 2.5,
+                 'Angle arrays should be set or explicitly allocated before being accessed.',
+                 'For now, accessing dxdz allocates an array with all zeros. '
+                 'This will become an error in a future version (probably 3.0).')
+            self.allocateAngles()
         return self._dxdz
     @dxdz.setter
     def dxdz(self, value):
@@ -256,7 +262,13 @@ class PhotonArray:
     def dydz(self):
         """The tangent of the inclination angles in the y direction: dy/dz.
         """
-        self.allocateAngles()
+        if not self.hasAllocatedAngles():
+            from .deprecated import depr
+            depr('dydz accessed before being set.', 2.5,
+                 'Angle arrays should be set or explicitly allocated before being accessed.',
+                 'For now, accessing dydz allocates an array with all zeros. '
+                 'This will become an error in a future version (probably 3.0).')
+            self.allocateAngles()
         return self._dydz
     @dydz.setter
     def dydz(self, value):
@@ -267,7 +279,13 @@ class PhotonArray:
     def wavelength(self):
         """The wavelength of the photons (in nm).
         """
-        self.allocateWavelengths()
+        if not self.hasAllocatedWavelengths():
+            from .deprecated import depr
+            depr('wavelength accessed before being set.', 2.5,
+                 'Wavelength array should be set or explicitly allocated before being accessed.',
+                 'For now, accessing wavelength allocates arrays with all zeros. '
+                 'This will become an error in a future version (probably 3.0).')
+            self.allocateWavelengths()
         return self._wave
     @wavelength.setter
     def wavelength(self, value):
@@ -278,7 +296,13 @@ class PhotonArray:
     def pupil_u(self):
         """Horizontal location of photon as it intersected the entrance pupil plane.
         """
-        self.allocatePupil()
+        if not self.hasAllocatedPupil():
+            from .deprecated import depr
+            depr('pupil_u accessed before being set.', 2.5,
+                 'Pupil arrays should be set or explicitly allocated before being accessed.',
+                 'For now, accessing pupil_u allocates arrays with all zeros. '
+                 'This will become an error in a future version (probably 3.0).')
+            self.allocatePupil()
         return self._pupil_u
     @pupil_u.setter
     def pupil_u(self, value):
@@ -289,7 +313,13 @@ class PhotonArray:
     def pupil_v(self):
         """Vertical location of photon as it intersected the entrance pupil plane.
         """
-        self.allocatePupil()
+        if not self.hasAllocatedPupil():
+            from .deprecated import depr
+            depr('pupil_v accessed before being set.', 2.5,
+                 'Pupil arrays should be set or explicitly allocated before being accessed.',
+                 'For now, accessing pupil_v allocates arrays with all zeros. '
+                 'This will become an error in a future version (probably 3.0).')
+            self.allocatePupil()
         return self._pupil_v
     @pupil_v.setter
     def pupil_v(self, value):
@@ -300,7 +330,13 @@ class PhotonArray:
     def time(self):
         """Time stamp of when photon encounters the pupil plane.
         """
-        self.allocateTimes()
+        if not self.hasAllocatedTimes():
+            from .deprecated import depr
+            depr('time accessed before being set.', 2.5,
+                 'Time array should be set or explicitly allocated before being accessed.',
+                 'For now, accessing time allocates arrays with all zeros. '
+                 'This will become an error in a future version (probably 3.0).')
+            self.allocateTimes()
         return self._time
     @time.setter
     def time(self, value):
@@ -409,14 +445,18 @@ class PhotonArray:
         self.y[s] = rhs.y
         self.flux[s] = rhs.flux
         if rhs.hasAllocatedAngles():
+            self.allocateAngles()
             self.dxdz[s] = rhs.dxdz
             self.dydz[s] = rhs.dydz
         if rhs.hasAllocatedWavelengths():
+            self.allocateWavelengths()
             self.wavelength[s] = rhs.wavelength
         if rhs.hasAllocatedPupil():
+            self.allocatePupil()
             self.pupil_u[s] = rhs.pupil_u
             self.pupil_v[s] = rhs.pupil_v
         if rhs.hasAllocatedTimes():
+            self.allocateTimes()
             self.time[s] = rhs.time
 
     def convolve(self, rhs, rng=None):
@@ -792,9 +832,7 @@ class FRatioAngles(PhotonOp):
         """
         gen = BaseDeviate(rng).as_numpy_generator()
 
-        dxdz = photon_array.dxdz
-        dydz = photon_array.dydz
-        n_photons = len(dxdz)
+        n_photons = len(photon_array)
 
         # The f/ratio is the ratio of the focal length to the diameter of the aperture of
         # the telescope.  The angular radius of the field of view is defined by the
@@ -813,8 +851,8 @@ class FRatioAngles(PhotonOp):
         # zero of phi does not matter but it would if the obscuration is dependent on
         # phi
         tantheta = np.sqrt(np.square(sintheta) / (1. - np.square(sintheta)))
-        dxdz[:] = tantheta * np.sin(phi)
-        dydz[:] = tantheta * np.cos(phi)
+        photon_array.dxdz = tantheta * np.sin(phi)
+        photon_array.dydz = tantheta * np.cos(phi)
 
     def __str__(self):
         return "galsim.FRatioAngles(fratio=%s, obscration=%s, rng=%s)"%(

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -492,6 +492,117 @@ def test_hsm_depr():
     hsmp = check_dep(galsim.hsm.HSMParams, max_moment_nsig2=25.0)
     assert hsmp.max_moment_nsig2 == 0.
 
+@timer
+def test_photon_array_depr():
+    nphotons = 1000
+
+    # First create from scratch
+    photon_array = galsim.PhotonArray(nphotons)
+    assert len(photon_array.x) == nphotons
+    assert len(photon_array.y) == nphotons
+    assert len(photon_array.flux) == nphotons
+    assert not photon_array.hasAllocatedWavelengths()
+    assert not photon_array.hasAllocatedAngles()
+    assert not photon_array.hasAllocatedTimes()
+    assert not photon_array.hasAllocatedPupil()
+
+    # No deprecation warning using setter
+    photon_array.dxdz = 0.17
+    assert photon_array.hasAllocatedAngles()
+    assert len(photon_array.dxdz) == nphotons
+    assert len(photon_array.dydz) == nphotons
+    np.testing.assert_array_equal(photon_array.dxdz, 0.17)
+    np.testing.assert_array_equal(photon_array.dydz, 0.)
+
+    photon_array.dydz = 0.59
+    assert photon_array.hasAllocatedAngles()
+    assert len(photon_array.dxdz) == nphotons
+    assert len(photon_array.dydz) == nphotons
+    np.testing.assert_array_equal(photon_array.dxdz, 0.17)
+    np.testing.assert_array_equal(photon_array.dydz, 0.59)
+
+    photon_array.wavelength = 500.
+    assert photon_array.hasAllocatedWavelengths()
+    assert len(photon_array.wavelength) == nphotons
+    np.testing.assert_array_equal(photon_array.wavelength, 500)
+
+    photon_array.pupil_u = 6.0
+    assert photon_array.hasAllocatedPupil()
+    assert len(photon_array.pupil_u) == nphotons
+    assert len(photon_array.pupil_v) == nphotons
+    np.testing.assert_array_equal(photon_array.pupil_u, 6.0)
+    np.testing.assert_array_equal(photon_array.pupil_v, 0.0)
+
+    photon_array.time = 0.0
+    assert photon_array.hasAllocatedTimes()
+    assert len(photon_array.time) == nphotons
+    np.testing.assert_array_equal(photon_array.time, 0.0)
+
+    # Using the getter is allowed, but deprecated.
+    photon_array = galsim.PhotonArray(nphotons)
+    dxdz = check_dep(getattr, photon_array, 'dxdz')
+    assert photon_array.hasAllocatedAngles()
+    assert photon_array.hasAllocatedAngles()
+    assert len(photon_array.dxdz) == nphotons
+    assert len(photon_array.dydz) == nphotons
+    dxdz[:] = 0.17
+    np.testing.assert_array_equal(photon_array.dxdz, 0.17)
+    np.testing.assert_array_equal(photon_array.dydz, 0.)
+
+    dydz = photon_array.dydz  # Allowed now.
+    dydz[:] = 0.59
+    np.testing.assert_array_equal(photon_array.dydz, 0.59)
+
+    wave = check_dep(getattr, photon_array, 'wavelength')
+    assert photon_array.hasAllocatedWavelengths()
+    assert len(photon_array.wavelength) == nphotons
+    wave[:] = 500.
+    np.testing.assert_array_equal(photon_array.wavelength, 500)
+
+    u = check_dep(getattr, photon_array, 'pupil_u')
+    assert photon_array.hasAllocatedPupil()
+    assert len(photon_array.pupil_u) == nphotons
+    assert len(photon_array.pupil_v) == nphotons
+    u[:] = 6.0
+    np.testing.assert_array_equal(photon_array.pupil_u, 6.0)
+    np.testing.assert_array_equal(photon_array.pupil_v, 0.0)
+    v = photon_array.pupil_v
+    v[:] = 10.0
+    np.testing.assert_array_equal(photon_array.pupil_v, 10.0)
+
+    t = check_dep(getattr, photon_array, 'time')
+    assert photon_array.hasAllocatedTimes()
+    assert len(photon_array.time) == nphotons
+    np.testing.assert_array_equal(photon_array.time, 0.0)
+    t[:] = 10
+    np.testing.assert_array_equal(photon_array.time, 10.0)
+
+    # For coverage, also need to test the two pair ones in other order.
+    photon_array = galsim.PhotonArray(nphotons)
+    dydz = check_dep(getattr, photon_array, 'dydz')
+    assert photon_array.hasAllocatedAngles()
+    assert photon_array.hasAllocatedAngles()
+    assert len(photon_array.dxdz) == nphotons
+    assert len(photon_array.dydz) == nphotons
+    dydz[:] = 0.59
+    np.testing.assert_array_equal(photon_array.dxdz, 0.)
+    np.testing.assert_array_equal(photon_array.dydz, 0.59)
+
+    dxdz = photon_array.dxdz  # Allowed now.
+    dxdz[:] = 0.17
+    np.testing.assert_array_equal(photon_array.dxdz, 0.17)
+
+    v = check_dep(getattr, photon_array, 'pupil_v')
+    assert photon_array.hasAllocatedPupil()
+    assert len(photon_array.pupil_u) == nphotons
+    assert len(photon_array.pupil_v) == nphotons
+    v[:] = 10.0
+    np.testing.assert_array_equal(photon_array.pupil_u, 0.0)
+    np.testing.assert_array_equal(photon_array.pupil_v, 10.0)
+    u = photon_array.pupil_u
+    u[:] = 6.0
+    np.testing.assert_array_equal(photon_array.pupil_u, 6.0)
+
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]

--- a/tests/test_photon_array.py
+++ b/tests/test_photon_array.py
@@ -1129,6 +1129,7 @@ def test_refract():
     ud = galsim.UniformDeviate(57721)
     for _ in range(1000):
         photon_array = galsim.PhotonArray(1000, flux=1)
+        photon_array.allocateAngles()
         ud.generate(photon_array.dxdz)
         ud.generate(photon_array.dydz)
         photon_array.dxdz *= 1.2  # -0.6 to 0.6
@@ -1188,6 +1189,8 @@ def test_refract():
     # Try a wavelength dependent index_ratio
     index_ratio = lambda w: np.where(w < 1, 1.1, 2.2)
     photon_array = galsim.PhotonArray(100)
+    photon_array.allocateWavelengths()
+    photon_array.allocateAngles()
     ud.generate(photon_array.wavelength)
     ud.generate(photon_array.dxdz)
     ud.generate(photon_array.dydz)
@@ -1241,8 +1244,8 @@ def test_focus_depth():
         photon_array2.x = 0.0
         photon_array2.y = 0.0
         galsim.FRatioAngles(1.234, obscuration=0.606).applyTo(photon_array, rng=bd)
-        photon_array2.dxdz[:] = photon_array.dxdz
-        photon_array2.dydz[:] = photon_array.dydz
+        photon_array2.dxdz = photon_array.dxdz
+        photon_array2.dydz = photon_array.dydz
         fd1 = galsim.FocusDepth(1.1)
         fd2 = galsim.FocusDepth(2.2)
         fd3 = galsim.FocusDepth(3.3)
@@ -1283,10 +1286,10 @@ def test_focus_depth():
         photon_array.x -= 0.5
         photon_array.y -= 0.5
         galsim.FRatioAngles(1.234, obscuration=0.606).applyTo(photon_array, rng=bd)
-        photon_array2.x[:] = photon_array.x
-        photon_array2.y[:] = photon_array.y
-        photon_array2.dxdz[:] = photon_array.dxdz
-        photon_array2.dydz[:] = photon_array.dydz
+        photon_array2.x = photon_array.x
+        photon_array2.y = photon_array.y
+        photon_array2.dxdz = photon_array.dxdz
+        photon_array2.dydz = photon_array.dydz
         depth = ud()-0.5
         galsim.FocusDepth(depth).applyTo(photon_array2)
         np.testing.assert_allclose((photon_array2.x - photon_array.x)/photon_array.dxdz, depth)


### PR DESCRIPTION
Currently, accessing any array in PhotonArray will make sure that it gets allocated if it isn't already and then return the relevant numpy array.  This is intended to make it easy for the user, who can just pretend all the arrays are already allocated and initialized to zeros, but only use up that memory if the user actually indicates that they are using the arrays.

However, Josh pointed out that this can be confusing if you think you've assigned values to something, but didn't and then access the arrays, it will happily give back zero arrays.  This is likely almost always an error.  And for the rare cases where the user might have intended this usage (e.g. doing `rng.generate(photon_array.dxdz)` to populate it), it's easy to just explicitly call `allocateWhatever()` first to make sure the appropriate array is allocated.  

The more typical case of using the setter method (e.g. `photon_array.dxdz = dxdz_values`) will still work as before.