### PR TITLE
Fix possible crash in PhotonArray.makeFromImage if image has negative pixels.

### DIFF
--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -1700,7 +1700,8 @@ class GSObject:
                     method=method, sensor=sensor, poisson_flux=poisson_flux)
 
         # If using photon ops with fft, then need a sensor.
-        if photon_ops is not None and method != 'phot' and sensor is None:
+        # Note: "if photon_ops" so photon_ops being [] or () is the same as None.
+        if photon_ops and method != 'phot' and sensor is None:
             sensor = Sensor()
         if photon_ops is None:
             # Easier to just make it an empty tuple, rather than deal with None below.

--- a/galsim/photon_array.py
+++ b/galsim/photon_array.py
@@ -577,7 +577,7 @@ class PhotonArray:
         max_flux = float(max_flux)
         if (max_flux <= 0):
             raise GalSimRangeError("max_flux must be positive", max_flux, 0.)
-        total_flux = image.array.sum(dtype=float)
+        total_flux = np.abs(image.array).sum(dtype=float)
 
         # This goes a bit over what we actually need, but not by much.  Worth it to not have to
         # worry about array reallocations.

--- a/src/PhotonArray.cpp
+++ b/src/PhotonArray.cpp
@@ -77,9 +77,11 @@ namespace galsim {
     {
         dbg<<"bounds = "<<image.getBounds()<<std::endl;
         dbg<<"flux, maxflux = "<<_flux<<','<<maxFlux<<std::endl;
+        dbg<<"photon array size = "<<this->size()<<std::endl;
         AddImagePhotons<T> adder(_x, _y, _flux, maxFlux, rng);
         for_each_pixel_ij_ref(image, adder);
         dbg<<"Done: size = "<<adder.getCount()<<std::endl;
+        assert(adder.getCount() < _N);  // Else we've overrun the photon's arrays.
         _N = adder.getCount();
         return _N;
     }

--- a/src/PhotonArray.cpp
+++ b/src/PhotonArray.cpp
@@ -50,7 +50,7 @@ namespace galsim {
 
         void operator()(T flux, int i, int j)
         {
-            int N = (flux <= _maxFlux) ? 1 : int(std::ceil(flux / _maxFlux));
+            int N = (std::abs(flux) <= _maxFlux) ? 1 : int(std::ceil(std::abs(flux) / _maxFlux));
             double fluxPer = double(flux) / N;
             for (int k=0; k<N; ++k) {
                 double x = i + _ud() - 0.5;
@@ -76,7 +76,7 @@ namespace galsim {
     int PhotonArray::setFrom(const BaseImage<T>& image, double maxFlux, BaseDeviate rng)
     {
         dbg<<"bounds = "<<image.getBounds()<<std::endl;
-        dbg<<"flux, maxflux = "<<_flux<<','<<maxFlux<<std::endl;
+        dbg<<"maxflux = "<<maxFlux<<std::endl;
         dbg<<"photon array size = "<<this->size()<<std::endl;
         AddImagePhotons<T> adder(_x, _y, _flux, maxFlux, rng);
         for_each_pixel_ij_ref(image, adder);

--- a/src/PhotonArray.cpp
+++ b/src/PhotonArray.cpp
@@ -81,7 +81,7 @@ namespace galsim {
         AddImagePhotons<T> adder(_x, _y, _flux, maxFlux, rng);
         for_each_pixel_ij_ref(image, adder);
         dbg<<"Done: size = "<<adder.getCount()<<std::endl;
-        assert(adder.getCount() < _N);  // Else we've overrun the photon's arrays.
+        assert(adder.getCount() <= _N);  // Else we've overrun the photon's arrays.
         _N = adder.getCount();
         return _N;
     }

--- a/tests/test_photon_array.py
+++ b/tests/test_photon_array.py
@@ -1614,13 +1614,19 @@ def test_setFromImage_crash():
     im1 = prof.drawImage(image=image.copy())
 
     # Now with photon_ops.
+    # This had been sufficient to trigger the bug, but now photon_ops=[] is the same as None.
     im2 = prof.drawImage(image=image.copy(), photon_ops=[], n_subsample=1)
+    assert im1 == im2
+
+    # Repeat with a non-empty, but still trivial, photon_ops.
+    im3 = prof.drawImage(image=image.copy(), photon_ops=[galsim.FRatioAngles(1.2)], n_subsample=1)
 
     # They aren't quite identical because of numerical rounding issues from going through
     # a sum of fluxes on individual photons.
     # In particular, we want to make sure negative pixels stay negative through this process.
-    np.testing.assert_allclose(im1.array, im2.array, rtol=1.e-11)
-    w = np.where(im1.array != im2.array)
+    assert im1 != im3
+    np.testing.assert_allclose(im1.array, im3.array, rtol=1.e-11)
+    w = np.where(im1.array != im3.array)
     print('diff in ',len(w[0]),'pixels')
     assert len(w[0]) < 100  # I find it to be different in only 39 photons on my machine.
 

--- a/tests/test_photon_array.py
+++ b/tests/test_photon_array.py
@@ -1593,6 +1593,24 @@ def test_time_sampler():
     np.testing.assert_array_less(-pa.time, 10)
     do_pickle(sampler)
 
+def test_setFromImage_crash():
+    """Geri Braunlich ran into a seg fault where the photon array was not allocated to be
+    sufficiently large for the photons it got from an image.
+    This test reproduces the error for version 2.4.8 for the purpose of fixing it.
+    """
+    # These are (approximately) the specific values for one case where the code used to crash.
+    prof = galsim.Gaussian(sigma=0.13).withFlux(3972551)
+    wcs = galsim.JacobianWCS(-0.170, -0.106, 0.106, -0.170)
+    image = galsim.Image(1000, 1000, wcs=wcs)
+
+    # Start with a simple draw with no photons
+    im1 = prof.drawImage(image=image.copy())
+
+    # Now with photon_ops.
+    im2 = prof.drawImage(image=image.copy(), photon_ops=[], n_subsample=1)
+
+    assert im1 == im2
+
 
 if __name__ == '__main__':
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]

--- a/tests/test_photon_array.py
+++ b/tests/test_photon_array.py
@@ -1597,11 +1597,18 @@ def test_setFromImage_crash():
     """Geri Braunlich ran into a seg fault where the photon array was not allocated to be
     sufficiently large for the photons it got from an image.
     This test reproduces the error for version 2.4.8 for the purpose of fixing it.
+
+    The bug turned out to be that some pixel values were (slightly) negative from the FFT,
+    and the total flux was estimated as np.sum(image.array).  The negative pixels added
+    negatively to this sum, so the calculated total flux wasn't quite enough to hold all the
+    required photons.
+
+    The fix was to use the absolute value of the image for this calculation.
     """
     # These are (approximately) the specific values for one case where the code used to crash.
     prof = galsim.Gaussian(sigma=0.13).withFlux(3972551)
     wcs = galsim.JacobianWCS(-0.170, -0.106, 0.106, -0.170)
-    image = galsim.Image(1000, 1000, wcs=wcs)
+    image = galsim.Image(1000, 1000, wcs=wcs, dtype=float)
 
     # Start with a simple draw with no photons
     im1 = prof.drawImage(image=image.copy())
@@ -1609,7 +1616,13 @@ def test_setFromImage_crash():
     # Now with photon_ops.
     im2 = prof.drawImage(image=image.copy(), photon_ops=[], n_subsample=1)
 
-    assert im1 == im2
+    # They aren't quite identical because of numerical rounding issues from going through
+    # a sum of fluxes on individual photons.
+    # In particular, we want to make sure negative pixels stay negative through this process.
+    np.testing.assert_allclose(im1.array, im2.array, rtol=1.e-11)
+    w = np.where(im1.array != im2.array)
+    print('diff in ',len(w[0]),'pixels')
+    assert len(w[0]) < 100  # I find it to be different in only 39 photons on my machine.
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
@g-braeunlich ran into a bug in the PhotonArray `makeFromImage` function where it would sometimes seg fault.  It turned out that the calculation for how many photons would be needed was wrong when there were negative-flux pixels, so it wasn't allocating enough space and the arrays were being overrun.  This PR fixes that bug.  

It also happened to be the case that that function shouldn't even have been run for what Geri was doing.  But he had the photon_ops set to [], rather than None.  Those should logically mean the same thing, but GalSim assumed that since photon_ops wasn't None, it needed photons.  Now photon_ops = () or [] means the same thing as None in the code.