### PR TITLE
#1229 Fix a few errors in photon shooting chromatic transformations.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,3 +44,5 @@ Bug Fixes
 
 - Fixed a bug that prevented Eval types from generating lists in config files in some contexts.
 - Changed the SED class to correctly broadcast over waves when the SED is constant. (#1228)
+- Fixed some errors when drawing ChromaticTransformation objects with photon shooting. (#1229)
+- Fixed the flux drawn by ChromaticConvolution with photon shooting when poisson_flux=True. (#1229)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,9 @@ New Features
 Performance Improvements
 ------------------------
 
+- Drawing chromatic objects with photon shooting automatically adds a WavelengthSampler photon_op.
+  It used to do this regardless of if one was already in a photon_ops list, which is inefficient.
+  Now it only adds it if there is not already one given by the user. (#1229)
 - Work around an OMP bug that disables multiprocessing on some systems when omp_get_max_threads
   is called. (#1241)
 

--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -443,8 +443,9 @@ class ChromaticObject:
         wave_list, _, _ = utilities.combine_wave_list(self, bandpass)
 
         # If there are photon ops, they'll probably need valid wavelengths, so add
-        # WavelengthSampler as the first op in the list.
-        if kwargs.get('photon_ops', None):
+        # WavelengthSampler as the first op in the list (if one isn't already present).
+        if (kwargs.get('photon_ops', None)
+            and not any([isinstance(p,WavelengthSampler) for p in kwargs['photon_ops']])):
             wave_sampler = WavelengthSampler(self.SED, bandpass)
             kwargs['photon_ops'] = [wave_sampler] + kwargs['photon_ops']
 

--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -2674,7 +2674,8 @@ class ChromaticConvolution(ChromaticObject):
             poisson_flux = kwargs.pop('poisson_flux', n_photons == 0.)
             max_extra_noise = kwargs.pop('max_extra_noise', 0.)
             rng = BaseDeviate(kwargs.get('rng', None))
-            n_photons, _ = prof1._calculate_nphotons(n_photons, poisson_flux, max_extra_noise, rng)
+            n_photons, g = prof1._calculate_nphotons(n_photons, poisson_flux, max_extra_noise, rng)
+            gal *= g
             return gal.drawImage(bandpass, image=image, integrator=integrator,
                                  n_photons=n_photons, **kwargs)
 

--- a/tests/test_chromatic.py
+++ b/tests/test_chromatic.py
@@ -2967,6 +2967,12 @@ def test_shoot_transformation():
     print(img.added_flux)
     np.testing.assert_allclose(img.added_flux, flux)
 
+    # We used to do the wrong thing with poisson_flux=True.  Check that the flux isn't
+    # just 1000 in that case.
+    img = obj.drawImage(bandpass, nx=25, ny=25, scale=0.2, method='phot', rng=rng)
+    print(img.added_flux)
+    assert abs(img.added_flux - flux) > 0.1
+
     # Rotate
     psf = galsim.ChromaticObject(
         galsim.Gaussian(fwhm=1)
@@ -2976,6 +2982,9 @@ def test_shoot_transformation():
                         poisson_flux=False)
     print(img.added_flux)
     np.testing.assert_allclose(img.added_flux, flux)
+    img = obj.drawImage(bandpass, nx=25, ny=25, scale=0.2, method='phot', rng=rng)
+    print(img.added_flux)
+    assert abs(img.added_flux - flux) > 0.1
 
     # Expand
     psf = galsim.ChromaticObject(
@@ -2989,16 +2998,22 @@ def test_shoot_transformation():
     # With only 1000 photons, it only matches to better than 2.e-3.
     print(img.added_flux)
     np.testing.assert_allclose(img.added_flux, flux, rtol=2.e-3)
+    img = obj.drawImage(bandpass, nx=25, ny=25, scale=0.2, method='phot', rng=rng)
+    print(img.added_flux)
+    assert abs(img.added_flux - flux) > 0.1
 
     # Shift
     psf = galsim.ChromaticObject(
         galsim.Gaussian(fwhm=1)
-    ).shift(lambda w: ((w/500)*0.3, (w/500)*0.9))
+    ).shift(lambda w: ((w/500)*0.3, (w/500)*-0.4))
     obj = galsim.Convolve(psf, star).withFlux(flux, bandpass)
     img = obj.drawImage(bandpass, nx=25, ny=25, scale=0.2, method='phot', rng=rng,
                         poisson_flux=False)
     print(img.added_flux)
     np.testing.assert_allclose(img.added_flux, flux)
+    img = obj.drawImage(bandpass, nx=25, ny=25, scale=0.2, method='phot', rng=rng)
+    print(img.added_flux)
+    assert abs(img.added_flux - flux) > 0.1
 
     # Shear
     psf = galsim.ChromaticObject(
@@ -3009,6 +3024,9 @@ def test_shoot_transformation():
                         poisson_flux=False)
     print(img.added_flux)
     np.testing.assert_allclose(img.added_flux, flux)
+    img = obj.drawImage(bandpass, nx=25, ny=25, scale=0.2, method='phot', rng=rng)
+    print(img.added_flux)
+    assert abs(img.added_flux - flux) > 0.1
 
     # Magnify
     psf = galsim.ChromaticObject(
@@ -3019,6 +3037,9 @@ def test_shoot_transformation():
                         poisson_flux=False)
     print(img.added_flux)
     np.testing.assert_allclose(img.added_flux, flux, rtol=2.e-3)
+    img = obj.drawImage(bandpass, nx=25, ny=25, scale=0.2, method='phot', rng=rng)
+    print(img.added_flux)
+    assert abs(img.added_flux - flux) > 0.1
 
     # Lens
     psf = galsim.ChromaticObject(
@@ -3029,6 +3050,9 @@ def test_shoot_transformation():
                         poisson_flux=False)
     print(img.added_flux)
     np.testing.assert_allclose(img.added_flux, flux, rtol=2.e-3)
+    img = obj.drawImage(bandpass, nx=25, ny=25, scale=0.2, method='phot', rng=rng)
+    print(img.added_flux)
+    assert abs(img.added_flux - flux) > 0.1
 
     # Transform
     psf = galsim.ChromaticObject(
@@ -3040,6 +3064,9 @@ def test_shoot_transformation():
                         poisson_flux=False)
     print(img.added_flux)
     np.testing.assert_allclose(img.added_flux, flux, rtol=2.e-3)
+    img = obj.drawImage(bandpass, nx=25, ny=25, scale=0.2, method='phot', rng=rng)
+    print(img.added_flux)
+    assert abs(img.added_flux - flux) > 0.1
 
     # Flux_scale
     psf = galsim.ChromaticObject(
@@ -3050,6 +3077,9 @@ def test_shoot_transformation():
                         poisson_flux=False)
     print(img.added_flux)
     np.testing.assert_allclose(img.added_flux, flux)
+    img = obj.drawImage(bandpass, nx=25, ny=25, scale=0.2, method='phot', rng=rng)
+    print(img.added_flux)
+    assert abs(img.added_flux - flux) > 0.1
 
 
 if __name__ == "__main__":

--- a/tests/test_photon_array.py
+++ b/tests/test_photon_array.py
@@ -876,11 +876,10 @@ def test_dcr():
     np.testing.assert_allclose(im8.array, im6.array, atol=1.e3,
                                err_msg="base_psf + dcr in photon_ops didn't match")
 
-    # Including the wavelength sampler with chromatic drawing is redundant.
-    # This raises a warning, not an error.
+    # Including the wavelength sampler with chromatic drawing is not necessary, but is allowed.
+    # (Mostly in case someone wants to do something a little different w.r.t. wavelenght sampling.
     photon_ops = [wave_sampler, base_PSF, dcr]
-    with assert_warns(galsim.GalSimWarning):
-        star.drawImage(bandpass, image=im8, method='phot', rng=rng, photon_ops=photon_ops)
+    star.drawImage(bandpass, image=im8, method='phot', rng=rng, photon_ops=photon_ops)
     printval(im8, im6, show=False)
     np.testing.assert_allclose(im8.array, im6.array, atol=1.e3,
                                err_msg="wave_sampler,base_psf,dcr in photon_ops didn't match")


### PR DESCRIPTION
Josh pointed out in #1229 that chromatic objects with wavelength-dependent transformations don't work with photon shooting.  This fixes that.

I also fixed two other issues in this part of the code:

* GalSim automatically adds a WavelengthSampler to the photon_ops for photon shooting chromatic objects.  But if the user already did that, then it (1) redundantly samples the wavelengths twice, which is inefficient and (2) warns the user that this is likely an error.  Well, IMO, the error is in the GalSim code, not the user code.  So now it skips adding a redundant WavelengthSampler and consequently doesn't emit the warning.
* I realized when writing the test that the handling of the poisson_flux option in ChromaticConvolution was incorrect.  It neglected to apply the g factor returned by `_calculate_nphotons`, which is required to get the rendered poisson flux correct.  (Basically because the way we implement this, shooting always tries to get the right total flux with whatever n_photons is, but then multiplying by g gets them back to the poisson value.)