### PR TITLE
Add initial_image input type

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Config Updates
 
 - Fixed a bug in Scattered type, where it didn't respect world_pos being specified in the
   stamp field, as it should.  (#1190)
+- Added a new ``initial_image`` input type that lets you read in an existing image file
+  and draw onto it. (#1237)
 
 
 New Features

--- a/galsim/config/__init__.py
+++ b/galsim/config/__init__.py
@@ -45,6 +45,7 @@ from . import input_real
 from . import input_cosmos
 from . import input_nfw
 from . import input_powerspectrum
+from . import input_image
 
 from . import extra_psf
 from . import extra_weight

--- a/galsim/config/image.py
+++ b/galsim/config/image.py
@@ -525,7 +525,10 @@ class ImageBuilder:
 
         current_image = base['current_image']
         if current_image is not None and image is not None:
-            image += current_image
+            b = current_image.bounds & image.bounds
+            if b.isDefined():
+                current_image[b] += image[b]
+            image = current_image
 
         return image, current_var
 

--- a/galsim/config/image_scattered.py
+++ b/galsim/config/image_scattered.py
@@ -21,7 +21,7 @@ import numpy as np
 
 from .image import ImageBuilder, FlattenNoiseVariance, RegisterImageType
 from .value import ParseValue, GetAllParams
-from .stamp import BuildStamps, _ParseDType
+from .stamp import BuildStamps
 from .noise import AddSky, AddNoise
 from .input import ProcessInputNObjects
 from ..errors import GalSimConfigError, GalSimConfigValueError
@@ -92,16 +92,7 @@ class ScatteredImageBuilder(ImageBuilder):
         Returns:
             the final image and the current noise variance in the image as a tuple
         """
-        full_xsize = base['image_xsize']
-        full_ysize = base['image_ysize']
-        wcs = base['wcs']
-
-        dtype = _ParseDType(config, base)
-        full_image = Image(full_xsize, full_ysize, dtype=dtype)
-        full_image.setOrigin(base['image_origin'])
-        full_image.wcs = wcs
-        full_image.setZero()
-        base['current_image'] = full_image
+        full_image = base['current_image']
 
         if 'image_pos' in config and 'world_pos' in config:
             raise GalSimConfigValueError(
@@ -111,6 +102,8 @@ class ScatteredImageBuilder(ImageBuilder):
         if ('image_pos' not in config and 'world_pos' not in config and
                 not ('stamp' in base and
                     ('image_pos' in base['stamp'] or 'world_pos' in base['stamp']))):
+            full_xsize = base['image_xsize']
+            full_ysize = base['image_ysize']
             xmin = base['image_origin'].x
             xmax = xmin + full_xsize-1
             ymin = base['image_origin'].y

--- a/galsim/config/image_tiled.py
+++ b/galsim/config/image_tiled.py
@@ -22,7 +22,7 @@ import numpy as np
 from .image import ImageBuilder, FlattenNoiseVariance, RegisterImageType
 from .util import GetRNG
 from .value import ParseValue, GetAllParams
-from .stamp import BuildStamps, _ParseDType
+from .stamp import BuildStamps
 from .noise import AddSky, AddNoise
 from ..errors import GalSimConfigError, GalSimConfigValueError
 from ..image import Image
@@ -115,16 +115,7 @@ class TiledImageBuilder(ImageBuilder):
         Returns:
             the final image and the current noise variance in the image as a tuple
         """
-        full_xsize = base['image_xsize']
-        full_ysize = base['image_ysize']
-        wcs = base['wcs']
-
-        dtype = _ParseDType(config, base)
-        full_image = Image(full_xsize, full_ysize, dtype=dtype)
-        full_image.setOrigin(base['image_origin'])
-        full_image.wcs = wcs
-        full_image.setZero()
-        base['current_image'] = full_image
+        full_image = base['current_image']
 
         nobjects = self.nx_tiles * self.ny_tiles
 

--- a/galsim/config/input_image.py
+++ b/galsim/config/input_image.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2012-2022 by the GalSim developers team on GitHub
+# https://github.com/GalSim-developers
+#
+# This file is part of GalSim: The modular galaxy image simulation toolkit.
+# https://github.com/GalSim-developers/GalSim
+#
+# GalSim is free software: redistribution and use in source and binary forms,
+# with or without modification, are permitted provided that the following
+# conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions, and the disclaimer given in the accompanying LICENSE
+#    file.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions, and the disclaimer given in the documentation
+#    and/or other materials provided with the distribution.
+#
+
+
+from .input import InputLoader, RegisterInputType
+from .value import GetAllParams
+from ..fits import read
+
+# This file adds input type initial_image.
+
+class InitialImageLoader(InputLoader):
+
+    def __init__(self):
+        self.init_func = read
+        self.has_nobj = False
+        self.file_scope = False
+        self.takes_logger = False
+        self.use_proxy = False
+
+    def getKwargs(self, config, base, logger):
+        """Parse the config dict and return the kwargs needed to build the PowerSpectrum object.
+
+        Parameters:
+            config:     The configuration dict for 'power_spectrum'
+            base:       The base configuration dict
+            logger:     If given, a logger object to log progress.
+
+        Returns:
+            kwargs, safe
+        """
+        req = { 'file_name': str }
+        opt = { 'dir': str, 'read_header': bool }
+        return GetAllParams(config, base, req=req, opt=opt)
+
+    def setupImage(self, input_obj, config, base, logger=None):
+        """Set up the PowerSpectrum input object's gridded values based on the
+        size of the image and the grid spacing.
+
+        Parameters:
+            input_obj:  The PowerSpectrum object to use
+            config:     The configuration dict for 'power_spectrum'
+            base:       The base configuration dict.
+            logger:     If given, a logger object to log progress.
+        """
+        base['current_image'] = input_obj.copy()
+
+# Register this as a valid input type
+RegisterInputType('initial_image', InitialImageLoader())

--- a/galsim/config/stamp.py
+++ b/galsim/config/stamp.py
@@ -525,7 +525,7 @@ def DrawBasic(prof, image, method, offset, config, base, logger, **kwargs):
         kwargs['sensor'] = sensor
 
     if image is None:
-        kwargs['dtype'] = _ParseDType(config, base)
+        kwargs['dtype'] = ParseDType(config, base)
 
     if logger.isEnabledFor(logging.DEBUG):
         # Don't output the full image array.  Use str(image) for that kwarg.  And Bandpass.
@@ -584,7 +584,7 @@ def ParseWorldPos(config, param_name, base, logger):
     else:
         return ParseValue(config, param_name, base, PositionD)[0]
 
-def _ParseDType(config, base):
+def ParseDType(config, base):
     dtype = config.get('dtype', None)
     if isinstance(dtype, str):
         try:
@@ -891,7 +891,7 @@ class StampBuilder:
             the image
         """
         if xsize and ysize:
-            dtype = _ParseDType(config, base)
+            dtype = ParseDType(config, base)
             im = Image(xsize, ysize, dtype=dtype)
             im.setZero()
             return im

--- a/tests/config_input/sn.yaml
+++ b/tests/config_input/sn.yaml
@@ -1,0 +1,86 @@
+# Copyright (c) 2012-2022 by the GalSim developers team on GitHub
+# https://github.com/GalSim-developers
+#
+# This file is part of GalSim: The modular galaxy image simulation toolkit.
+# https://github.com/GalSim-developers/GalSim
+#
+# GalSim is free software: redistribution and use in source and binary forms,
+# with or without modification, are permitted provided that the following
+# conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions, and the disclaimer given in the accompanying LICENSE
+#    file.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions, and the disclaimer given in the documentation
+#    and/or other materials provided with the distribution.
+#
+
+
+modules:
+    - numpy
+
+psf:
+    type: Moffat
+    beta: 3
+    fwhm: 0.6
+    ellip: '$galsim.Shear(e1=0.03, e2=-0.04)'
+
+image:
+    type: Single
+    size: 128
+    dtype: float
+    random_seed:
+        - 12345
+    pixel_scale: 0.2
+    # No noise, which is unrealistic, but makes the test easier.
+
+---
+
+gal:
+    type: Exponential
+    half_light_radius: 2.3
+    flux: 3.e6
+    ellip:
+        type: E1E2
+        e1: 0.4
+        e2: 0.7
+
+output:
+    dir: output
+    file_name: ref.fits
+
+---
+
+eval_variables:
+    # Model the time of the exposure as a linear function of the image_num with a 8 day cadence.
+    # More realistic versions of this could use datetime with observation times from
+    # a file or something similarly interesting.
+    ftime: '$(image_num - 2.3) * 7'  # in days
+    fmax_flux: 1.e5
+
+input:
+    initial_image:
+        dir: output
+        file_name: ref.fits
+
+gal:
+    # The "gal" here is the SN, which is a point source.
+    type: DeltaFunction
+    flux: '$0 if time < 0 else np.exp(-time/50) * max_flux'
+
+stamp:
+    image_pos:
+        type: XY
+        x: 80
+        y: 60
+
+output:
+    nfiles: 12
+    dir: output
+    file_name:
+        type: NumberedFile
+        root: 'SN_image'
+        num: '$file_num'
+        digits: 2
+

--- a/tests/config_input/sn.yaml
+++ b/tests/config_input/sn.yaml
@@ -17,9 +17,6 @@
 #
 
 
-modules:
-    - numpy
-
 psf:
     type: Moffat
     beta: 3

--- a/tests/test_config_image.py
+++ b/tests/test_config_image.py
@@ -214,7 +214,7 @@ def test_positions():
     #logger.setLevel(logging.DEBUG)
 
     gal = galsim.Gaussian(sigma=1.7, flux=100)
-    im1= gal.drawImage(nx=21, ny=21, scale=1)
+    im1 = gal.drawImage(nx=21, ny=21, scale=1)
     im1.setCenter(39,43)
 
     im2 = galsim.config.BuildImage(config, logger=logger)
@@ -279,6 +279,29 @@ def test_positions():
     config['stamp']['world_pos'] = { 'type' : 'Random' }
     with assert_raises(galsim.GalSimConfigError):
         galsim.config.BuildImage(config)
+    del config['stamp']['world_pos']
+
+    # If the size is set in image, then image_pos will put the object offset in this image.
+    config['image'] = {
+        'type' : 'Single',
+        'size' : 64,
+    }
+    im11 = galsim.config.BuildImage(config)
+    assert im11.bounds == galsim.BoundsI(1,64,1,64)
+    assert im11[im2.bounds] == im2
+
+    # If the offset is larger, then only the overlap is included
+    config['image']['size'] = 50
+    im12 = galsim.config.BuildImage(config)
+    assert im12.bounds == galsim.BoundsI(1,50,1,50)
+    b = im12.bounds & im2.bounds
+    assert im12[b] == im2[b]
+
+    # If the offset is large enough, none of the stamp is included.
+    config['image']['size'] = 32
+    im13 = galsim.config.BuildImage(config)
+    assert im13.bounds == galsim.BoundsI(1,32,1,32)
+    np.testing.assert_array_equal(im13.array, 0.)
 
 
 @timer


### PR DESCRIPTION
This PR adds the ability for the config processing to read in an initial image from a file and draw additional things onto that.  The implementation is pretty simple:
```
input:
    initial_image:
        file_name: inital_image_file.fits
```
My test for this is to simulate a supernova time series.  It draws a single reference image, and then draws a point source with variable flux 12 times.  The SN appears between the 3rd and 4th image.  And then it decays exponentially.
<img width="724" alt="Screen Shot 2023-08-15 at 4 11 04 PM" src="https://github.com/GalSim-developers/GalSim/assets/623887/7e1fc07c-cc09-43c6-94d6-b39036f63c82">
