### PR TITLE
Make inputs work if dependent on later input items

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ Config Updates
 - Added a new ``initial_image`` input type that lets you read in an existing image file
   and draw onto it. (#1237)
 - Added skip_failures option in stamp fields.  (#1238)
+- Let input items depend on other input items, even if they appear later in the input field.
+  (#1239)
 
 
 New Features


### PR DESCRIPTION
imSim has input types that depend on other input types.  Most notably, many things implicitly depend on opsim_data, which is basically a dict with a bunch of values that things need.  If the inputs are listed in order with dependencies first, everything is fine.  But when using recursive templates, this can be difficult to get right.  Currently, that causes the input items that are dependent on later ones not to load properly.  The most critical of these is atm_psf, which needs to be loaded at the start to only build one set of atmospheric screens for all the CCDs to use.  cf. https://github.com/LSSTDESC/imSim/pull/408

In this PR, when loading an input object, if it raises an exception that indicates it needs a different input type, it tries to load that one first before continuing on.
