### PR TITLE
Let Input Proxy objects access attributes, not just methods.

### DIFF
--- a/galsim/config/input_cosmos.py
+++ b/galsim/config/input_cosmos.py
@@ -61,7 +61,7 @@ class SampleLoader(InputLoader):
             if out_str != '':
                 logger.log(log_level, 'Using user-specified %s: %s',self.cls_name, out_str)
             logger.info("file %d: Sample catalog has %d total objects; %d passed initial cuts.",
-                        base['file_num'], cosmos_cat.getNTot(), cosmos_cat.getNObjects())
+                        base['file_num'], cosmos_cat.getNTot(), cosmos_cat.nobjects)
             if base.get('gal',{}).get('gal_type',None) == 'parametric':
                 logger.log(log_level,"Using parametric galaxies.")
             else:
@@ -92,7 +92,7 @@ def _FinishBuildSampleGalaxy(config, base, ignore, gsparams, logger, sample_cat,
     # Special: if galaxies are selected based on index, and index is Sequence or Random, and max
     # isn't set, set it to nobjects-1.
     if 'index' in config:
-        SetDefaultIndex(config, sample_cat.getNObjects())
+        SetDefaultIndex(config, sample_cat.nobjects)
 
     opt = { "index" : int,
             "gal_type" : str,
@@ -126,7 +126,7 @@ def _FinishBuildSampleGalaxy(config, base, ignore, gsparams, logger, sample_cat,
     #     set by a call to selectRandomIndex, explicitly by the user, or due to the call to
     #     SetDefaultIndex.
     index = kwargs['index']
-    if index >= sample_cat.getNObjects():
+    if index >= sample_cat.nobjects:
         raise GalSimConfigError(
             "index=%s has gone past the number of entries in the %s"%(index, cls_name))
 

--- a/galsim/config/input_real.py
+++ b/galsim/config/input_real.py
@@ -41,10 +41,10 @@ def _BuildRealGalaxy(config, base, ignore, gsparams, logger, param_name='RealGal
     # But not if they specify 'id' or have 'random=True', which overrides that.
     if 'id' not in config:
         if 'random' not in config:
-            SetDefaultIndex(config, real_cat.getNObjects())
+            SetDefaultIndex(config, real_cat.nobjects)
         else:
             if not config['random']:
-                SetDefaultIndex(config, real_cat.getNObjects())
+                SetDefaultIndex(config, real_cat.nobjects)
                 # Need to do this to avoid being caught by the GetAllParams() call, which will flag
                 # it if it has 'index' and 'random' set (but 'random' is False, so really it's OK).
                 del config['random']
@@ -57,7 +57,7 @@ def _BuildRealGalaxy(config, base, ignore, gsparams, logger, param_name='RealGal
 
     if 'index' in kwargs:
         index = kwargs['index']
-        if index >= real_cat.getNObjects() or index < 0:
+        if index >= real_cat.nobjects or index < 0:
             raise GalSimConfigError(
                 "index=%s has gone past the number of entries in the RealGalaxyCatalog"%index)
 
@@ -88,10 +88,10 @@ def _BuildChromaticRealGalaxy(config, base, ignore, gsparams, logger):
     # But not if they specify 'id' or have 'random=True', which overrides that.
     if 'id' not in config:
         if 'random' not in config:
-            SetDefaultIndex(config, real_cats[0].getNObjects())
+            SetDefaultIndex(config, real_cats[0].nobjects)
         else:
             if not config['random']:
-                SetDefaultIndex(config, real_cats[0].getNObjects())
+                SetDefaultIndex(config, real_cats[0].nobjects)
                 # Need to do this to avoid being caught by the GetAllParams() call, which will flag
                 # it if it has 'index' and 'random' set (but 'random' is False, so really it's OK).
                 del config['random']
@@ -105,7 +105,7 @@ def _BuildChromaticRealGalaxy(config, base, ignore, gsparams, logger):
 
     if 'index' in kwargs:
         index = kwargs['index']
-        if index >= real_cats[0].getNObjects() or index < 0:
+        if index >= real_cats[0].nobjects or index < 0:
             raise GalSimConfigError(
                 "index=%s has gone past the number of entries in the RealGalaxyCatalog"%index)
 

--- a/tests/test_galaxy_sample.py
+++ b/tests/test_galaxy_sample.py
@@ -41,7 +41,7 @@ def test_cosmos_basic():
     # Check GalaxySample equivalent
     cat1 = galsim.GalaxySample('real_galaxy_catalog_23.5_example.fits', datapath,
                                cut_ratio=0.2, sn_limit=20.)
-    assert cat1.nobjects == cat.nobjects
+    assert cat1.nobjects == cat1.getNObjects() == cat.nobjects == cat.getNObjects()
     assert cat1 == cat  # These (intentionally) test as equal even though different classes.
 
     # Initialize one that doesn't exclude failures.  It should be >= the previous one in length.


### PR DESCRIPTION
This PR fixes a long term annoyance about input objects in the config.  We use Proxies to avoid having input objects get cloned into every process, since they are often relatively large.  This works fairly well, but there is a catch -- the standard multiprocessing AutoProxy class doesn't expose attributes and properties of the wrapped object.  Just methods.  So you need to write getters for any attribute you want to access.  This has recently become onerous in ImSim.

Fortunately, @jmeyers314 discovered [this SO answer](https://stackoverflow.com/a/63741184/1332281), which shows how to circumvent this behavior.  I actually used a [slight modification](https://stackoverflow.com/a/65466807/1332281), which doesn't use exec, and then had to fix a [bug](https://stackoverflow.com/questions/65451457/how-can-i-update-class-members-in-processes#comment131796241_65466807) in it.  But basically, that was all that was needed.

No new unit tests.  I just changed some places in the code where we used getters rather than attributes to the more natural attribute syntax.  This failed without the new InputProxy class, and it works with that change.