### PR TITLE
Add --log_format to GalSim executable

### DIFF
--- a/galsim/download_cosmos.py
+++ b/galsim/download_cosmos.py
@@ -80,6 +80,7 @@ def parse_args(command_args):
         help="Don't link to the alternate directory from share/galsim")
     args = parser.parse_args(command_args)
     args.log_file = None
+    args.log_format = None
 
     # Return the args
     return args

--- a/galsim/main.py
+++ b/galsim/main.py
@@ -52,6 +52,9 @@ def parse_args(command_args):
         '-v', '--verbosity', type=int, action='store', default=1, choices=(0, 1, 2, 3),
         help='integer verbosity level: min=0, max=3 [default=1]')
     parser.add_argument(
+        '--log_format', type=str, action='store', default="%(message)s",
+        help='logger format string [default="%(message)s"]')
+    parser.add_argument(
         '-l', '--log_file', type=str, action='store', default=None,
         help='filename for storing logging output [default is to stream to stdout]')
     parser.add_argument(
@@ -154,11 +157,11 @@ def make_logger(args):
     # Setup logging to go to sys.stdout or (if requested) to an output file
     if args.log_file is None:
         handler = logging.StreamHandler(sys.stdout)
-        handler.setFormatter(logging.Formatter("%(message)s"))
+        handler.setFormatter(logging.Formatter(args.log_format))
         handler.setLevel(level)
     else:
         handler = logging.FileHandler(args.log_file, mode='w')
-        handler.setFormatter(logging.Formatter("%(message)s"))
+        handler.setFormatter(logging.Formatter(args.log_format))
         handler.setLevel(level)
     logger.addHandler(handler)
     return logger

--- a/galsim/main.py
+++ b/galsim/main.py
@@ -52,11 +52,11 @@ def parse_args(command_args):
         '-v', '--verbosity', type=int, action='store', default=1, choices=(0, 1, 2, 3),
         help='integer verbosity level: min=0, max=3 [default=1]')
     parser.add_argument(
-        '--log_format', type=str, action='store', default="%(message)s",
-        help='logger format string [default="%(message)s"]')
-    parser.add_argument(
         '-l', '--log_file', type=str, action='store', default=None,
         help='filename for storing logging output [default is to stream to stdout]')
+    parser.add_argument(
+        '--log_format', type=str, action='store', default="%(message)s",
+        help='logger format string [default="%(message)s"]')
     parser.add_argument(
         '-f', '--file_type', type=str, action='store', choices=('yaml','json'),
         default=None,

--- a/galsim/main.py
+++ b/galsim/main.py
@@ -56,7 +56,7 @@ def parse_args(command_args):
         help='filename for storing logging output [default is to stream to stdout]')
     parser.add_argument(
         '--log_format', type=str, action='store', default="%(message)s",
-        help='logger format string [default="%(message)s"]')
+        help='logger format string [default="%%(message)s"]')
     parser.add_argument(
         '-f', '--file_type', type=str, action='store', choices=('yaml','json'),
         default=None,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -196,6 +196,21 @@ def test_logger():
     with open(args.log_file) as f:
         assert f.readlines() == []
 
+    args.verbosity = 3
+    args.log_format == '%(levelname)s - %(message)s'
+    remove_handler()
+    logger = galsim.main.make_logger(args)
+    print('handlers = ',logger.handlers)
+    assert logger.getEffectiveLevel() == logging.DEBUG
+    logger.warning("Test warning")
+    logger.info("Test info")
+    logger.debug("Test debug")
+
+    with open(args.log_file) as f:
+        assert f.readline().strip() == "WARNING - Test warning"
+        assert f.readline().strip() == "INFO - Test info"
+        assert f.readline().strip() == "DEBUG - Test debug"
+
 @timer
 def test_parse_variables():
     logger = logging.getLogger('test_main')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -197,7 +197,7 @@ def test_logger():
         assert f.readlines() == []
 
     args.verbosity = 3
-    args.log_format == '%(levelname)s - %(message)s'
+    args.log_format = '%(levelname)s - %(message)s'
     remove_handler()
     logger = galsim.main.make_logger(args)
     print('handlers = ',logger.handlers)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -56,6 +56,7 @@ def test_args():
     assert args.config_file == config_file
     assert args.verbosity == 1
     assert args.log_file is None
+    assert args.log_format == '%(message)s'
     assert args.file_type is None
     assert args.module is None
     assert args.profile is False
@@ -73,6 +74,10 @@ def test_args():
     args = galsim.main.parse_args([config_file, '-l', 'test.log'])
     assert args.config_file == config_file
     assert args.log_file == 'test.log'
+
+    args = galsim.main.parse_args([config_file, '--log_format', '%(asctime)s - %(name)s - %(levelname)s - %(message)s'])
+    assert args.config_file == config_file
+    assert args.log_format == '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 
     args = galsim.main.parse_args([config_file, '-f', 'yaml'])
     assert args.config_file == config_file


### PR DESCRIPTION
This pull request adds the `--log_format` option to the GalSim executable. The default behavior is `"%(message)s"` (i.e., consistent with the past behavior of the GalSim logger).

Example usage would be
```
$ galsim --log_format="%(asctime)s - %(name)s - %(levelname)s - %(message)s" demo1.yaml 
2022-12-13 14:12:47,824 - galsim - WARNING - Reading config file demo1.yaml
2022-12-13 14:12:47,834 - galsim - WARNING - Start file 0 = output_yaml/demo1.fits
2022-12-13 14:12:47,858 - galsim - WARNING - File 0 = output_yaml/demo1.fits: time = 0.024030 sec
2022-12-13 14:12:47,858 - galsim - WARNING - Done building files
```