### PR TITLE
Chromatic seeing when photon shooting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,8 @@ jobs:
                 cd tests
                 coverage run -m pytest -v
                 pytest -v run_examples.py
+                coverage combine
+                coverage xml
                 cd ..  # N.B. This seems to happen automatically if omitted.
                        # Less confusing to include it explicitly.
 
@@ -209,18 +211,12 @@ jobs:
 
             - name: Upload coverage to codecov
               if: matrix.py != 'pypy-3.7'
-              run: |
-                cd tests
-                pwd -P
-                ls -la
-                coverage combine || true  # (Not necessary I think, but just in case.)
-                coverage report
-                ls -la
-                #codecov  # This didn't work.
-                # cf. https://community.codecov.io/t/github-not-getting-codecov-report-after-switching-from-travis-to-github-actions-for-ci/
-                # The solution was to switch to the bash uploader line instead.
-                bash <(curl -s https://codecov.io/bash)
-                cd ..
+              uses: codecov/codecov-action@v3
+              with:
+                token: ${{ secrets.CODECOV_TOKEN }}
+                files: tests/coverage.xml
+                fail_ci_if_error: false
+                verbose: true
 
             - name: Pre-cache cleanup
               continue-on-error: true

--- a/galsim/phase_psf.py
+++ b/galsim/phase_psf.py
@@ -1583,7 +1583,7 @@ class PhaseScreenPSF(GSObject):
         if photons.hasAllocatedWavelengths():
             w = photons.wavelength
         else:
-            w = None
+            w = self.lam
 
         n_photons = len(photons)
 

--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -764,7 +764,7 @@ class AtmosphericScreen:
         if theta[1].rad != 0:
             v += self._altitude*theta[1].tan()
         dfdx, dfdy = self._tab2d._gradient_wrap(u.ravel(), v.ravel())
-        if w is not None:
+        if w is not None and self.seeing_exp is not None:
             dfdx *= (w/500.)**self.seeing_exp
             dfdy *= (w/500.)**self.seeing_exp
         return dfdx.reshape(u.shape), dfdy.reshape(u.shape)

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -1569,6 +1569,24 @@ def test_seeing_exp():
     np.testing.assert_allclose(photons1.x, photons2.x*(700/500)**-0.3, rtol=0, atol=1e-15)
     np.testing.assert_allclose(photons1.y, photons2.y*(700/500)**-0.3, rtol=0, atol=1e-15)
 
+    # Also try when using a range of wavelengths
+    sed = galsim.SED('vega.txt', 'nm', 'flambda')
+    op1 = galsim.WavelengthSampler(sed)
+    op2 = galsim.WavelengthSampler(sed)
+
+    photons1 = psf1.drawImage(
+        image=img, save_photons=True, method='phot', n_photons=nphot, rng=rng.duplicate(),
+        photon_ops=[op1]
+    ).photons
+    photons2 = psf2.drawImage(
+        image=img, save_photons=True, method='phot', n_photons=nphot, rng=rng.duplicate(),
+        photon_ops=[op2]
+    ).photons
+    np.testing.assert_equal(photons1.wavelength, photons2.wavelength)
+    assert np.std(photons1.wavelength) > 0
+    np.testing.assert_allclose(photons1.x, photons2.x*(700/500)**-0.3, rtol=0, atol=1e-15)
+    np.testing.assert_allclose(photons1.y, photons2.y*(700/500)**-0.3, rtol=0, atol=1e-15)
+
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]


### PR DESCRIPTION
Adds chromatic seeing to atmospheric code for use when using geometric photon shooting (I believe similar behavior is already emergent when drawing with Fourier techniques).

To implement, I added a `wavelength` argument to the various `wavefront_gradient` methods.  In retrospect, I maybe should only have added the extra argument to the private version `_wavefront_gradient`, since as a purely geometric object, the real wavefront gradient isn't wavelength dependent.  Adding wavelength dependence here is kind of a hack to ensure we get the lambda^-beta chromatic dependence (beta ~ 0.2-0.4) expected from the fully diffractive calculation.  But I could lean either way on this one so curious for feedback.
