### PR TITLE
Add list (and dict, LookupTable) as a registered type for Eval

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,3 +35,4 @@ Performance Improvements
 Bug Fixes
 ---------
 
+- Fixed a bug that prevented Eval types from generating lists in config files in some contexts.

--- a/galsim/__init__.py
+++ b/galsim/__init__.py
@@ -76,7 +76,7 @@ software or any products related to or derived from the software, or for
 lost profits, business interruption, or indirect special or consequential
 damages of any kind.
 """
-import re, os, glob
+import os
 
 # The version is stored in _version.py as recommended here:
 # http://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package

--- a/galsim/__init__.py
+++ b/galsim/__init__.py
@@ -90,17 +90,8 @@ version = __version__
 # C++ layer directly.  (Basically copied from TreeCorr's __init__.py.)
 galsim_dir = os.path.dirname(__file__)
 include_dir = os.path.join(galsim_dir,'include')
-
-lib_file = os.path.join(galsim_dir,'_galsim.so')
-# Some installation (e.g. Travis with python 3.x) name this e.g. _galsim.cpython-34m.so,
-# so if the normal name doesn't exist, look for something else.
-if not os.path.exists(lib_file): # pragma: no cover
-    alt_files = glob.glob(os.path.join(os.path.dirname(__file__),'_galsim*.so'))
-    if len(alt_files) == 0:
-        raise OSError("No file '_galsim.so' found in %s"%galsim_dir)
-    if len(alt_files) > 1:
-        raise OSError("Multiple files '_galsim*.so' found in %s: %s"%(galsim_dir,alt_files))
-    lib_file = alt_files[0]
+from . import _galsim
+lib_file = os.path.abspath(_galsim.__file__)
 
 # Import things from other files we want to be in the galsim namespace
 

--- a/galsim/config/util.py
+++ b/galsim/config/util.py
@@ -443,7 +443,7 @@ def PropagateIndexKeyRNGNum(config, index_key=None, rng_num=None, rng_index_key=
 
     if key is None:
         for key, field in config.items():
-            if key[0] == '_': continue
+            if isinstance(key, str) and key[0] == '_': continue
             PropagateIndexKeyRNGNum(field, index_key, rng_num, rng_index_key)
     else:
         PropagateIndexKeyRNGNum(config[key], index_key, rng_num, rng_index_key)
@@ -1000,7 +1000,8 @@ def CleanConfig(config, keep_current=False):
     """
     if isinstance(config, dict):
         return { k : CleanConfig(config[k], keep_current) for k in config
-                 if k[0] != '_' and (keep_current or k != 'current') }
+                 if not (isinstance(k, str) and k[0] == '_')
+                 and (keep_current or k != 'current') }
     elif isinstance(config, list):
         return [ CleanConfig(item, keep_current) for item in config ]
     else:

--- a/galsim/config/value_eval.py
+++ b/galsim/config/value_eval.py
@@ -194,4 +194,5 @@ def _GenerateFromEval(config, base, value_type):
 
 # Register this as a valid value type
 RegisterValueType('Eval', _GenerateFromEval,
-                  [ float, int, bool, str, Angle, Shear, PositionD, CelestialCoord, None ])
+                  [ float, int, bool, str, Angle, Shear, PositionD, CelestialCoord,
+                    LookupTable, dict, list, None ])

--- a/tests/test_config_value.py
+++ b/tests/test_config_value.py
@@ -1608,7 +1608,9 @@ def test_table_value():
                               ]
                   },
         'cur1' : { 'type' : 'Current', 'key' : 'file3' },
-        'cur2' : { 'type' : 'Current', 'key' : 'list1.items.1' }
+        'cur2' : { 'type' : 'Current', 'key' : 'list1.items.1' },
+        'eval1' : '$galsim.LookupTable([0,1,2,3], [0,10,10,0], interpolant="linear")',
+        'eval2' : '$galsim.LookupTable.from_file(@file1.file_name)',
     }
 
     # Test direct values
@@ -1643,6 +1645,12 @@ def test_table_value():
     assert cur1 == file3
     cur2 = galsim.config.ParseValue(config,'cur2',config, galsim.LookupTable)[0]
     assert cur2 == list1[1]
+
+    # Test Eval
+    eval1 = galsim.config.ParseValue(config,'eval1',config, galsim.LookupTable)[0]
+    assert eval1 == val1
+    eval2 = galsim.config.ParseValue(config,'eval2',config, galsim.LookupTable)[0]
+    assert eval2 == file1
 
 @timer
 def test_eval():

--- a/tests/test_config_value.py
+++ b/tests/test_config_value.py
@@ -1706,6 +1706,12 @@ def test_eval():
         'list2' : (0,1,2,3,4,5),
         'list3' : '$(0,1,2,3,4,5)',
 
+        # Check that a dict can be made using Eval
+        'dict0' : {0:'h', 1:'e', 2:'l', 3:'l', 4:'o'},
+        'dict1' : dict(enumerate("hello")),
+        'dict2' : '$dict(enumerate("hello"))',
+        'dict3' : '${ k:v for k,v in zip(np.arange(5), "hello") }',
+
         # These would be set by config in real runs, but just add them here for the tests.
         'image_pos' : galsim.PositionD(1.8,13),
         'world_pos' : galsim.PositionD(7.2,1.8),
@@ -1761,6 +1767,12 @@ def test_eval():
         test_list = galsim.config.ParseValue(config, 'list%d'%i, config, list)[0]
         print(test_list)
         np.testing.assert_array_equal(test_list, np.arange(6))
+
+    # Check ways of making a dict
+    for i in range(4):
+        test_dict = galsim.config.ParseValue(config, 'dict%d'%i, config, dict)[0]
+        print(test_dict)
+        np.testing.assert_array_equal(test_dict, dict(enumerate('hello')))
 
     # Test the evaluation in RandomDistribution
     # Example config taken directly from Issue #776:

--- a/tests/test_config_value.py
+++ b/tests/test_config_value.py
@@ -1700,6 +1700,12 @@ def test_eval():
         'bad4' : { 'type' : 'Eval', 'str' : 'np.exp(-0.5 * q**2)', 'fx' : 1.8 },
         'bad5' : { 'type' : 'Eval', 'eval_str' : 'np.exp(-0.5 * x**2)', 'fx' : 1.8 },
 
+        # Check that a list can be made using Eval
+        'list0' : [0,1,2,3,4,5],
+        'list1' : '$np.arange(6)',
+        'list2' : (0,1,2,3,4,5),
+        'list3' : '$(0,1,2,3,4,5)',
+
         # These would be set by config in real runs, but just add them here for the tests.
         'image_pos' : galsim.PositionD(1.8,13),
         'world_pos' : galsim.PositionD(7.2,1.8),
@@ -1749,6 +1755,12 @@ def test_eval():
     del config['eval_variables']
     with assert_raises(galsim.GalSimConfigError):
         galsim.config.ParseValue(config,'eval3',config, float)
+
+    # Check ways of making a list
+    for i in range(4):
+        test_list = galsim.config.ParseValue(config, 'list%d'%i, config, list)[0]
+        print(test_list)
+        np.testing.assert_array_equal(test_list, np.arange(6))
 
     # Test the evaluation in RandomDistribution
     # Example config taken directly from Issue #776:


### PR DESCRIPTION
@jmeyers314  discovered a bug in the config parsing that prevented Eval types from being used to generate a list object, when parsed in the normal way.  The oversight was that list (and dict and LookupTable) were not registered as valid types associated with the Eval type.  

The workaround is to use None for the value_type rather than list, but this is inelegant and less type-safe.