### PR TITLE
Add support for building GPU-enabled GalSim using NVIDIA compiler

### DIFF
--- a/include/galsim/Std.h
+++ b/include/galsim/Std.h
@@ -134,9 +134,10 @@ private:
 #define verbose_level Debugger::instance().get_level()
 #define xassert(x) assert(x)
 #else
-#define dbg if(false) (std::cerr)
-#define xdbg if(false) (std::cerr)
-#define xxdbg if(false) (std::cerr)
+extern std::ostream* dbgout;
+#define dbg if(false) (*dbgout)
+#define xdbg if(false) (*dbgout)
+#define xxdbg if(false) (*dbgout)
 #define set_dbgout(dbgout)
 #define set_verbose(level)
 #define xassert(x)

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ copt =  {
 }
 lopt =  {
     'gcc' : ['-fopenmp'],
-    'gcc w/ GPU' : ['-fopenmp','-foffload=nvptx-none'],
+    'gcc w/ GPU' : ['-fopenmp','-foffload=nvptx-none', '-foffload=-lm'],
     'icc' : ['-openmp'],
     'clang' : ['-stdlib=libc++'],
     'clang w/ OpenMP' : ['-stdlib=libc++','-fopenmp'],

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ shared_data = all_files_from('share')
 
 copt =  {
     'gcc' : ['-O2','-std=c++11','-fvisibility=hidden','-fopenmp'],
-    'gcc w/ GPU' : ['-O2','-std=c++11','-fvisibility=hidden','-fopenmp','-foffload=nvptx-none'],
+    'gcc w/ GPU' : ['-O2','-std=c++11','-fvisibility=hidden','-fopenmp','-foffload=nvptx-none','-DGALSIM_USE_GPU'],
     'icc' : ['-O2','-vec-report0','-std=c++11','-openmp'],
     'clang' : ['-O2','-std=c++11',
                '-Wno-shorten-64-to-32','-fvisibility=hidden','-stdlib=libc++'],
@@ -85,7 +85,7 @@ copt =  {
     'clang w/ GPU' : ['-O2','-msse2','-std=c++11','-fopenmp','-fopenmp-targets=nvptx64-nvidia-cuda',
                       '-Wno-openmp-mapping','-Wno-unknown-cuda-version',
                       '-Wno-shorten-64-to-32','-fvisibility=hidden', '-DGALSIM_USE_GPU'],
-    'nvc++' : ['-O2','-std=c++11','-mp=gpu'],
+    'nvc++' : ['-O2','-std=c++11','-mp=gpu','-DGALSIM_USE_GPU'],
     'unknown' : [],
 }
 lopt =  {

--- a/src/Silicon.cpp
+++ b/src/Silicon.cpp
@@ -1372,7 +1372,9 @@ namespace galsim {
             // Get the location where the photon strikes the silicon:
             double x0 = photonsX[i]; // in pixels
             double y0 = photonsY[i]; // in pixels
+#ifdef DEBUGLOGGING
             xdbg<<"x0,y0 = "<<x0<<','<<y0;
+#endif
 
             // get uniform random number for conversion depth from randomArray
             // (4th of 4 numbers for this photon)
@@ -1390,10 +1392,14 @@ namespace galsim {
                 x0 += dxdz * dz_pixel; // dx in pixels
                 y0 += dydz * dz_pixel; // dy in pixels
             }
+#ifdef DEBUGLOGGING
             xdbg<<" => "<<x0<<','<<y0;
+#endif
             // This is the reverse of depth. zconv is how far above the substrate the e- converts.
             double zconv = _sensorThickness - dz;
+#ifdef DEBUGLOGGING
             xdbg<<"zconv = "<<zconv<<std::endl;
+#endif
             if (zconv < 0.0) continue; // Throw photon away if it hits the bottom
             // TODO: Do something more realistic if it hits the bottom.
 
@@ -1405,7 +1411,9 @@ namespace galsim {
                 x0 += diffStep * randomArray[(i-i1)*4];
                 y0 += diffStep * randomArray[(i-i1)*4+1];
             }
+#ifdef DEBUGLOGGING
             xdbg<<" => "<<x0<<','<<y0<<std::endl;
+#endif
             double flux = photonsFlux[i];
 
 #ifdef DEBUGLOGGING

--- a/src/Silicon.cpp
+++ b/src/Silicon.cpp
@@ -1372,9 +1372,7 @@ namespace galsim {
             // Get the location where the photon strikes the silicon:
             double x0 = photonsX[i]; // in pixels
             double y0 = photonsY[i]; // in pixels
-#ifdef DEBUGLOGGING
             xdbg<<"x0,y0 = "<<x0<<','<<y0;
-#endif
 
             // get uniform random number for conversion depth from randomArray
             // (4th of 4 numbers for this photon)
@@ -1392,14 +1390,10 @@ namespace galsim {
                 x0 += dxdz * dz_pixel; // dx in pixels
                 y0 += dydz * dz_pixel; // dy in pixels
             }
-#ifdef DEBUGLOGGING
             xdbg<<" => "<<x0<<','<<y0;
-#endif
             // This is the reverse of depth. zconv is how far above the substrate the e- converts.
             double zconv = _sensorThickness - dz;
-#ifdef DEBUGLOGGING
             xdbg<<"zconv = "<<zconv<<std::endl;
-#endif
             if (zconv < 0.0) continue; // Throw photon away if it hits the bottom
             // TODO: Do something more realistic if it hits the bottom.
 
@@ -1411,9 +1405,7 @@ namespace galsim {
                 x0 += diffStep * randomArray[(i-i1)*4];
                 y0 += diffStep * randomArray[(i-i1)*4+1];
             }
-#ifdef DEBUGLOGGING
             xdbg<<" => "<<x0<<','<<y0<<std::endl;
-#endif
             double flux = photonsFlux[i];
 
 #ifdef DEBUGLOGGING


### PR DESCRIPTION
This PR adds support for building with the NVIDIA compiler, nvc++. This compiler doesn't support one of the warnings commonly enabled in the other compilers so we have to remove it. It also formats its version information a little differently from gcc and clang.

This also adds a missing macro definition for building for GPU with gcc.
