### PR TITLE
Set OMP_PROC_BIND=false before calling omp_get_max_threads

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,8 @@ New Features
 Performance Improvements
 ------------------------
 
+- Work around an OMP bug that disables multiprocessing on some systems when omp_get_max_threads
+  is called. (#1241)
 
 
 Bug Fixes

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -1867,9 +1867,9 @@ def get_omp_threads():
     """
     # Some OMP implemenations have a bug where if omp_get_max_threads() is called
     # (which is what this function does), it sets something called thread affinity.
-    # The upshot of that is that multiprocessing (i.e. not even omp threading) is confined
-    # to a single thread.  Yeah, it's idiotic, but that seems to be the case.
-    # The only solution found by Eli, who looked into it prett hard, is to set the env
+    # The upshot of that is that multiprocessing (i.e. not even just omp threading) is confined
+    # to a single hardware thread.  Yeah, it's idiotic, but that seems to be the case.
+    # The only solution found by Eli, who looked into it pretty hard, is to set the env
     # variable OMP_PROC_BIND to "false".  This seems to stop the bad behavior.
     # So we do it here always before calling GetOMPThreads.
     # If this breaks someone valid use of this variable, let us know and we can try to

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1208,6 +1208,17 @@ def test_omp():
         assert "OpenMP reports that it will use 1 threads" in cl.output
         assert "Unable to use multiple threads" in cl.output
 
+    # This is really just for coverage.  Check that OMP_PROC_BIND gets set properly.
+    with mock.patch('os.environ', {}):
+        assert os.environ.get('OMP_PROC_BIND') is None
+        galsim.get_omp_threads()
+        assert os.environ.get('OMP_PROC_BIND') == 'false'
+
+    with mock.patch('os.environ', {}):
+        assert os.environ.get('OMP_PROC_BIND') is None
+        galsim.set_omp_threads(4)
+        assert os.environ.get('OMP_PROC_BIND') == 'false'
+
 
 @timer
 def test_big_then_small():


### PR DESCRIPTION
Some OMP implemenations have a bug where if omp_get_max_threads() is called (which is what this function does), it sets something called thread affinity.

The upshot of that is that multiprocessing (i.e. not even just omp threading) is confined to a single hardware thread.  Yeah, it's idiotic, but that seems to be the case. The only solution found by @erykoff, who looked into it pretty hard, is to set the env variable OMP_PROC_BIND to "false".  This seems to stop the bad behavior. 

So this PR adds that to the two functions that could potentially call omp_get_max_threads in the C++ layer.