### PR TITLE
Delay calculation of SED until it is actually needed.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,6 +49,9 @@ Performance Improvements
   is called. (#1241)
 - The `combine_wave_lists` function is faster now, using the new `merge_sorted` function.
   (#1243)
+- Delayed the calculation of the `sed` attributes of `ChromaticObject`s until they are actually
+  needed.  Since sometimes they aren't needed, this is a performance improvement in those cases.
+  (#1245)
 
 
 Bug Fixes

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ API Changes
   if the angle arrays have not been either set or explicitly allocated.  One should be sure
   to either set them (e.g. using ``photon_array.dxdz = [...]``) or explicitly allocate
   them (using ``photon_array.allocateAngles()``).  (#1191)
+- Changed the ``.SED`` attribute name of `ChromaticObject`s to lowercase ``.sed``. (#1245)
 
 
 Config Updates

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Config Updates
 - Added skip_failures option in stamp fields.  (#1238)
 - Let input items depend on other input items, even if they appear later in the input field.
   (#1239)
+- Allow profiling output to reach the logger when running with -v0. (#1245)
 
 
 New Features

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,6 +49,9 @@ Performance Improvements
   is called. (#1241)
 - The `combine_wave_lists` function is faster now, using the new `merge_sorted` function.
   (#1243)
+- No longer keep a separate ``wave_list`` array in `ChromaticObject`s.  These are always
+  equal to the ``wave_list`` in the ``sed`` attribute, so there is no need to duplicate the
+  work of computing the ``wave_list``. (#1245)
 - Delayed the calculation of the `sed` attributes of `ChromaticObject`s until they are actually
   needed.  Since sometimes they aren't needed, this is a performance improvement in those cases.
   (#1245)

--- a/devel/time_faint_bd_gals.py
+++ b/devel/time_faint_bd_gals.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2012-2022 by the GalSim developers team on GitHub
+# https://github.com/GalSim-developers
+#
+# This file is part of GalSim: The modular galaxy image simulation toolkit.
+# https://github.com/GalSim-developers/GalSim
+#
+# GalSim is free software: redistribution and use in source and binary forms,
+# with or without modification, are permitted provided that the following
+# conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions, and the disclaimer given in the accompanying LICENSE
+#    file.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions, and the disclaimer given in the documentation
+#    and/or other materials provided with the distribution.
+#
+
+import timeit
+import galsim
+import numpy as np
+
+# This script more or less runs through what happens to faint bulge + disk + knots
+# objects in imSim.  In particular, these used to spend a lot of time computing
+# SEDs, especially combining wave_lists, which are eventually discarded to instead
+# use a "trivial_sed".
+
+bulge_sed = galsim.SED('CWW_E_ext.sed', wave_type='ang', flux_type='flambda')
+disk_sed = galsim.SED('CWW_Sbc_ext.sed', wave_type='ang', flux_type='flambda')
+knots_sed = galsim.SED('CWW_Scd_ext.sed', wave_type='ang', flux_type='flambda')
+trivial_sed = galsim.SED(galsim.LookupTable([100, 2000], [1,1], interpolant='linear'),
+                         wave_type='nm', flux_type='fphotons')
+
+bandpass = galsim.Bandpass('LSST_r.dat', 'nm')
+
+rng = galsim.BaseDeviate(1234)
+
+# This is from the DoubleGaussian class in imSim.
+# It's cached in imsim, so put it a global scope here.
+fwhm1=0.6
+fwhm2=0.12
+wgt1=1.0
+wgt2=0.1
+r1 = fwhm1/2.355
+r2 = fwhm2/2.355
+norm = 1.0/(wgt1 + wgt2)
+gaussian1 = galsim.Gaussian(sigma=r1)
+gaussian2 = galsim.Gaussian(sigma=r2)
+double_gaussian = norm*(wgt1*gaussian1 + wgt2*gaussian2)
+
+
+def draw_faint(rng):
+    ud = galsim.UniformDeviate(rng)
+    bulge = galsim.Sersic(n=4,
+                          half_light_radius= 0.7 + ud() * 0.5)
+    disk = galsim.Exponential(half_light_radius= 1.0 + ud() * 0.5)
+    knots = galsim.RandomKnots(profile=disk, rng=rng, npoints=int(20+ud()*20))
+
+    bulge_fraction = ud() * 0.5
+    knots_fraction = ud() * 0.2
+    disk_fraction = 1 - knots_fraction - bulge_fraction
+    gal = galsim.Add(bulge * bulge_fraction * bulge_sed,
+                     disk * disk_fraction * disk_sed,
+                     knots * knots_fraction * knots_sed)
+    gal.flux = ud() * 20  # Anything fainter than flux=100 is considered *faint* in imSim.
+
+    # This isn't the psf we use, but it's suitably complicated enough for this test.
+    psf = galsim.ChromaticAtmosphere(galsim.Moffat(fwhm=0.8, beta=2.3),
+                                     base_wavelength=500, zenith_angle=15*galsim.degrees)
+
+    realized_flux = galsim.PoissonDeviate(rng, mean=gal.flux)()
+
+    if realized_flux == 0:
+        return None
+
+    if realized_flux < 10:
+        image_size = 32
+    else:
+        psf = double_gaussian
+        gal_achrom = gal.evaluateAtWavelength(bandpass.effective_wavelength)
+        obj = galsim.Convolve(gal_achrom, psf).withFlux(realized_flux)
+        image_size = obj.getGoodImageSize(0.2)
+
+    image = galsim.Image(ncol=image_size, nrow=image_size, scale=0.2)  # Simple WCS.
+
+    faint = realized_flux < 100
+    assert faint  # This script is designed for this to always be true.
+
+    gal = gal.evaluateAtWavelength(bandpass.effective_wavelength)
+    gal = gal * trivial_sed
+    gal = gal.withFlux(realized_flux, bandpass)
+
+    gal.drawImage(bandpass, method='phot', rng=rng, n_photons=realized_flux, image=image,
+                  poisson_flux=False)
+    return image
+
+n = 1000
+t1 = min(timeit.repeat(lambda: draw_faint(rng), number=n))
+
+print(f'Time for {n} iterations of draw_faint = {t1}')
+
+with galsim.utilities.Profile(filename='faint.pstats'):
+    for i in range(n):
+        draw_faint(rng)

--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -2847,7 +2847,7 @@ class ChromaticDeconvolution(ChromaticObject):
 
     @property
     def sed(self):
-        return self._obj.sed
+        return SED(lambda w: self._obj.sed(w)**-1, 'nm', '1')
 
     @property
     def gsparams(self):
@@ -3132,7 +3132,7 @@ class ChromaticFourierSqrtProfile(ChromaticObject):
 
     @property
     def sed(self):
-        return self._obj.sed
+        return SED(lambda w: self._obj.sed(w)**0.5, 'nm', '1')
 
     @property
     def gsparams(self):

--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -176,7 +176,7 @@ class ChromaticObject:
 
     @property
     def wave_list(self):
-        return self._obj.wave_list
+        return self.SED.wave_list
 
     @property
     def gsparams(self):
@@ -1211,10 +1211,6 @@ class InterpolatedChromaticObject(ChromaticObject):
     def SED(self):
         return self.deinterpolated.SED
 
-    @property
-    def wave_list(self):
-        return self.deinterpolated.wave_list
-
     # Note: We don't always need all of these, so only calculate them if needed.
     # E.g. if photon shooting, pretty much only need objs.
     @lazy_property
@@ -1568,10 +1564,6 @@ class ChromaticAtmosphere(ChromaticObject):
         return self.base_obj.SED
 
     @property
-    def wave_list(self):
-        return self.base_obj.wave_list
-
-    @property
     def gsparams(self):
         """The `GSParams` for this object.
         """
@@ -1774,11 +1766,9 @@ class ChromaticTransformation(ChromaticObject):
     @lazy_property
     def SED(self):
         sed = self._original.SED * self._flux_ratio
-        self._wave_list, _, _ = utilities.combine_wave_list(self._original, sed)
 
         if self._redshift is not None:
             sed = sed.atRedshift(self._redshift)
-            self._wave_list *= (1.+self._redshift)
 
         # Need to account for non-unit determinant jacobian in normalization.
         if hasattr(self._jac, '__call__'):
@@ -1790,11 +1780,6 @@ class ChromaticTransformation(ChromaticObject):
             sed *= np.linalg.det(np.asarray(self._jac).reshape(2,2))
 
         return sed
-
-    @property
-    def wave_list(self):
-        self.SED  # Make sure this is made.
-        return self._wave_list
 
     @property
     def gsparams(self):
@@ -2127,10 +2112,6 @@ class ChromaticSum(ChromaticObject):
             sed += obj.SED
         return sed
 
-    @lazy_property
-    def wave_list(self):
-        return utilities.combine_wave_list(self._obj_list)[0]
-
     @property
     def gsparams(self):
         """The `GSParams` for this object.
@@ -2394,10 +2375,6 @@ class ChromaticConvolution(ChromaticObject):
         for obj in self._obj_list[1:]:
             sed *= obj.SED
         return sed
-
-    @lazy_property
-    def wave_list(self):
-        return utilities.combine_wave_list(self._obj_list)[0]
 
     @property
     def gsparams(self):
@@ -2761,10 +2738,6 @@ class ChromaticDeconvolution(ChromaticObject):
         return self._obj.SED
 
     @property
-    def wave_list(self):
-        return self._obj.wave_list
-
-    @property
     def gsparams(self):
         """The `GSParams` for this object.
         """
@@ -2854,10 +2827,6 @@ class ChromaticAutoConvolution(ChromaticObject):
     @lazy_property
     def SED(self):
         return self._obj.SED * self._obj.SED
-
-    @property
-    def wave_list(self):
-        return self._obj.wave_list
 
     @property
     def gsparams(self):
@@ -2957,10 +2926,6 @@ class ChromaticAutoCorrelation(ChromaticObject):
         return self._obj.SED * self._obj.SED
 
     @property
-    def wave_list(self):
-        return self._obj.wave_list
-
-    @property
     def gsparams(self):
         """The `GSParams` for this object.
         """
@@ -3056,10 +3021,6 @@ class ChromaticFourierSqrtProfile(ChromaticObject):
     @property
     def SED(self):
         return self._obj.SED
-
-    @property
-    def wave_list(self):
-        return self._obj.wave_list
 
     @property
     def gsparams(self):
@@ -3253,10 +3214,6 @@ class ChromaticOpticalPSF(ChromaticObject):
     @property
     def SED(self):
         return SED(1, 'nm', '1')
-
-    @property
-    def wave_list(self):
-        return np.array([], dtype=float)
 
     @property
     def gsparams(self):
@@ -3490,10 +3447,6 @@ class ChromaticAiry(ChromaticObject):
     @property
     def SED(self):
         return SED(1, 'nm', '1')
-
-    @property
-    def wave_list(self):
-        return np.array([], dtype=float)
 
     @property
     def gsparams(self):

--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -49,6 +49,7 @@ from . import utilities
 from . import integ
 from . import dcr
 
+
 class ChromaticObject:
     """Base class for defining wavelength-dependent objects.
 
@@ -2032,7 +2033,7 @@ class ChromaticTransformation(ChromaticObject):
 
 
 class SimpleChromaticTransformation(ChromaticTransformation):
-    """A class for the simplest kind of chromatic object -- a GSObject times and SED.
+    """A class for the simplest kind of chromatic object -- a GSObject times an SED.
 
     This is a subclass of ChromaticTransformation, which just skips some calculations
     that are unnecessary in this simple, but fairly common special case.
@@ -2097,10 +2098,6 @@ class SimpleChromaticTransformation(ChromaticTransformation):
         """
         See `ChromaticObject.drawImage` for a full description.
 
-        This version usually just calls that one, but if the transformed object (self.original) is
-        an `InterpolatedChromaticObject`, and the transformation is achromatic, then it will still
-        be able to use the interpolation.
-
         Parameters:
             bandpass:       A `Bandpass` object representing the filter against which to
                             integrate.
@@ -2121,7 +2118,6 @@ class SimpleChromaticTransformation(ChromaticTransformation):
         Returns:
             the drawn `Image`.
         """
-        from .transform import Transform
         # Store the last bandpass used.
         self._last_bp = bandpass
         if self.sed.dimensionless:

--- a/galsim/config/image.py
+++ b/galsim/config/image.py
@@ -67,7 +67,7 @@ def BuildImages(nimages, config, image_num=0, obj_num=0, logger=None):
                  config.get('file_num',0),nimages,image_num,obj_num)
 
     if nimages == 0:
-        logger.error('No images were built, since nimages == 0.')
+        logger.warning('No images were built, since nimages == 0.')
         return []
 
     # Figure out how many processes we will use for building the images.
@@ -118,7 +118,7 @@ def BuildImages(nimages, config, image_num=0, obj_num=0, logger=None):
 
     logger.debug('file %d: Done making images',config.get('file_num',0))
     if len(images) == 0:
-        logger.error('No images were built.  All were either skipped or had errors.')
+        logger.warning('No images were built.  All were either skipped or had errors.')
 
     return images
 

--- a/galsim/config/output.py
+++ b/galsim/config/output.py
@@ -98,7 +98,7 @@ def BuildFiles(nfiles, config, file_num=0, logger=None, except_abort=False):
         timeout = 3600
 
     if nfiles == 0:
-        logger.error("No files were made, since nfiles == 0.")
+        logger.warning("No files were made, since nfiles == 0.")
         return orig_config
 
     for k in range(nfiles + first_file_num):
@@ -174,7 +174,7 @@ def BuildFiles(nfiles, config, file_num=0, logger=None, except_abort=False):
         nfiles_written = sum([ t!=0 for t in times])
 
     if nfiles_written == 0:
-        logger.error('No files were written.  All were either skipped or had errors.')
+        logger.warning('No files were written.  All were either skipped or had errors.')
     else:
         if nfiles_written > 1 and nproc != 1:
             logger.warning('Total time for %d files with %d processes = %f sec',

--- a/galsim/config/stamp.py
+++ b/galsim/config/stamp.py
@@ -85,7 +85,7 @@ def BuildStamps(nobjects, config, obj_num=0,
                  config.get('image_num',0),nobjects,obj_num)
 
     if nobjects == 0:
-        logger.error("No stamps were built, since nstamps == 0.")
+        logger.warning("No stamps were built, since nstamps == 0.")
         return (), ()
 
     # Figure out how many processes we will use for building the stamps:
@@ -141,7 +141,7 @@ def BuildStamps(nobjects, config, obj_num=0,
 
     logger.debug('image %d: Done making stamps',config.get('image_num',0))
     if all(im is None for im in images):
-        logger.error('No stamps were built.  All objects were skipped.')
+        logger.warning('No stamps were built.  All objects were skipped.')
 
     return images, current_vars
 

--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -435,7 +435,7 @@ class GSObject:
     @property
     def deinterpolated(self): return self
     @property
-    def SED(self):
+    def sed(self):
         return sed.SED(self.flux, 'nm', '1')
     @property
     def spectral(self): return False

--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -438,6 +438,11 @@ class GSObject:
     def sed(self):
         return sed.SED(self.flux, 'nm', '1')
     @property
+    def SED(self):
+        from .deprecated import depr
+        depr('obj.SED', 2.5, 'obj.sed')
+        return self.sed
+    @property
     def spectral(self): return False
     @property
     def dimensionless(self): return True

--- a/galsim/main.py
+++ b/galsim/main.py
@@ -148,7 +148,7 @@ def make_logger(args):
     logger = logging.getLogger('galsim')
 
     # Parse the integer verbosity level from the command line args into a logging_level string
-    logging_levels = { 0: logging.CRITICAL,
+    logging_levels = { 0: logging.ERROR,
                        1: logging.WARNING,
                        2: logging.INFO,
                        3: logging.DEBUG }

--- a/galsim/sed.py
+++ b/galsim/sed.py
@@ -131,7 +131,7 @@ class SED:
     _dimensionless = units.dimensionless_unscaled
 
     def __init__(self, spec, wave_type, flux_type, redshift=0., fast=True,
-                 _blue_limit=0.0, _red_limit=np.inf, _wave_list=None, _spectral=None):
+                 _blue_limit=0.0, _red_limit=np.inf, _wave_list=None):
         self._flux_type = flux_type  # Need to save the original for repr
         # Parse the various options for wave_type
         if isinstance(wave_type, str):
@@ -497,10 +497,10 @@ class SED:
             spec = lambda w: self._fast_spec(w * zfactor1) * other._fast_spec(w * zfactor2)
         else:
             spec = lambda w: self(w * (1.+redshift)) * other(w * (1.+redshift))
-        _spectral = self.spectral or other.spectral
-        return SED(spec, 'nm', 'fphotons', redshift=redshift, fast=fast,
-                   _blue_limit=blue_limit, _red_limit=red_limit, _wave_list=wave_list,
-                   _spectral=_spectral)
+        spectral = self.spectral or other.spectral
+        flux_type = 'fphotons' if spectral else '1'
+        return SED(spec, 'nm', flux_type, redshift=redshift, fast=fast,
+                   _blue_limit=blue_limit, _red_limit=red_limit, _wave_list=wave_list)
 
     def _mul_bandpass(self, other):
         """Equivalent to self * other when other is a Bandpass"""
@@ -519,8 +519,7 @@ class SED:
         else:
             spec = lambda w: self(w*(1.0+self.redshift)) * other._tp(w*zfactor)
         return SED(spec, 'nm', 'fphotons', redshift=self.redshift, fast=self.fast,
-                   _blue_limit=blue_limit, _red_limit=red_limit, _wave_list=wave_list,
-                   _spectral=self.spectral)
+                   _blue_limit=blue_limit, _red_limit=red_limit, _wave_list=wave_list)
 
 
     def _mul_scalar(self, other, spectral):
@@ -546,8 +545,7 @@ class SED:
                 spec = lambda w: self(w*(1.0+self.redshift)) * other
         return SED(spec, wave_type, flux_type, redshift=self.redshift, fast=self.fast,
                    _blue_limit=self.blue_limit, _red_limit=self.red_limit,
-                   _wave_list=self.wave_list,
-                   _spectral=self.spectral)
+                   _wave_list=self.wave_list)
 
 
     def __mul__(self, other):
@@ -601,8 +599,7 @@ class SED:
             flux_type = 'fphotons' if self.spectral else '1'
             return SED(spec, 'nm', flux_type, redshift=self.redshift, fast=self.fast,
                        _blue_limit=self.blue_limit, _red_limit=self.red_limit,
-                       _wave_list=self.wave_list,
-                       _spectral=self.spectral)
+                       _wave_list=self.wave_list)
 
         elif isinstance(other, (int, float)):
             return self._mul_scalar(other, self.spectral)
@@ -652,10 +649,8 @@ class SED:
 
         if self.dimensionless and other.dimensionless:
             flux_type = '1'
-            _spectral = False
         elif self.spectral and other.spectral:
             flux_type = 'fphotons'
-            _spectral = True
         else:
             raise GalSimIncompatibleValuesError(
                 "Cannot add SEDs with incompatible dimensions.", self_sed=self, other=other)
@@ -686,8 +681,7 @@ class SED:
 
         return SED(spec, wave_type='nm', flux_type=flux_type,
                    redshift=self.redshift, fast=self.fast, _wave_list=wave_list,
-                   _blue_limit=blue_limit, _red_limit=red_limit,
-                   _spectral=_spectral)
+                   _blue_limit=blue_limit, _red_limit=red_limit)
 
     def __sub__(self, other):
         # Subtract two SEDs, with the same caveats as adding two SEDs.

--- a/galsim/sed.py
+++ b/galsim/sed.py
@@ -582,7 +582,7 @@ class SED:
             else:
                 return self._mul_sed(other)
 
-        # Product of SED and achromatic GSObject is a `ChromaticTransformation`.
+        # Product of SED and achromatic GSObject is a SimpleChromaticTransformation.
         elif isinstance(other, gsobject.GSObject):
             return other * self
 

--- a/galsim/table.py
+++ b/galsim/table.py
@@ -150,6 +150,10 @@ class LookupTable:
         if self.f_log and np.any(self.f <= 0.):
             raise GalSimValueError("Cannot interpolate in log(f) when table contains f<=0.", f)
 
+        # inf causes problems in some cases, so avoid it if used as the maximum x value.
+        if self._x_max == np.inf:
+            self.x[-1] = self._x_max = 1.e300
+
         # Check equal-spaced arrays
         if self._interp1d is not None:
             if self.x_log:

--- a/galsim/transform.py
+++ b/galsim/transform.py
@@ -77,7 +77,7 @@ def Transform(obj, jac=None, offset=(0.,0.), flux_ratio=1., gsparams=None,
         # help preserve separability in many cases.
 
         # Don't transform ChromaticSum object, better to just transform the arguments.
-        if isinstance(obj, chrom.ChromaticSum) or isinstance(obj, Sum):
+        if isinstance(obj, chrom.ChromaticSum):
             new_obj = chrom.ChromaticSum(
                 [ Transform(o,jac,offset,flux_ratio,gsparams,propagate_gsparams)
                   for o in obj.obj_list ])

--- a/tests/test_chromatic.py
+++ b/tests/test_chromatic.py
@@ -1640,7 +1640,8 @@ def test_centroid():
     np.testing.assert_almost_equal(cen.y, 0.0, 5, "ChromaticObject.calculateCentroid() failed")
 
     # Now check the centroid sampling integrator...
-    gal.wave_list = np.linspace(0.0, 1.0, 500)
+    # (Writing to the dict is a quick and dirty way to overwrite an attribute that is a property.)
+    gal.__dict__['wave_list'] = np.linspace(0.0, 1.0, 500)
     cen = gal.calculateCentroid(bp)
     np.testing.assert_almost_equal(cen.x, 0.75, 5, "ChromaticObject.calculateCentroid() failed")
     np.testing.assert_almost_equal(cen.y, 0.0, 5, "ChromaticObject.calculateCentroid() failed")
@@ -1660,8 +1661,14 @@ def test_interpolated_ChromaticObject():
             self.separable = False
             self.interpolated = False
             self.deinterpolated = self
-            self.SED = galsim.SED(1, 'nm', '1')
-            self.wave_list = np.array([], dtype=float)
+
+        @property
+        def SED(self):
+            return galsim.SED(1, 'nm', '1')
+
+        @property
+        def wave_list(self):
+            return np.array([], dtype=float)
 
         def evaluateAtWavelength(self, wave):
             this_sigma = self.sigma * (wave / 500.)

--- a/tests/test_chromatic.py
+++ b/tests/test_chromatic.py
@@ -612,7 +612,7 @@ def test_chromatic_flux():
     PSF = PSF.deinterpolated
     PSF = PSF * 1.0
     PSF = PSF.interpolate(waves=np.linspace(bandpass.blue_limit, bandpass.red_limit, 30),
-                          use_exact_SED=False)
+                          use_exact_sed=False)
     final_int = galsim.Convolve([star, PSF])
     image3 = galsim.ImageD(stamp_size, stamp_size, scale=pixel_scale)
     final_int.drawImage(bandpass, image=image3)
@@ -715,8 +715,8 @@ def test_chromatic_flux():
     np.testing.assert_almost_equal(image.array.sum(), 5.0, 4,
                                    err_msg="Drawn ChromaticConvolve flux density doesn't match "
                                    "using ChromaticObject.withFluxDensity(5.0, 500)")
-    np.testing.assert_almost_equal(5.0, final.SED(500), 7,
-                                   err_msg="ChromaticObject.SED(500) doesn't match "
+    np.testing.assert_almost_equal(5.0, final.sed(500), 7,
+                                   err_msg="ChromaticObject.sed(500) doesn't match "
                                    "withFluxDensity.")
     from astropy import units
     star8 = star.withFluxDensity(5.0, 5000*units.AA)
@@ -1663,7 +1663,7 @@ def test_interpolated_ChromaticObject():
             self.deinterpolated = self
 
         @property
-        def SED(self):
+        def sed(self):
             return galsim.SED(1, 'nm', '1')
 
         @property
@@ -2212,7 +2212,7 @@ def test_phot():
             # This is the old way that photon shooting used to work.  The new way will be tested
             # below.  But since it now uses photon_ops, we'll wait to test that last.
             effective_psf = galsim.ChromaticConvolution._get_effective_prof(
-                    psf*gal.SED, bandpass, integrator='trapezoidal', gsparams=psf.gsparams,
+                    psf*gal.sed, bandpass, integrator='trapezoidal', gsparams=psf.gsparams,
                     iimult=None)
             temp_obj = galsim.Convolve(gal_achrom/flux,effective_psf)
             im2 = temp_obj.drawImage(image=im1.copy(), method='phot', rng=rng)
@@ -2401,7 +2401,7 @@ def check_chromatic_invariant(obj, bps=None, waves=None):
     assert isinstance(obj.deinterpolated, (galsim.ChromaticObject, galsim.GSObject))
 
     for wave in waves:
-        desired = obj.SED(wave)
+        desired = obj.sed(wave)
         # Since InterpolatedChromaticObject.evaluateAtWavelength involves actually drawing an
         # image, which implies flux can be lost off of the edges of the image, we don't expect
         # its accuracy to be nearly as good as for other objects.
@@ -2416,10 +2416,10 @@ def check_chromatic_invariant(obj, bps=None, waves=None):
                 desired,
                 rtol=1e-2)
 
-    if obj.SED.spectral:
+    if obj.sed.spectral:
         for bp in bps:
             calc_flux = obj.calculateFlux(bp)
-            np.testing.assert_equal(obj.SED.calculateFlux(bp), calc_flux)
+            np.testing.assert_equal(obj.sed.calculateFlux(bp), calc_flux)
             np.testing.assert_allclose(calc_flux,
                                        obj.drawImage(bp).array.sum(dtype=float), rtol=1e-2)
             # Also try manipulating exptime and area.
@@ -2434,7 +2434,7 @@ def check_chromatic_invariant(obj, bps=None, waves=None):
 
         try:
             obj = copy.copy(obj)
-            obj.SED = galsim.SED('1', 'nm', '1')
+            obj.sed = galsim.SED('1', 'nm', '1')
         except AttributeError:
             return
     if isinstance(obj, galsim.GSObject): return
@@ -2501,7 +2501,7 @@ def test_chromatic_invariant():
     check_chromatic_invariant(chrom2)
     check_chromatic_invariant(chrom3)
     # also check that these end up with the same SED
-    assert chrom1.SED == chrom2.SED == chrom3.SED
+    assert chrom1.sed == chrom2.sed == chrom3.sed
 
     # And that they make the same image through a given bandpass
     bp = galsim.Bandpass('0.8 + wave/800*0.1', 'nm', blue_limit=700, red_limit=900)

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -635,6 +635,8 @@ def test_chromatic_flux():
     assert sed == PSF.sed
     sed1 = check_dep(getattr, PSF1, 'SED')
     assert sed1 == PSF1.sed
+    sed2 = check_dep(getattr, mono_PSF, 'SED')
+    assert sed1 == mono_PSF.sed == galsim.SED(1, 'nm', '1')
 
 
 if __name__ == "__main__":

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -188,7 +188,7 @@ def test_logger():
     remove_handler()
     logger = galsim.main.make_logger(args)
     print('handlers = ',logger.handlers)
-    assert logger.getEffectiveLevel() == logging.CRITICAL
+    assert logger.getEffectiveLevel() == logging.ERROR
     logger.warning("Test warning")
     logger.info("Test info")
     logger.debug("Test debug")
@@ -214,7 +214,7 @@ def test_logger():
 @timer
 def test_parse_variables():
     logger = logging.getLogger('test_main')
-    logger.setLevel(logging.CRITICAL)
+    logger.setLevel(logging.ERROR)
 
     # Empty list -> empty dict
     new_params = galsim.main.parse_variables([], logger)

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -1543,7 +1543,8 @@ def test_convolve_phasepsf():
     obj = galsim.Convolve(star * sed, psf1, psf2)
     bandpass = galsim.Bandpass('LSST_r.dat', wave_type='nm')
     obj = obj.withFlux(10, bandpass)
-    im = obj.drawImage(bandpass, method='phot', n_photons=10)
+    rng = galsim.BaseDeviate(1234)
+    im = obj.drawImage(bandpass, method='phot', n_photons=10, rng=rng)
 
     # The main thing is that it works.  But check that flux makes sense.
     assert im.array.sum() == 10

--- a/tests/test_sed.py
+++ b/tests/test_sed.py
@@ -1102,6 +1102,36 @@ def test_broadcast():
     assert np.array_equal(sed(waves), np.ones(3) * waves / (galsim.SED._h * galsim.SED._c))
 
 
+@timer
+def test_SED_calculateFlux_inf():
+    """ Check that calculateFlux works properly if the endpoint is inf.
+    """
+    # These two SEDs are functionally the same, but it didn't use to work with np.inf.
+    sed1 = galsim.SED(
+        galsim.LookupTable(
+            [0, 621, 622, 623, 10000],
+            [0, 0, 1, 0, 0],
+            interpolant='linear'
+        ),
+        wave_type='nm',
+        flux_type='fphotons'
+    )
+    sed2 = galsim.SED(
+        galsim.LookupTable(
+            [0, 621, 622, 623, np.inf],
+            [0, 0, 1, 0, 0],
+            interpolant='linear'
+        ),
+        wave_type='nm',
+        flux_type='fphotons'
+    )
+
+    bp = galsim.Bandpass("LSST_r.dat", 'nm')
+    flux1 = sed1.calculateFlux(bp)
+    flux2 = sed2.calculateFlux(bp)
+    print('flux = ', flux1, flux2)
+    assert flux1 == flux2
+
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
     for testfn in testfns:


### PR DESCRIPTION
I was looking through the profile Jim made recently of an imSim run, which inspired the `combine_wave_list` speed up in #1243.  This PR continues in that vein with various optimizations, mostly related to the SEDs.

* First I realized that for faint objects (which there are many in typical imSim runs!), a lot of those SED calculations end up completely wasted, since their SEDs get replaced with a trivial SED later anyway.  I fixed this by making the SED a property rather than an attribute.  That way if it ends up getting replaced, we never need to do those SED calculations at all.  Of course, in regular usage, it's not much of an optimization, since the same calculation gets done at some point, just not in the constructor, but for faint things in imSim, it definitely makes a big difference.
* I also realized that we were calling `combine_wave_list` twice whenever we do those calculations.  Once internal to the SED object, and once with a separate `wave_list` attribute in the chromatic object.  But AFAICT, there is no possible way for these two wave lists to get out of sync.  The only difference between them is that the one in the ChromaticObject can sometimes have an initial 0 wave and a final np.inf wave.  Other than that, they were always identical.  Furthermore, those bounding values were never useful for anything.  So I switched the `wave_list` in the ChromaticObject to be a property that just returns `self.SED.wave_list`.  This didn't require any other adjustments in the code or tests, so I'm pretty confident it's functionally equivalent and saves half the calls to `combine_wave_list`.
* The ChromaticSum class does a complicated calculation to see if it can pull out a separable piece.  This requires that multiple components have exactly the same SED and exactly the same relative flux.  This is an extremely contrived use case, since typically a chromatic bulge + disk would have two different SEDs.  And even if there were two components that had the same SED (e.g. maybe the knots and disk), they would typically have different flux fractions, which couldn't be identified as separable.  So now I switched it to always consider ChromaticSums to be not separable, which removes some moderately slow hashing of SEDs.
* The ChromaticTransformation class also does quite a few checks that are mostly not helpful for the very common case of gsobject * sed.  So I added a SimpleChromaticTransformation class that specializes for this very simple kind of chromatic object.
* I was noticing items called `<frozen importlib._bootstrap>:389(parent)` in the profile, and I finally figured out that these are when `import` statements happen inside a function rather than at the top of a module.  I guess it's when python checks to see if it needs to import anything and realizes it already has everything imported.  It's not a huge amount of time, but it's wasteful.  So I went through the whole code base and moved as many imports as possible out of functions to module scope.  Some of these required a little care to avoid circular import patterns.  But since it was a lot of lines changed with no real content, I did this directly on main.  If anyone wants to look, it's commit 5388b0ec61565897.  But I don't think there is anything really substantive there.  Anyway, this also led to a non-trivial speed up for faint objects that don't require a lot of work, so tiny bits of overhead are noticeable.
* Finally, this isn't an optimization, but I've always been a little annoyed by our capitalized attribute name `obj.SED`.  So I decided while I was working on all this to change it to lowercase.  (The capital one works still, but it deprecated.)  This matches our prevailing style in GalSim to use lowercase attributes, even for abbreviations that are otherwise usually capitalized.  (e.g. wcs, psf)

The relevant timing script is `devel/time_faint_bd_gals.py`.  On my laptop, the time to draw 1000 galaxies went from 1.48 seconds before these changes down to 0.47 seconds after.  So a factor of 3 faster, which feels pretty good to me.  The remaining tall (ish) poles are initializing the knots in c++, multiplying the sed by a scalar to get the final flux right, making the non-chromatic Transformation object, and initializing the SED objects.  Here is the full profile now, fwiw
```
Time for 1000 iterations of draw_faint = 0.47057316699999996
         2083935 function calls (1973139 primitive calls) in 0.769 seconds

   Ordered by: internal time
   List reduced from 344 to 30 due to restriction <30>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      959    0.042    0.000    0.074    0.000 /Users/Mike/GalSim/galsim/knots.py:134(_sbp)
65602/35898    0.025    0.000    0.199    0.000 /Users/Mike/GalSim/galsim/_utilities.py:56(__get__)
    10713    0.024    0.000    0.090    0.000 /Users/Mike/GalSim/galsim/sed.py:525(_mul_scalar)
    10774    0.020    0.000    0.054    0.000 /Users/Mike/GalSim/galsim/transform.py:197(__init__)
    10713    0.017    0.000    0.047    0.000 /Users/Mike/GalSim/galsim/sed.py:133(__init__)
     4063    0.016    0.000    0.018    0.000 /Users/Mike/GalSim/galsim/photon_array.py:546(_pa)
4063/1918    0.015    0.000    0.086    0.000 /Users/Mike/GalSim/galsim/transform.py:585(_shoot)
   217331    0.013    0.000    0.013    0.000 {built-in method builtins.isinstance}
     9314    0.013    0.000    0.013    0.000 {method 'reduce' of 'numpy.ufunc' objects}
     4567    0.013    0.000    0.013    0.000 /Users/Mike/GalSim/galsim/table.py:170(_tab)
     1000    0.012    0.000    0.769    0.001 time_faint_bd_gals.py:52(draw_faint)
     8076    0.011    0.000    0.021    0.000 /Users/Mike/GalSim/galsim/table.py:197(__call__)
    36202    0.011    0.000    0.011    0.000 /Users/Mike/GalSim/galsim/_utilities.py:316(__init__)
    10713    0.011    0.000    0.021    0.000 /Users/Mike/GalSim/galsim/sed.py:238(_setup_funcs)
    12479    0.011    0.000    0.015    0.000 /Users/Mike/GalSim/galsim/table.py:514(_LookupTable)
    13651    0.010    0.000    0.014    0.000 /Users/Mike/GalSim/galsim/position.py:81(_parse_args)
     9382    0.010    0.000    0.049    0.000 /Users/Mike/GalSim/galsim/transform.py:40(Transform)
      959    0.010    0.000    0.366    0.000 /Users/Mike/GalSim/galsim/chromatic.py:406(drawImage)
     7193    0.010    0.000    0.037    0.000 /Users/Mike/GalSim/galsim/sed.py:418(_call_fast)
     1918    0.009    0.000    0.208    0.000 /Users/Mike/GalSim/galsim/gsobject.py:1273(drawImage)
     1842    0.008    0.000    0.046    0.000 /Users/Mike/GalSim/galsim/table.py:310(integrate_product)
16530/13805    0.008    0.000    0.050    0.000 {built-in method numpy.core._multiarray_umath.implement_array_function}
    81602    0.008    0.000    0.008    0.000 {built-in method builtins.setattr}
     9086    0.008    0.000    0.025    0.000 /Users/Mike/mambaforge/envs/py3.8/lib/python3.8/site-packages/numpy/core/fromnumeric.py:69(_wrapreduction)
     3959    0.008    0.000    0.009    0.000 /Users/Mike/GalSim/galsim/random.py:157(duplicate)
      959    0.008    0.000    0.063    0.000 /Users/Mike/GalSim/galsim/sum.py:312(_shoot)
    10713    0.008    0.000    0.101    0.000 /Users/Mike/GalSim/galsim/sed.py:551(__mul__)
    15432    0.007    0.000    0.007    0.000 {built-in method numpy.array}
    22156    0.007    0.000    0.011    0.000 /Users/Mike/GalSim/galsim/gsparams.py:180(check)
    10713    0.007    0.000    0.126    0.000 /Users/Mike/GalSim/galsim/chromatic.py:2067(sed)
```
(The `__get__` call in the second line is our lazy_property decorator, so it's just farming out to various other things and then writing the result as an attribute.)  Nothing jumps out as particularly egregious now.