### PR TITLE
Fix segmentation faults in the Silicon class

### DIFF
--- a/include/galsim/Silicon.h
+++ b/include/galsim/Silicon.h
@@ -42,8 +42,8 @@ namespace galsim
                 const Table& tr_radial_table, Position<double> treeRingCenter,
                 const Table& abs_length_table, bool transpose);
         ~Silicon();
-    
-	bool insidePixel(int ix, int iy, double x, double y, double zconv,
+
+        bool insidePixel(int ix, int iy, double x, double y, double zconv,
                          Bounds<int>& targetBounds, bool* off_edge,
                          int emptypolySize,
                          Bounds<double>* pixelInnerBoundsData,
@@ -52,7 +52,7 @@ namespace galsim
                          Position<float>* verticalBoundaryPointsData,
                          Position<double>* emptypolyData) const;
 
-	void scaleBoundsToPoly(int i, int j, int nx, int ny,
+        void scaleBoundsToPoly(int i, int j, int nx, int ny,
                                const Polygon& emptypoly, Polygon& result,
                                double factor) const;
 
@@ -84,7 +84,7 @@ namespace galsim
         void initialize(ImageView<T> target, Position<int> orig_center);
 
         void finalize();
-    
+
         template <typename T>
         double accumulate(const PhotonArray& photons, int i1, int i2,
                           BaseDeviate rng, ImageView<T> target);
@@ -283,7 +283,7 @@ namespace galsim
         ImageAlloc<double> _delta;
         std::unique_ptr<bool[]> _changed;
 
-	// GPU data
+        // GPU data
         std::vector<double> _abs_length_table_GPU;
         std::vector<Position<double> > _emptypolyGPU;
         double _abs_length_arg_min, _abs_length_arg_max;

--- a/src/Silicon.cpp
+++ b/src/Silicon.cpp
@@ -1176,6 +1176,7 @@ namespace galsim {
         double* deltaData = _delta.getData();
         T* targetData = target.getData();
 
+        assert(targetData + imageDataSize <= target.getMaxPtr());
 #ifdef _OPENMP
 #ifndef GALSIM_USE_GPU
 #pragma omp parallel for
@@ -1201,6 +1202,7 @@ namespace galsim {
         double* deltaData = _delta.getData();
         T* targetData = target.getData();
 
+        assert(targetData + imageDataSize <= target.getMaxPtr());
 #ifdef _OPENMP
 #ifndef GALSIM_USE_GPU
 #pragma omp parallel for
@@ -1446,6 +1448,7 @@ namespace galsim {
         double* deltaData = _delta.getData();
         T* targetData = target.getData();
         
+        assert(targetData + imageDataSize <= target.getMaxPtr());
 #ifdef _OPENMP
 #ifndef GALSIM_USE_GPU
 #pragma omp parallel for


### PR DESCRIPTION
@cwwalter was getting occasional segmentation faults using GalSim main to do some imSim work, stemming from the Silicon class, which this PR partially fixes.  (It fixes them for CPU runs, but not completely for GPU runs.)

It turns out there were two serious problems with the current implementation related to calculating the number of pixels to work on:
1. The number of pixels was sometimes calculated as `int imageDataSize = _delta.getMaxPtr() - _delta.getData();`.  This is sometimes correct, but it's not reliable, since `_delta` gets resized from time to time.  When the size decreases, we don't deallocate and reallocate.  So `getMaxPtr()` can be much larger than the number of pixels currently being worked on.  This was the case in what Chris was doing, so some loops ended up writing many more values than the image stored, overrunning the allocated data.  Hence SIGSEGV.
2. Even when calculating the number of pixel correctly (from NCol * NRow), which it also did in various places, the addDelta function was wrongly assuming that the target image is contiguous in memory, which it doesn't have to be.  This error could also potentially cause seg faults, but mostly it just did the wrong thing when the target was not contiguous data.

I fixed both problems for CPU execution.  But I'm pretty confident that some of the GPU syncing is still not correct when the target image is not contiguous.  I marked these with FIXME comments.  

@jamesp-epcc Can you please fix those remaining GPU commands to make them work when step!=1?  And especially when step or stride < 0, which seems particularly tricky to get right.  I don't have easy access to a GPU machine to test on.