### PR TITLE
Add options to convert HSM moments to sky coordinates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,8 @@ Config Updates
 New Features
 ------------
 
-- Added `ShapeData.applyWCS` method to convert HSM shapes to sky coordinates.
+- Added `ShapeData.applyWCS` method to convert HSM shapes to sky coordinates.  Also added
+  the option ``use_sky_coords=True`` to `FindAdaptiveMom` to apply this automatically.
 
 
 Performance Improvements

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Config Updates
 New Features
 ------------
 
+- Added `ShapeData.applyWCS` method to convert HSM shapes to sky coordinates.
 
 
 Performance Improvements

--- a/galsim/hsm.py
+++ b/galsim/hsm.py
@@ -687,7 +687,8 @@ def EstimateShear(gal_image, PSF_image, weight=None, badpix=None, sky_var=0.0,
             return ShapeData(error_message = str(err))
 
 def FindAdaptiveMom(object_image, weight=None, badpix=None, guess_sig=5.0, precision=1.0e-6,
-                    guess_centroid=None, strict=True, round_moments=False, hsmparams=None):
+                    guess_centroid=None, strict=True, round_moments=False, hsmparams=None,
+                    use_sky_coords=False):
     """Measure adaptive moments of an object.
 
     This method estimates the best-fit elliptical Gaussian to the object (see Hirata & Seljak 2003
@@ -773,6 +774,10 @@ def FindAdaptiveMom(object_image, weight=None, badpix=None, guess_sig=5.0, preci
         hsmparams:          The hsmparams keyword can be used to change the settings used by
                             FindAdaptiveMom when estimating moments; see `HSMParams` documentation
                             for more information. [default: None]
+        use_sky_coords:     Whether to convert the measured moments to sky_coordinates.
+                            Setting this to true is equivalent to running
+                            ``applyWCS(object_image.wcs, image_pos=object_image.true_center)``
+                            on the result.  [default: False]
 
     Returns:
         a `ShapeData` object containing the results of moment measurement.
@@ -791,6 +796,9 @@ def FindAdaptiveMom(object_image, weight=None, badpix=None, guess_sig=5.0, preci
                                     object_image._image, weight._image,
                                     float(guess_sig), float(precision), guess_centroid._p,
                                     bool(round_moments), hsmparams._hsmp)
+
+        if use_sky_coords:
+            result = result.applyWCS(object_image.wcs, image_pos=object_image.true_center)
         return result
     except RuntimeError as err:
         if (strict == True):

--- a/galsim/hsm.py
+++ b/galsim/hsm.py
@@ -54,7 +54,7 @@ class ShapeData:
       ``(image.xmin, image.ymin)``.  An object drawn at the center of the image should generally
       have moments_centroid equal to ``image.true_center``.
 
-    - ``moments_rho4``: the weighted radial fourth moment of the image.
+    - ``moments_rho4``: the weighted radial fourth moment of the image (dimensionless).
 
     - ``moments_n_iter``: number of iterations needed to get adaptive moments, or 0 if not measured.
 
@@ -233,7 +233,6 @@ class ShapeData:
         moments_sigma is changed to be in units of arcsec.
         observed_shape is changed to be in (u,v) coordinates.
         moments_centroid is changed to be in (u,v) coordinates relative to image_pos.
-        moments_rho4 is changed to be in units of arcsec^4.
 
         .. note::
 
@@ -266,16 +265,13 @@ class ShapeData:
         # Fix moments_centroid
         moments_centroid = jac.toWorld(self.moments_centroid) - jac.toWorld(image_pos)
 
-        # Fix moments_rho4
-        moments_rho4 = self.moments_rho4 * scale**4
-
         return ShapeData(image_bounds=self.image_bounds,
                          moments_status=self.moments_status,
                          observed_shape=observed_shape,
                          moments_sigma=moments_sigma,
                          moments_amp=self.moments_amp,
                          moments_centroid=moments_centroid,
-                         moments_rho4=moments_rho4,
+                         moments_rho4=self.moments_rho4,
                          moments_n_iter=self.moments_n_iter,
                          error_message=self.error_message)
                          # The other values are reset to the defaults, since they are

--- a/galsim/hsm.py
+++ b/galsim/hsm.py
@@ -563,6 +563,11 @@ def EstimateShear(gal_image, PSF_image, weight=None, badpix=None, sky_var=0.0,
     This routine assumes that (at least locally) the WCS can be approximated as a `PixelScale`, with
     no distortion or non-trivial remapping. Any non-trivial WCS gets completely ignored.
 
+    .. note::
+
+        There is not currently an option to ``use_sky_coords`` as we have for `FindAdaptiveMom`.
+        We would welcome a PR adding this feature if someone wants it for their science case.
+
     Note that the method will fail if the PSF or galaxy are too point-like to easily fit an
     elliptical Gaussian; when running on batches of many galaxies, it may be preferable to set
     ``strict=False`` and catch errors explicitly, as in the second example below.

--- a/galsim/hsm.py
+++ b/galsim/hsm.py
@@ -220,7 +220,7 @@ class ShapeData:
     def __setstate__(self, state):
         self.__init__(*state)
 
-    def applyWCS(self, wcs, image_pos=None):
+    def applyWCS(self, wcs, image_pos):
         """Convert moments in pixel coordinates to moments in sky coordinates.
 
         Natively, the HSM algorithm computes second moments in (x,y) coordinates in the
