### PR TITLE
#1231 Fix slight inaccuracy in single precision fft phase shifts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -57,3 +57,4 @@ Bug Fixes
 - Changed the SED class to correctly broadcast over waves when the SED is constant. (#1228)
 - Fixed some errors when drawing ChromaticTransformation objects with photon shooting. (#1229)
 - Fixed the flux drawn by ChromaticConvolution with photon shooting when poisson_flux=True. (#1229)
+- Fixed a slight inaccuracy in the FFT phase shifts for single-precision images. (#1231, #1234)

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -386,6 +386,26 @@ def test_ne():
     check_all_diff(gals)
 
 
+@timer
+def test_accurate_shift():
+    """Test that shifted Gaussian looks the same with real and fourier drawing.
+    """
+    # This is in response to issue #1231
+
+    gal = galsim.Gaussian(sigma=1.).shift([5,5]).withFlux(200)
+
+    real_im = gal.drawImage(nx=128, ny=128, scale=0.2, method='real_space')
+    fft_im = gal.drawImage(nx=128, ny=128, scale=0.2, method='fft')
+    print('max abs diff = ',np.max(np.abs(real_im.array - fft_im.array)))
+    np.testing.assert_allclose(fft_im.array, real_im.array, rtol=1.e-7, atol=1.e-7)
+
+    # In double precision it's almost perfect.
+    real_im = gal.drawImage(nx=128, ny=128, scale=0.2, method='real_space', dtype=float)
+    fft_im = gal.drawImage(nx=128, ny=128, scale=0.2, method='fft', dtype=float)
+    print('max abs diff = ',np.max(np.abs(real_im.array - fft_im.array)))
+    np.testing.assert_allclose(fft_im.array, real_im.array, rtol=1.e-14, atol=1.e-14)
+
+
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
     for testfn in testfns:


### PR DESCRIPTION
@EiffL reported a very slight difference in the rendered images of a shifted profile using FFT rendering vs real space for single-precision images.  It's about 10x higher than the single precision epsilon on my laptop and 100x higher on Google collab, so I went ahead and switched the code to use double precision for the complex phases to avoid the accumulation of rounding errors, which fixed the problem.

Original:
![junk](https://github.com/GalSim-developers/GalSim/assets/623887/6a3f12ac-0345-4b51-8727-67983c6672f8)

Fixed:
![junk2](https://github.com/GalSim-developers/GalSim/assets/623887/38a75f24-4088-433c-b638-7fca9fd530bc)
