### PR TITLE
Fix some problems when using photon_ops with fft drawing.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,13 @@ jobs:
                       CXX: clang++
 
                     # And a pypy system.
-                    - os: ubuntu-latest
-                      py: pypy-3.7
-                      CC: gcc
-                      CXX: g++
+                    # As of 12/1/2022, this is broken for astropy.
+                    # pypy3 used to work, but that's Py 3.6, and GHA no longer supports it.
+                    # Maybe revisit at some point.  Or maybe don't care too much about pypy...
+                    #- os: ubuntu-latest
+                      #py: pypy-3.7
+                      #CC: gcc
+                      #CXX: g++
 
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
                     # And a pypy system.
                     - os: ubuntu-latest
-                      py: pypy3
+                      py: pypy-3.7
                       CC: gcc
                       CXX: g++
 
@@ -150,7 +150,7 @@ jobs:
                 pip install -U matplotlib astroplan
 
             - name: Install CPython-only dependencies
-              if: matrix.py != 'pypy3'
+              if: matrix.py != 'pypy-3.7'
               run: |
                 # The only one left that doesn't seem to work right on pypy is starlink-pyast.
                 pip install -U starlink-pyast
@@ -205,7 +205,7 @@ jobs:
                 GALSIM_TEST_PY=0 python setup.py test
 
             - name: Upload coverage to codecov
