### PR TITLE
Fix LoggerWrapper inefficiency

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -152,7 +152,7 @@ Changes from v2.4.6 to v2.4.7
 - Only use proxies for input objects if not yet in a multiprocessing context. This had been
   causing significant slow downs in some imsim runs. (#1206)
 
-Changes from v2.4.6 to v2.4.8
+Changes from v2.4.7 to v2.4.8
 =============================
 
-- Fix a slow-down in multiprocessing especially when running very many (>10) processes.
+- Fix a slow-down in multiprocessing especially when running very many (>10) processes. (#1213)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -151,3 +151,8 @@ Changes from v2.4.6 to v2.4.7
 - Add options to InputLoader to make inputs with AtmosphericScreens work properly. (#1206)
 - Only use proxies for input objects if not yet in a multiprocessing context. This had been
   causing significant slow downs in some imsim runs. (#1206)
+
+Changes from v2.4.6 to v2.4.8
+=============================
+
+- Fix a slow-down in multiprocessing especially when running very many (>10) processes.

--- a/galsim/config/util.py
+++ b/galsim/config/util.py
@@ -284,12 +284,14 @@ class LoggerWrapper:
     def __init__(self, logger):
         if isinstance(logger,LoggerWrapper):
             self.logger = logger.logger
+            self.level = logger.level
         else:
             self.logger = logger
-        # When multiprocessing, it is faster to check if the level is enabled locally, rather than
-        # communicating over the pipe to ask the base logger if it isEnabledFor a given level.
-        # If the logger is None, use more than the top logging level (CRITICAL).
-        self.level = self.logger.getEffectiveLevel() if self.logger else logging.CRITICAL+1
+            # When multiprocessing, it is faster to check if the level is enabled locally, rather
+            # than communicating over the pipe to ask the base logger if it isEnabledFor a given
+            # level.
+            # If the logger is None, use more than the top logging level (CRITICAL).
+            self.level = self.logger.getEffectiveLevel() if self.logger else logging.CRITICAL+1
 
     def getEffectiveLevel(self):
         return self.level

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -2306,7 +2306,10 @@ def test_Image_constructor():
 
         # Make a NumPy array directly, with non-trivially interesting values.
         test_arr = np.ones((3,4), dtype=types[i])
-        test_arr[1,3] = -5
+        if np.dtype(types[i]).kind == 'u':
+            test_arr[1,3] = -5 % np.iinfo(types[i]).max
+        else:
+            test_arr[1,3] = -5
         test_arr[2,2] = 7
         # Initialize the Image from it.
         test_im = galsim.Image(test_arr)
@@ -2318,7 +2321,10 @@ def test_Image_constructor():
         # Now make an opposite-endian Numpy array, to initialize the Image.
         new_type = array_dtype.newbyteorder('S')
         test_arr = np.ones((3,4), dtype=new_type)
-        test_arr[1,3] = -5
+        if np.dtype(types[i]).kind == 'u':
+            test_arr[1,3] = -5 % np.iinfo(types[i]).max
+        else:
+            test_arr[1,3] = -5
         test_arr[2,2] = 7
         # Initialize the Image from it.
         test_im = galsim.Image(test_arr)


### PR DESCRIPTION
We have a class in GalSim config called LoggerWrapper, which is intended to avoid communicating with the main logger via the proxy when we aren't actually going to output anything.  E.g. logger.debug statements when the logging level is only INFO or WARNING.  This is mostly a big improvement.

However, @beckermr and @jchiang87 have each recently found huge inefficiencies when running on Perlmutter with ~128 processes.  I tracked it down to when we make a new LoggerWrapper instance and call `logger.getEffectiveLevel()`.  This had always been going back to the original proxy logger instance even when we already have a wrapped one.  And for lots of processes, this can end up clogging the inter-process communication completely unnecessarily. 

This PR makes the fairly trivial change that when we're re-wrapping something that is already wrapped, it doesn't call `getEffectiveLevel`.  It just gets the already received value stored as an attribute.  This seems to resolve the blockage that Matt (and I presume Jim) was seeing.