### PR TITLE
Allow input objects to return an approximate number of objects.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -139,3 +139,9 @@ Changes from v2.4.5 to v2.4.6
 
 - Fixed drawImage to work correctly for method=fft when using photon_ops. (#1193)
 - Fixed the proxies used by config Input items to allow access to attributes. (#1195)
+
+Changes from v2.4.6 to v2.4.7
+=============================
+
+- Allow input objects with has_nobj=True to return an approximate number of objects for the
+  initial pass, rather than the eventual exact number. (#1202)

--- a/galsim/config/image.py
+++ b/galsim/config/image.py
@@ -314,7 +314,7 @@ def BuildImage(config, image_num=0, obj_num=0, logger=None):
     return image
 
 
-def GetNObjForImage(config, image_num, logger=None):
+def GetNObjForImage(config, image_num, logger=None, approx=False):
     """
     Get the number of objects that will be made for the image number image_num based on
     the information in the config dict.
@@ -323,6 +323,7 @@ def GetNObjForImage(config, image_num, logger=None):
         config:         The configuration dict.
         image_num:      The current image number.
         logger:         If given, a logger object to log progress.
+        approx:         Whether an approximate/overestimate is ok [default: False]
 
     Returns:
         the number of objects
@@ -332,7 +333,8 @@ def GetNObjForImage(config, image_num, logger=None):
     if image_type not in valid_image_types:
         raise GalSimConfigValueError("Invalid image.type.", image_type,
                                      list(valid_image_types.keys()))
-    return valid_image_types[image_type].getNObj(image,config,image_num,logger=logger)
+    return valid_image_types[image_type].getNObj(image, config, image_num,
+                                                 logger=logger, approx=approx)
 
 
 def FlattenNoiseVariance(config, full_image, stamps, current_vars, logger):
@@ -568,17 +570,18 @@ class ImageBuilder:
         """
         pass
 
-    def getNObj(self, config, base, image_num, logger=None):
+    def getNObj(self, config, base, image_num, logger=None, approx=False):
         """Get the number of objects that will be built for this image.
 
         For Single, this is just 1, but other image types would figure this out from the
         configuration parameters.
 
         Parameters:
-            config:     The configuration dict for the image field.
-            base:       The base configuration dict.
-            image_num:  The current image number.
-            logger:     If given, a logger object to log progress.
+            config:         The configuration dict for the image field.
+            base:           The base configuration dict.
+            image_num:      The current image number.
+            logger:         If given, a logger object to log progress.
+            approx:         Whether an approximate/overestimate is ok [default: False]
 
         Returns:
             the number of objects

--- a/galsim/config/image_scattered.py
+++ b/galsim/config/image_scattered.py
@@ -181,14 +181,15 @@ class ScatteredImageBuilder(ImageBuilder):
         AddNoise(base,image,current_var,logger)
 
 
-    def getNObj(self, config, base, image_num, logger=None):
+    def getNObj(self, config, base, image_num, logger=None, approx=False):
         """Get the number of objects that will be built for this image.
 
         Parameters:
-            config:     The configuration dict for the image field.
-            base:       The base configuration dict.
-            image_num:  The current image number.
-            logger:     If given, a logger object to log progress.
+            config:         The configuration dict for the image field.
+            base:           The base configuration dict.
+            image_num:      The current image number.
+            logger:         If given, a logger object to log progress.
+            approx:         Whether an approximate/overestimate is ok [default: False]
 
         Returns:
             the number of objects
@@ -199,7 +200,7 @@ class ScatteredImageBuilder(ImageBuilder):
 
         # Allow nobjects to be automatic based on input catalog
         if 'nobjects' not in config:
-            nobj = ProcessInputNObjects(base, logger=logger)
+            nobj = ProcessInputNObjects(base, logger=logger, approx=approx)
             if nobj is None:
                 raise GalSimConfigError(
                     "Attribute nobjects is required for image.type = Scattered")

--- a/galsim/config/image_tiled.py
+++ b/galsim/config/image_tiled.py
@@ -220,14 +220,15 @@ class TiledImageBuilder(ImageBuilder):
             AddSky(base,image)
             AddNoise(base,image,current_var,logger)
 
-    def getNObj(self, config, base, image_num, logger=None):
+    def getNObj(self, config, base, image_num, logger=None, approx=False):
         """Get the number of objects that will be built for this image.
 
         Parameters:
-            config:     The configuration dict for the image field.
-            base:       The base configuration dict.
-            image_num:  The current image number.
-            logger:     If given, a logger object to log progress.
+            config:         The configuration dict for the image field.
+            base:           The base configuration dict.
+            image_num:      The current image number.
+            logger:         If given, a logger object to log progress.
+            approx:         Whether an approximate/overestimate is ok [default: False]
 
         Returns:
             the number of objects

--- a/galsim/config/output.py
+++ b/galsim/config/output.py
@@ -111,7 +111,7 @@ def BuildFiles(nfiles, config, file_num=0, logger=None, except_abort=False):
         ProcessInput(config, logger=logger, file_scope_only=True)
 
         # Get the number of objects in each image for this file.
-        nobj = GetNObjForFile(config,file_num,image_num,logger=logger)
+        nobj = GetNObjForFile(config, file_num, image_num, logger=logger, approx=True)
 
         # The kwargs to pass to BuildFile
         kwargs = {
@@ -214,7 +214,7 @@ def BuildFile(config, file_num=0, image_num=0, obj_num=0, logger=None):
 
     # Put these values in the config dict so we won't have to run them again later if
     # we need them.  e.g. ExtraOuput processing uses these.
-    nobj = GetNObjForFile(config,file_num,image_num,logger=logger)
+    nobj = GetNObjForFile(config, file_num, image_num, logger=logger)
     nimages = len(nobj)
     config['nimages'] = nimages
     config['nobj'] = nobj
@@ -316,16 +316,17 @@ def GetNImagesForFile(config, file_num, logger=None):
     return valid_output_types[output_type].getNImages(output, config, file_num, logger=logger)
 
 
-def GetNObjForFile(config, file_num, image_num, logger=None):
+def GetNObjForFile(config, file_num, image_num, logger=None, approx=False):
     """
     Get the number of objects that will be made for each image built as part of the file file_num,
     which starts at image number image_num, based on the information in the config dict.
 
     Parameters:
-        config:     The configuration dict.
-        file_num:   The current file number.
-        image_num:  The current image number.
-        logger:     If given, a logger object to log progress. [default: None]
+        config:         The configuration dict.
+        file_num:       The current file number.
+        image_num:      The current image number.
+        logger:         If given, a logger object to log progress. [default: None]
+        approx:         Whether an approximate/overestimate is ok [default: False]
 
     Returns:
         a list of the number of objects in each image [ nobj0, nobj1, nobj2, ... ]
@@ -336,7 +337,7 @@ def GetNObjForFile(config, file_num, image_num, logger=None):
         raise GalSimConfigValueError("Invalid output.type.", output_type,
                                      list(valid_output_types.keys()))
     return valid_output_types[output_type].getNObjPerImage(output, config, file_num, image_num,
-                                                           logger=logger)
+                                                           logger=logger, approx=approx)
 
 
 def SetupConfigFileNum(config, file_num, image_num, obj_num, logger=None):
@@ -500,7 +501,7 @@ class OutputBuilder:
         """
         return 1
 
-    def getNObjPerImage(self, config, base, file_num, image_num, logger=None):
+    def getNObjPerImage(self, config, base, file_num, image_num, logger=None, approx=False):
         """
         Get the number of objects that will be made for each image built as part of the file
         file_num, which starts at image number image_num, based on the information in the config
@@ -512,12 +513,14 @@ class OutputBuilder:
             file_num:       The current file number.
             image_num:      The current image number (the first one for this file).
             logger:         If given, a logger object to log progress.
+            approx:         Whether an approximate/overestimate is ok [default: False]
 
         Returns:
             a list of the number of objects in each image [ nobj0, nobj1, nobj2, ... ]
         """
         nimages = self.getNImages(config, base, file_num, logger=logger)
-        nobj = [ GetNObjForImage(base, image_num+j, logger=logger) for j in range(nimages) ]
+        nobj = [ GetNObjForImage(base, image_num+j, logger=logger, approx=approx)
+                 for j in range(nimages) ]
         base['image_num'] = image_num  # Make sure this is set back to current image num.
         return nobj
 

--- a/galsim/config/photon_ops.py
+++ b/galsim/config/photon_ops.py
@@ -113,7 +113,7 @@ def BuildPhotonOp(config, key, base, logger=None):
     logger.debug('obj %d: Building photon_op type %s', base.get('obj_num',0), op_type)
     builder = valid_photon_op_types[op_type]
     op = builder.buildPhotonOp(param, base, logger)
-    logger.debug('obj %d: photon_op = %s', base.get('obj_num',0), op)
+    logger.debug('obj %d: photon_op = %s', base.get('obj_num',0), str(op))
 
     param['current'] = op, False, None, index, index_key
 


### PR DESCRIPTION
The calculation of the number of objects on each image in imsim can take quite a while when doing a lot of CCDs, since it needs to load the WCS and compute the overlap of the CCD with heal-pixels, etc.  This is currently being done in the serial part of the processing, rather than the parallel part, since GalSim needs to know the object numbers to assign to each image before starting the parallelization.  

However, we realized that this doesn't really need to be precise.  An approximage estimate of the number of objects is fine.  Or really an upper bound.  And in fact, if it misses and accidentally under-estimates, it's not the end of the world for most use cases.  It would just end up in some objects having the same random number sequence for whatever they use that for.

So this PR adds the option for an input object, who is slated to inform about the number of objects to render, to return an estimate of this number using the method `getApproxNObjects`.