@@ -232,7 +232,7 @@ class ShapeData:
 
         moments_sigma is changed to be in units of arcsec.
         observed_shape is changed to be in (u,v) coordinates.
-        moments_centroid is changed to be in (u,v) coordinates in units of arcsec.
+        moments_centroid is changed to be in (u,v) coordinates relative to image_pos.
         moments_rho4 is changed to be in units of arcsec^4.
 
         .. note::
@@ -244,9 +244,8 @@ class ShapeData:
 
         Parameters:
             wcs:            The WCS to apply.
-            image_pos:      If wcs is not a UniformWCS, then this is required.  It should be the
-                            position in image coordinates (x,y) of the object whose moments have
-                            been measured. [default: None]
+            image_pos:      The position in image coordinates (x,y) of the object whose moments
+                            have been measured.
         """
         jac = wcs.jacobian(image_pos=image_pos)
         scale, shear, theta, flip = jac.getDecomposition()

--- a/galsim/hsm.py
+++ b/galsim/hsm.py
@@ -237,9 +237,10 @@ class ShapeData:
 
         .. note::
 
-            The corrected shapes (corrected_e1, corrected_e2, corrected_g1, corrected_g2) and
-            the psf_shape are not adjusted.  We would welcome a PR adding this feature if someone
-            wants it for their science case.
+            This currently only works for the measurements from `FindAdaptiveMom`.
+            If the input ShapeData instance has any values set from `EstimateShear`, they will
+            not be present in the return value.  We would welcome a PR adding the ability to
+            work on corrected shapes if someone wants it for their science case.
 
         Parameters:
             wcs:            The WCS to apply.
@@ -276,25 +277,10 @@ class ShapeData:
                          moments_amp=self.moments_amp,
                          moments_centroid=moments_centroid,
                          moments_rho4=moments_rho4,
-                         # (All the rest are unchanged.)
                          moments_n_iter=self.moments_n_iter,
-                         correction_status=self.correction_status,
-                         # TODO: I'm not sure exactly what to do for the corrected values.
-                         #       They don't have to be |e|<1, so my procedure above won't work.
-                         corrected_e1=self.corrected_e1,
-                         corrected_e2=self.corrected_e2,
-                         corrected_g1=self.corrected_g1,
-                         corrected_g2=self.corrected_g2,
-                         meas_type=self.meas_type,
-                         corrected_shape_err=self.corrected_shape_err,
-                         correction_method=self.correction_method,
-                         resolution_factor=self.resolution_factor,
-                         # The PSF values could be converted in the same way as the regular
-                         # moments sigma and shape, but since they are generally connected to
-                         # the corrected shapes, I didn't touch this.
-                         psf_sigma=self.psf_sigma,
-                         psf_shape=self.psf_shape,
                          error_message=self.error_message)
+                         # The other values are reset to the defaults, since they are
+                         # results from EstimateShear.
 
 
 class HSMParams:

--- a/tests/test_hsm.py
+++ b/tests/test_hsm.py
@@ -200,11 +200,15 @@ def test_moments_wcs():
                       galsim.CelestialCoord(74.2 * galsim.degrees, -32 * galsim.degrees)),
     ]
 
+    rng = galsim.BaseDeviate(1234)
+
     for sig in gaussian_sig_values:
         for g1 in shear_values:
             for g2 in shear_values:
                 for wcs in wcs_list:
-                    gal = galsim.Gaussian(sigma=sig).shear(g1=g1, g2=g2)
+                    du = rng.np.uniform(-2,2)
+                    dv = rng.np.uniform(-2,2)
+                    gal = galsim.Gaussian(sigma=sig).shear(g1=g1, g2=g2).shift(du,dv)
                     image = gal.drawImage(nx=200, ny=200, wcs=wcs, method='no_pixel')
                     result = image.FindAdaptiveMom()
 
@@ -212,16 +216,22 @@ def test_moments_wcs():
                     result = result.applyWCS(wcs, image_pos=image.true_center)
                     print(result.moments_sigma, sig,
                           result.observed_shape.g1, g1,
-                          result.observed_shape.g2, g2)
+                          result.observed_shape.g2, g2,
+                          result.moments_centroid.x, du,
+                          result.moments_centroid.y, dv)
                     np.testing.assert_allclose(result.moments_sigma, sig, rtol=1.e-5)
                     np.testing.assert_allclose(result.observed_shape.g1, g1, rtol=1.e-5)
                     np.testing.assert_allclose(result.observed_shape.g2, g2, rtol=1.e-5)
+                    np.testing.assert_allclose(result.moments_centroid.x, du, atol=1.e-7)
+                    np.testing.assert_allclose(result.moments_centroid.y, dv, atol=1.e-7)
 
                     # Can also do this directly with FindAdaptiveMom(use_sky_coords=True)
                     result = image.FindAdaptiveMom(use_sky_coords=True)
                     np.testing.assert_allclose(result.moments_sigma, sig, rtol=1.e-5)
                     np.testing.assert_allclose(result.observed_shape.g1, g1, rtol=1.e-5)
                     np.testing.assert_allclose(result.observed_shape.g2, g2, rtol=1.e-5)
+                    np.testing.assert_allclose(result.moments_centroid.x, du, atol=1.e-7)
+                    np.testing.assert_allclose(result.moments_centroid.y, dv, atol=1.e-7)
 
 
 @timer

--- a/tests/test_hsm.py
+++ b/tests/test_hsm.py
@@ -210,11 +210,19 @@ def test_moments_wcs():
                     distortion_2 = g2*conversion_factor
                     gal = galsim.Gaussian(sigma=sig).shear(g1=g1, g2=g2)
                     image = gal.drawImage(nx=200, ny=200, wcs=wcs, method='no_pixel')
-                    result = image.FindAdaptiveMom().applyWCS(wcs, image_pos=image.true_center)
+                    result = image.FindAdaptiveMom()
 
+                    # Convert to sky coords
+                    result = result.applyWCS(wcs, image_pos=image.true_center)
                     print(result.moments_sigma, sig,
                           result.observed_shape.g1, g1,
                           result.observed_shape.g2, g2)
+                    np.testing.assert_allclose(result.moments_sigma, sig, rtol=1.e-5)
+                    np.testing.assert_allclose(result.observed_shape.g1, g1, rtol=1.e-5)
+                    np.testing.assert_allclose(result.observed_shape.g2, g2, rtol=1.e-5)
+
+                    # Can also do this directly with FindAdaptiveMom(use_sky_coords=True)
+                    result = image.FindAdaptiveMom(use_sky_coords=True)
                     np.testing.assert_allclose(result.moments_sigma, sig, rtol=1.e-5)
                     np.testing.assert_allclose(result.observed_shape.g1, g1, rtol=1.e-5)
                     np.testing.assert_allclose(result.observed_shape.g2, g2, rtol=1.e-5)

--- a/tests/test_hsm.py
+++ b/tests/test_hsm.py
@@ -204,10 +204,6 @@ def test_moments_wcs():
         for g1 in shear_values:
             for g2 in shear_values:
                 for wcs in wcs_list:
-                    total_shear = np.sqrt(g1**2 + g2**2)
-                    conversion_factor = np.tanh(2.0*math.atanh(total_shear))/total_shear
-                    distortion_1 = g1*conversion_factor
-                    distortion_2 = g2*conversion_factor
                     gal = galsim.Gaussian(sigma=sig).shear(g1=g1, g2=g2)
                     image = gal.drawImage(nx=200, ny=200, wcs=wcs, method='no_pixel')
                     result = image.FindAdaptiveMom()


### PR DESCRIPTION
This PR involves code that I've been copying around to various places (e.g. it is in the piff.Star.hsm method) knowing each time that I should really put it into GalSim directly.  But it was always more expedient to just copy it.  So today, as I was about to copy it yet again, I decided to do it right and add it here.

The HSM moments are natively measured in pixel coordinates.  Indeed the back end code doesn't have any knowledge of the WCS.  However, it's fairly straightforward to convert these (x,y) moments in to (u,v) moments using the jacobian of the WCS.  This PR adds two ways the user can do this:

`ShapeData.applyWCS(wcs)` converts a ShapeData instance into one where the size and shape values are based on the u,v moments rather than x,y.
`image.FindAdaptiveMom(use_sky_coords=True)` does this for you using the wcs that is in the image.