### PR TITLE
Don't error if two photon_arrays being convolved both have allocated ancillary arrays.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -64,3 +64,5 @@ Bug Fixes
 - Fixed some errors when drawing ChromaticTransformation objects with photon shooting. (#1229)
 - Fixed the flux drawn by ChromaticConvolution with photon shooting when poisson_flux=True. (#1229)
 - Fixed a slight inaccuracy in the FFT phase shifts for single-precision images. (#1231, #1234)
+- Fixed a bug that prevented a convolution of two PhaseScreenPSF objects from being drawn with
+  photon shooting. (#1242)

--- a/galsim/photon_array.py
+++ b/galsim/photon_array.py
@@ -465,44 +465,28 @@ class PhotonArray:
 
     def convolve(self, rhs, rng=None):
         """Convolve this `PhotonArray` with another.
+
+        ..note::
+
+            If both self and rhs have wavelengths, angles, pupil coordinates or times assigned,
+            then the values from the first array (i.e. self) take precedence.
         """
         if rhs.size() != self.size():
             raise GalSimIncompatibleValuesError("PhotonArray.convolve with unequal size arrays",
                                                 self_pa=self, rhs=rhs)
-        if rhs.hasAllocatedAngles():
-            if self.hasAllocatedAngles():
-                raise GalSimIncompatibleValuesError(
-                    "PhotonArray.convolve with doubly assigned angles"
-                )
-            else:
-                self.dxdz = rhs.dxdz
-                self.dydz = rhs.dydz
+        if rhs.hasAllocatedAngles() and not self.hasAllocatedAngles():
+            self.dxdz = rhs.dxdz
+            self.dydz = rhs.dydz
 
-        if rhs.hasAllocatedWavelengths():
-            if self.hasAllocatedWavelengths() and self._wave is not rhs._wave:
-                raise GalSimIncompatibleValuesError(
-                    "PhotonArray.convolve with doubly assigned wavelengths"
-                )
-            else:
-                self.wavelength = rhs.wavelength
+        if rhs.hasAllocatedWavelengths() and not self.hasAllocatedWavelengths():
+            self.wavelength = rhs.wavelength
 
-        if rhs.hasAllocatedPupil():
-            if self.hasAllocatedPupil() and (
-                    self._pupil_u is not rhs._pupil_u or self._pupil_v is not rhs._pupil_v):
-                raise GalSimIncompatibleValuesError(
-                    "PhotonArray.convolve with doubly assigned pupil coordinates"
-                )
-            else:
-                self.pupil_u = rhs.pupil_u
-                self.pupil_v = rhs.pupil_v
+        if rhs.hasAllocatedPupil() and not self.hasAllocatedPupil():
+            self.pupil_u = rhs.pupil_u
+            self.pupil_v = rhs.pupil_v
 
-        if rhs.hasAllocatedTimes():
-            if self.hasAllocatedTimes() and self._time is not rhs._time:
-                raise GalSimIncompatibleValuesError(
-                    "PhotonArray.convolve with doubly assigned time stamps"
-                )
-            else:
-                self.time = rhs.time
+        if rhs.hasAllocatedTimes() and not self.hasAllocatedTimes():
+            self.time = rhs.time
 
         rng = BaseDeviate(rng)
         self._pa.convolve(rhs._pa, rng._rng)

--- a/tests/test_photon_array.py
+++ b/tests/test_photon_array.py
@@ -350,18 +350,26 @@ def test_convolve():
 
     # Check propagation of dxdz, dydz, wavelength, pupil_u, pupil_v
     for attr, checkFn in zip(
-        ['dxdz', 'wavelength', 'pupil_u', 'time'],
-        ['hasAllocatedAngles', 'hasAllocatedWavelengths', 'hasAllocatedPupil',
+        ['dxdz', 'dydz', 'wavelength', 'pupil_u', 'pupil_v', 'time'],
+        ['hasAllocatedAngles', 'hasAllocatedAngles',
+         'hasAllocatedWavelengths', 'hasAllocatedPupil', 'hasAllocatedPupil',
          'hasAllocatedTimes']
     ):
         pa1 = obj.shoot(nphotons, rng)
         pa2 = obj.shoot(nphotons, rng)
+        assert not getattr(pa1, checkFn)()
+        assert not getattr(pa1, checkFn)()
         data = np.linspace(-0.1, 0.1, nphotons)
         setattr(pa1, attr, data)
-        pa1.convolve(pa2)
-        np.testing.assert_array_equal(getattr(pa1, attr), data)
+        assert getattr(pa1, checkFn)()
         assert not getattr(pa2, checkFn)()
+        pa1.convolve(pa2)
+        assert getattr(pa1, checkFn)()
+        assert not getattr(pa2, checkFn)()
+        np.testing.assert_array_equal(getattr(pa1, attr), data)
         pa2.convolve(pa1)
+        assert getattr(pa1, checkFn)()
+        assert getattr(pa2, checkFn)()
         np.testing.assert_array_equal(getattr(pa2, attr), data)
 
         # both have data now...

--- a/tests/test_photon_array.py
+++ b/tests/test_photon_array.py
@@ -365,8 +365,15 @@ def test_convolve():
         np.testing.assert_array_equal(getattr(pa2, attr), data)
 
         # both have data now...
-        with assert_raises(galsim.GalSimIncompatibleValuesError):
-            pa1.convolve(pa2)
+        pa1.convolve(pa2)
+        np.testing.assert_array_equal(getattr(pa1, attr), data)
+        np.testing.assert_array_equal(getattr(pa2, attr), data)
+
+        # If the second one has different data, the first takes precedence.
+        setattr(pa2, attr, data * 2)
+        pa1.convolve(pa2)
+        np.testing.assert_array_equal(getattr(pa1, attr), data)
+        np.testing.assert_array_equal(getattr(pa2, attr), 2*data)
 
 
 @timer


### PR DESCRIPTION
When convolving two PhotonArrays, we had a feature where GalSim would check if both of them had various ancillary arrays set (and not identical), and if they were both set, it would raise an exception.  The thought was that this probably indicated an error.  But in practice it meant that when two PhaseScreenPSFs were convolved, they couldn't be drawn with photon shooting, since each of them would have set the pupil coordinates and the time independently.

If you want to be really careful about these ancillary arrays, then you can put the PSFs in photon_ops, in which case they will be processed sequentially and PhaseScreenPSF won't overwrite e.g. pupil coordinates that are already there.  But if you don't much care about these ancillary arrays, it should be allowed to just convolve two PSF objects and draw them any old way.  So now you can.

This bug showed up in imSim when doOpt=True.  The workaround was to put the psfs in photon_ops, as I mentioned above.  cf. https://github.com/LSSTDESC/imSim/pull/410