### PR TITLE
update GREAT3 links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ can operate directly on "config" files, for those users who prefer not to work
 in Python.  The impetus for the software package was a weak lensing community
 data challenge, called GREAT3:
 
-    http://great3challenge.info/
+    https://github.com/barnabytprowe/great3-public
 
 However, the code has numerous additional capabilities beyond those needed for
 the challenge, and has been useful for a number of projects that needed to

--- a/docs/real_gal.rst
+++ b/docs/real_gal.rst
@@ -105,9 +105,9 @@ to choose between the two::
     It will still be required to rerun this after reinstalling GalSim, but it will notice that
     you already have the files downloaded and merely update the symbolic link.
 
-A copy of the data is also available on the GREAT3 server at
+Instructions for how to download a copy of the GREAT3 data are found at
 
-http://great3.jb.man.ac.uk/leaderboard/data
+https://github.com/barnabytprowe/great3-public#how-to-get-the-data
 
 HSC Postage Stamp Data
 ----------------------

--- a/galsim/__init__.py
+++ b/galsim/__init__.py
@@ -25,7 +25,7 @@ can operate directly on "config" files, for those users who prefer not to work
 in python.  The impetus for the software package was a weak lensing community
 data challenge, called GREAT3:
 
-http://great3challenge.info/
+https://github.com/barnabytprowe/great3-public
 
 However, the code has numerous additional capabilities beyond those needed for
 the challenge, and has been useful for a number of projects that needed to


### PR DESCRIPTION
Made some minor README/documentation updates compared to releases/2.4 (just fixing broken URLs since great3challenge.info is gone). 