-              if: matrix.py != 'pypy3'
+              if: matrix.py != 'pypy-3.7'
               run: |
                 cd tests
                 pwd -P

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -134,3 +134,8 @@ Changes from v2.4.4 to v2.4.5
 
 - Fixed an assert error that would trigger if hsm was run on images with negative stride. (#1185)
 
+Changes from v2.4.5 to v2.4.6
+=============================
+
+- Fixed drawImage to work correctly for method=fft when using photon_ops. (#1193)
+

--- a/galsim/_version.py
+++ b/galsim/_version.py
@@ -15,5 +15,5 @@
 #    this list of conditions, and the disclaimer given in the documentation
 #    and/or other materials provided with the distribution.
 #
-__version__ = '2.4.5'
+__version__ = '2.4.6'
 __version_info__ = tuple(map(lambda x:int(x.split('-')[0]), __version__.split('.')))[:3]

--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -1275,7 +1275,7 @@ class GSObject:
                   method='auto', area=1., exptime=1., gain=1., add_to_image=False,
                   center=None, use_true_center=True, offset=None,
                   n_photons=0., rng=None, max_extra_noise=0.,
-                  poisson_flux=None, sensor=None, photon_ops=(), n_subsample=3, maxN=None,
+                  poisson_flux=None, sensor=None, photon_ops=None, n_subsample=3, maxN=None,
                   save_photons=False, bandpass=None, setup_only=False,
                   surface_ops=None):
         """Draws an `Image` of the object.
@@ -1597,7 +1597,7 @@ class GSObject:
                             photons onto the image. [default: None]
             photon_ops:     A list of operators that can modify the photon array that will be
                             applied in order before accumulating the photons on the sensor.
-                            [default: ()]
+                            [default: None]
             n_subsample:    The number of sub-pixels per final pixel to use for fft drawing when
                             using a sensor.  The sensor step needs to know the sub-pixel positions
                             of the photons, which is lost in the fft method.  So using smaller
@@ -1676,8 +1676,11 @@ class GSObject:
                     method=method, sensor=sensor, poisson_flux=poisson_flux)
 
         # If using photon ops with fft, then need a sensor.
-        if photon_ops != () and method != 'phot' and sensor is None:
+        if photon_ops is not None and method != 'phot' and sensor is None:
             sensor = Sensor()
+        if photon_ops is None:
+            # Easier to just make it an empty tuple, rather than deal with None below.
+            photon_ops = ()
 
         # Some parameters are only relevant for either phot or when using a sensor.
         if method != 'phot' and sensor is None:

--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -1676,7 +1676,7 @@ class GSObject:
                     method=method, sensor=sensor, poisson_flux=poisson_flux)
 
         # If using photon ops with fft, then need a sensor.
-        if photon_ops != () and method != 'phot':
+        if photon_ops != () and method != 'phot' and sensor is None:
             sensor = Sensor()
 
         # Some parameters are only relevant for either phot or when using a sensor.
@@ -1807,8 +1807,8 @@ class GSObject:
                     niter = 1
 
                 added_photons = 0
+                resume = False
                 for it in range(niter):
-                    resume = False
                     photons = PhotonArray.makeFromImage(draw_image, rng=rng)
 
                     for op in photon_ops:

--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -1606,6 +1606,15 @@ class GSObject:
                             [default: 3]
             maxN:           Sets the maximum number of photons that will be added to the image
                             at a time.  (Memory requirements are proportional to this number.)
+
+                            .. note::
+
+                                Using this parameter will not necessarily produce identical
+                                results as when not using it due to potentially different order
+                                of various random number generations in either the photon_ops,
+                                or the sensor, or (for method='fft') the conversion of the FFT
+                                image to photons.
+
                             [default: None, which means no limit]
             save_photons:   If True, save the `PhotonArray` as ``image.photons``. Only valid if
                             method is 'phot' or sensor is not None.  [default: False]

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -393,7 +393,6 @@ def test_drawImage():
     assert_raises(TypeError, obj.drawImage, rng=galsim.BaseDeviate(234))
     assert_raises(TypeError, obj.drawImage, max_extra_noise=23)
     assert_raises(TypeError, obj.drawImage, poisson_flux=True)
-    assert_raises(TypeError, obj.drawImage, photon_ops=('dummy'))
     assert_raises(TypeError, obj.drawImage, maxN=10000)
     assert_raises(TypeError, obj.drawImage, save_photons=True)
 

--- a/tests/test_photon_array.py
+++ b/tests/test_photon_array.py
@@ -686,6 +686,35 @@ def test_dcr():
     im2c = galsim.config.BuildImage(config)
     assert im2c == im2
 
+    # Should work with fft, but not quite match (because of inexact photon locations).
+    im3 = galsim.ImageF(50, 50, scale=pixel_scale)
+    achrom.drawImage(image=im3, method='fft', rng=rng, photon_ops=photon_ops)
+    printval(im3, im2, show=False)
+    np.testing.assert_allclose(im3.array, im2.array, atol=0.1 * np.max(im2.array),
+                               err_msg="PhotonDCR on fft image didn't match phot image")
+    # Moments come out less than 1% different.
+    res2 = im2.FindAdaptiveMom()
+    res3 = im3.FindAdaptiveMom()
+    np.testing.assert_allclose(res3.moments_amp, res2.moments_amp, rtol=1.e-2)
+    np.testing.assert_allclose(res3.moments_sigma, res2.moments_sigma, rtol=1.e-2)
+    np.testing.assert_allclose(res3.observed_shape.e1, res2.observed_shape.e1, atol=1.e-2)
+    np.testing.assert_allclose(res3.observed_shape.e2, res2.observed_shape.e2, atol=1.e-2)
+    np.testing.assert_allclose(res3.moments_centroid.x, res2.moments_centroid.x, rtol=1.e-2)
+    np.testing.assert_allclose(res3.moments_centroid.y, res2.moments_centroid.y, rtol=1.e-2)
+
+    # Repeat with maxN < flux
+    achrom.drawImage(image=im3, method='auto', rng=rng, photon_ops=photon_ops, maxN=10**4)
+    printval(im3, im2, show=False)
+    np.testing.assert_allclose(im3.array, im2.array, atol=0.2 * np.max(im2.array),
+                               err_msg="PhotonDCR on fft image with maxN didn't match phot image")
+    res3 = im3.FindAdaptiveMom()
+    np.testing.assert_allclose(res3.moments_amp, res2.moments_amp, rtol=1.e-2)
+    np.testing.assert_allclose(res3.moments_sigma, res2.moments_sigma, rtol=1.e-2)
+    np.testing.assert_allclose(res3.observed_shape.e1, res2.observed_shape.e1, atol=1.e-2)
+    np.testing.assert_allclose(res3.observed_shape.e2, res2.observed_shape.e2, atol=1.e-2)
+    np.testing.assert_allclose(res3.moments_centroid.x, res2.moments_centroid.x, rtol=1.e-2)
+    np.testing.assert_allclose(res3.moments_centroid.y, res2.moments_centroid.y, rtol=1.e-2)
+
     # Compare ChromaticAtmosphere image with PhotonDCR image.
     printval(im2, im1, show=False)
     # tolerace for photon shooting is ~sqrt(flux) = 1.e3

--- a/tests/test_photon_array.py
+++ b/tests/test_photon_array.py
@@ -703,6 +703,9 @@ def test_dcr():
     np.testing.assert_allclose(res3.moments_centroid.y, res2.moments_centroid.y, rtol=1.e-2)
 
     # Repeat with maxN < flux
+    # Note: Because of the different way this generates the random positions, it's not identical
+    #       to the above run without maxN.  Both runs are equally valid realizations of photon
+    #       positions corresponding to the FFT image.  But not the same realization.
     achrom.drawImage(image=im3, method='auto', rng=rng, photon_ops=photon_ops, maxN=10**4)
     printval(im3, im2, show=False)
     np.testing.assert_allclose(im3.array, im2.array, atol=0.2 * np.max(im2.array),


### PR DESCRIPTION
@g-braeunlich discovered that using photon_ops with method='fft' doesn't quite work as intended.

First, if you don't explicitly give a sensor object, then it bails out telling you that this isn't allowed.
Second, there is no way to limit the number of photons used as we do when photon shooting very bright objects, so the memory explodes if you try to do this for very bright objects (as we want to do in imSim).

So this fixes some of the sanity checks to work correctly when the user is applying photon ops on an fft image.  And it implements the maxN parameter for this use case, following the same pattern as we do in drawPhot.