### PR TITLE
Fix error in Moffat maxk calculation

### DIFF
--- a/include/galsim/SBMoffat.h
+++ b/include/galsim/SBMoffat.h
@@ -79,6 +79,7 @@ namespace galsim {
     protected:
 
         class SBMoffatImpl;
+        friend class MoffatMaxKSolver;
 
     private:
         // op= is undefined

--- a/include/galsim/SBMoffatImpl.h
+++ b/include/galsim/SBMoffatImpl.h
@@ -38,6 +38,7 @@ namespace galsim {
         double xValue(const Position<double>& p) const;
 
         std::complex<double> kValue(const Position<double>& k) const;
+        double kV2(double ksq) const;
 
         bool isAxisymmetric() const { return true; }
         bool hasHardEdges() const { return (1.-_fluxFactor) > this->gsparams.maxk_threshold; }
@@ -106,6 +107,7 @@ namespace galsim {
         double _flux; ///< Flux.
         double _norm; ///< Normalization. (Including the flux)
         double _knorm; ///< Normalization for kValue. (Including the flux)
+        double _knorm2; ///< Normalization for kValue. (Not including the flux)
         double _rD;   ///< Scale radius for profile `[1 + (r / rD)^2]^beta`.
         double _rD_sq;
         double _inv_rD;

--- a/src/SBMoffat.cpp
+++ b/src/SBMoffat.cpp
@@ -583,15 +583,9 @@ namespace galsim {
         for(double k=0.; k < 50; k += dk) {
 
             double val;
-            if (_trunc > 0) {
-                val = math::hankel_trunc(I, k, 0., _maxRrD,
-                                         this->gsparams.integration_relerr,
-                                         this->gsparams.integration_abserr);
-            } else {
-                val = math::hankel_inf(I, k, 0.,
-                                       this->gsparams.integration_relerr,
-                                       this->gsparams.integration_abserr);
-            }
+            val = math::hankel_trunc(I, k, 0., _maxRrD,
+                                     this->gsparams.integration_relerr,
+                                     this->gsparams.integration_abserr);
             val *= prefactor;
 
             xdbg<<"ft("<<k<<") = "<<val<<std::endl;

--- a/tests/test_chromatic.py
+++ b/tests/test_chromatic.py
@@ -106,6 +106,7 @@ def test_draw_add_commutativity():
     for w in ws:
         flux = bulge_SED(w) * bandpass(w) * h
         mPSF = galsim.Moffat(flux=flux, beta=PSF_beta, half_light_radius=PSF_hlr*dilate_fn(w))
+        mPSF = mPSF.withGSParams(maxk_threshold=1.e-4)
         mPSF = mPSF.shear(e1=PSF_e1, e2=PSF_e2)
         mPSF = mPSF.shift(shift_fn(w))
         mPSFs.append(mPSF)
@@ -145,6 +146,7 @@ def test_draw_add_commutativity():
 
     # make chromatic PSF
     mono_PSF = galsim.Moffat(beta=PSF_beta, half_light_radius=PSF_hlr)
+    mono_PSF = mono_PSF.withGSParams(maxk_threshold=1.e-4)
     mono_PSF = mono_PSF.shear(e1=PSF_e1, e2=PSF_e2)
     chromatic_PSF = galsim.ChromaticTransformation(mono_PSF, flux_ratio=1.0)
     do_pickle(chromatic_PSF, lambda x: (x.evaluateAtWavelength(bandpass.effective_wavelength)

--- a/tests/test_config_output.py
+++ b/tests/test_config_output.py
@@ -872,6 +872,7 @@ def test_extra_psf_sn():
             'type' : 'Moffat',
             'beta' : 3.5,
             'fwhm' : 0.7,
+            'gsparams' : { 'maxk_threshold': 3.e-4 }
         },
         'output' : {
             'psf' : {}

--- a/tests/test_convolve.py
+++ b/tests/test_convolve.py
@@ -485,6 +485,7 @@ def test_deconvolve():
     myImg2.setCenter(0,0)
 
     psf = galsim.Moffat(beta=3.8, fwhm=1.3, flux=5)
+    psf = psf.withGSParams(maxk_threshold=3.e-4)
     inv_psf = galsim.Deconvolve(psf)
     psf.drawImage(myImg1, method='no_pixel')
     conv = galsim.Convolve(psf,psf,inv_psf)

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -528,13 +528,14 @@ def test_drawKImage():
     # So this should draw in Fourier space the same image as the Exponential drawn in
     # test_drawImage().
     obj = galsim.Moffat(flux=test_flux, beta=1.5, scale_radius=0.5)
+    obj = obj.withGSParams(maxk_threshold=1.e-4)
 
     # First test drawKImage() with no kwargs.  It should:
     #   - create new images
     #   - return the new images
     #   - set the scale to 2pi/(N*obj.nyquist_scale)
     im1 = obj.drawKImage()
-    N = 1162
+    N = 1174
     np.testing.assert_equal(im1.bounds, galsim.BoundsI(-N/2,N/2,-N/2,N/2),
                             "obj.drawKImage() produced image with wrong bounds")
     stepk = obj.stepk
@@ -604,7 +605,7 @@ def test_drawKImage():
     np.testing.assert_almost_equal(CalculateScale(im7), 2, 1,
                                    "Measured wrong scale after obj.drawKImage(dx)")
     # This image is smaller because not using nyquist scale for stepk
-    np.testing.assert_equal(im7.bounds, galsim.BoundsI(-36,36,-36,36),
+    np.testing.assert_equal(im7.bounds, galsim.BoundsI(-37,37,-37,37),
                             "obj.drawKImage(dx) produced image with wrong bounds")
 
     # Test if we provide an image with a defined scale.  It should:
@@ -1274,8 +1275,9 @@ def test_fft():
 
     # Now use drawKImage (as above in test_drawKImage) to get a more realistic k-space image
     obj = galsim.Moffat(flux=test_flux, beta=1.5, scale_radius=0.5)
+    obj = obj.withGSParams(maxk_threshold=1.e-4)
     im1 = obj.drawKImage()
-    N = 1162  # NB. It is useful to have this come out not a multiple of 4, since some of the
+    N = 1174  # NB. It is useful to have this come out not a multiple of 4, since some of the
               #     calculation needs to be different when N/2 is odd.
     np.testing.assert_equal(im1.bounds, galsim.BoundsI(-N/2,N/2,-N/2,N/2),
                             "obj.drawKImage() produced image with wrong bounds")

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -1775,20 +1775,20 @@ def test_depixelize():
     t8 = time.time()
     if platform.python_implementation() != 'PyPy':
         # PyPy timings can be fairly arbitrary at times.
-        assert t8-t7 < (t3-t2)/10
+        assert t8-t7 < (t3-t2)/5
 
     # Even if the image is different.
     nopix_image3 = im4.depixelize(x_interpolant=interp)
     t9 = time.time()
     if platform.python_implementation() != 'PyPy':
-        assert t9-t8 < (t3-t2)/10
+        assert t9-t8 < (t3-t2)/5
 
     # But not if you clear the cache.
     galsim.Image.clear_depixelize_cache()
     nopix_image4 = im4.depixelize(x_interpolant=interp)
     t10 = time.time()
     if platform.python_implementation() != 'PyPy':
-        assert t10-t9 > (t3-t2)/10
+        assert t10-t9 > (t3-t2)/5
 
     print('times:')
     print('make ii_with_pixel: ',t1-t0)

--- a/tests/test_moffat.py
+++ b/tests/test_moffat.py
@@ -136,7 +136,7 @@ def test_moffat_properties():
     cen = galsim.PositionD(0, 0)
     np.testing.assert_equal(psf.centroid, cen)
     # Check Fourier properties
-    np.testing.assert_almost_equal(psf.maxk, 11.613036117918105)
+    np.testing.assert_almost_equal(psf.maxk, 11.634597424960159)
     np.testing.assert_almost_equal(psf.stepk, 0.62831853071795873)
     np.testing.assert_almost_equal(psf.kValue(cen), test_flux+0j)
     np.testing.assert_almost_equal(psf.half_light_radius, 1.0)
@@ -150,7 +150,7 @@ def test_moffat_properties():
     psf = galsim.Moffat(beta=2.0, half_light_radius=1.,
                         trunc=2*fwhm_backwards_compatible, flux=test_flux)
     np.testing.assert_equal(psf.centroid, cen)
-    np.testing.assert_almost_equal(psf.maxk, 11.613036112206663)
+    np.testing.assert_almost_equal(psf.maxk, 11.634597426100862)
     np.testing.assert_almost_equal(psf.stepk, 0.62831853071795862)
     np.testing.assert_almost_equal(psf.kValue(cen), test_flux+0j)
     np.testing.assert_almost_equal(psf.half_light_radius, 1.0)

--- a/tests/test_moffat.py
+++ b/tests/test_moffat.py
@@ -167,6 +167,39 @@ def test_moffat_properties():
         outFlux = psfFlux.flux
         np.testing.assert_almost_equal(outFlux, inFlux)
 
+@timer
+def test_moffat_maxk():
+    """Check accuracy of maxk given maxk_threshold
+    """
+    psfs = [
+        # Make sure to include all the specialized betas we have in C++ layer.
+        # The scale_radius and flux don't matter, but vary themm too.
+        # Note: We also specialize beta=1, but that seems to be impossible to realize,
+        #       even when it is trunctatd.
+        galsim.Moffat(beta=1.5, scale_radius=1, flux=1),
+        galsim.Moffat(beta=1.5001, scale_radius=1, flux=1),
+        galsim.Moffat(beta=2, scale_radius=0.8, flux=23),
+        galsim.Moffat(beta=2.5, scale_radius=1.8e-3, flux=2),
+        galsim.Moffat(beta=3, scale_radius=1.8e3, flux=35),
+        galsim.Moffat(beta=3.5, scale_radius=1.3, flux=123),
+        galsim.Moffat(beta=4, scale_radius=4.9, flux=23),
+        galsim.Moffat(beta=1.22, scale_radius=23, flux=23),
+        galsim.Moffat(beta=3.6, scale_radius=2, flux=23),
+        galsim.Moffat(beta=12.9, scale_radius=5, flux=23),
+        galsim.Moffat(beta=1.22, scale_radius=7, flux=23, trunc=30),
+        galsim.Moffat(beta=3.6, scale_radius=9, flux=23, trunc=50),
+        galsim.Moffat(beta=12.9, scale_radius=11, flux=23, trunc=1000),
+    ]
+    threshs = [1.e-3, 1.e-4, 0.03]
+    print('beta \t trunc \t thresh \t kValue(maxk)')
+    for psf in psfs:
+        for thresh in threshs:
+            psf = psf.withGSParams(maxk_threshold=thresh)
+            rtol = 1.e-7 if psf.trunc == 0 else 3.e-3
+            fk = psf.kValue(psf.maxk,0).real/psf.flux
+            print(f'{psf.beta} \t {int(psf.trunc)} \t {thresh:.1e} \t {fk:.3e}')
+            np.testing.assert_allclose(abs(psf.kValue(psf.maxk,0).real)/psf.flux, thresh, rtol=rtol)
+
 
 @timer
 def test_moffat_radii():


### PR DESCRIPTION
@jecampagne pointed out an error in our maxk calculation for Moffat.  See details in #1208.  The upshot is that our Moffat FFT renderings were a bit more accurate and a bit slower than they needed to be for the nominal maxk_threshold.  This PR fixes the calculation to be only as accurate as requested.