### PR TITLE
Improve behavior of SED class, especially with respect to pickling and spline interpolation.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -82,3 +82,18 @@ Bug Fixes
 - Fixed a slight inaccuracy in the FFT phase shifts for single-precision images. (#1231, #1234)
 - Fixed a bug that prevented a convolution of two PhaseScreenPSF objects from being drawn with
   photon shooting. (#1242)
+
+
+Changes from v2.5.0 to v2.5.1
+=============================
+
+- Fixed an incompatibility with Python 3.12 that we had missed.
+- Fixed a bug in the SED class normalization when using astropy.units for flux_type.  Thanks
+  to Sid Mau for finding and fixing this bug. (#1254, #1256)
+- Fixed a bug in the `EmissionLine.atRedshift` method. (#1257)
+- Added interpolant option to `SED` and `Bandpass` classes to use when reading from a file.
+  (#1257)
+- Improved the behavior of SEDs when using spline interpolant. (#1187, #1257)
+- No longer pickle the SED of chromatic objects when the SED is a derived value. (#1257)
+- Added interpolant option to `utilities.trapz`. (#1257)
+- Added clip_neg option to `DistDeviate` class. (#1257)

--- a/galsim/bandpass.py
+++ b/galsim/bandpass.py
@@ -596,9 +596,8 @@ class Bandpass:
             newx, newf = utilities.thin_tabulated_values(x, f, rel_err=rel_err,
                                                          trim_zeros=trim_zeros,
                                                          preserve_range=preserve_range,
-                                                         fast_search=fast_search)
-            interpolant = (self.interpolant if not isinstance(self._tp, LookupTable)
-                           else self._tp.interpolant)
+                                                         fast_search=fast_search,
+                                                         interpolant=interpolant)
             tp = _LookupTable(newx, newf, interpolant)
             blue_limit = np.min(newx)
             red_limit = np.max(newx)

--- a/galsim/bandpass.py
+++ b/galsim/bandpass.py
@@ -590,7 +590,9 @@ class Bandpass:
                                                          trim_zeros=trim_zeros,
                                                          preserve_range=preserve_range,
                                                          fast_search=fast_search)
-            tp = _LookupTable(newx, newf, 'linear')
+            interpolant = (self.interpolant if not isinstance(self._tp, LookupTable)
+                           else self._tp.interpolant)
+            tp = _LookupTable(newx, newf, interpolant)
             blue_limit = np.min(newx)
             red_limit = np.max(newx)
             wave_list = np.array(newx)

--- a/galsim/bandpass.py
+++ b/galsim/bandpass.py
@@ -105,9 +105,10 @@ class Bandpass:
         zeropoint:      Set the zero-point for this Bandpass.  Here, this can only be a float
                         value.  See the method `withZeropoint` for other options for how to
                         set this using a particular spectrum (AB, Vega, etc.) [default: None]
+        interpolant:    If reading from a file, what interpolant to use. [default: 'linear']
     """
     def __init__(self, throughput, wave_type, blue_limit=None, red_limit=None,
-                 zeropoint=None, _wave_list=None, _tp=None):
+                 zeropoint=None, interpolant='linear', _wave_list=None, _tp=None):
         # Note that `_wave_list` acts as a private construction variable that overrides the way that
         # `wave_list` is normally constructed (see `Bandpass.__mul__` below)
 
@@ -122,6 +123,7 @@ class Bandpass:
         self.blue_limit = blue_limit # These may change as we go through this.
         self.red_limit = red_limit
         self.zeropoint = zeropoint
+        self.interpolant = interpolant
 
         # Parse the various options for wave_type
         if isinstance(wave_type, str):
@@ -222,7 +224,7 @@ class Bandpass:
         elif isinstance(self._orig_tp, basestring):
             isfile, filename = utilities.check_share_file(self._orig_tp, 'bandpasses')
             if isfile:
-                self._tp = LookupTable.from_file(filename, interpolant='linear')
+                self._tp = LookupTable.from_file(filename, interpolant=self.interpolant)
             else:
                 if self.blue_limit is None or self.red_limit is None:
                     raise GalSimIncompatibleValuesError(
@@ -433,8 +435,9 @@ class Bandpass:
             raise TypeError(
                    "Don't know how to handle zeropoint of type: {0}".format(type(zeropoint)))
 
-        return Bandpass(self._orig_tp, self.wave_type, self.blue_limit, self.red_limit, zeropoint,
-                        self.wave_list, self._tp)
+        return Bandpass(self._orig_tp, self.wave_type, self.blue_limit, self.red_limit,
+                        zeropoint=zeropoint, interpolant=self.interpolant,
+                        _wave_list=self.wave_list, _tp=self._tp)
 
     def truncate(self, blue_limit=None, red_limit=None, relative_throughput=None,
                  preserve_zp='auto'):
@@ -528,9 +531,11 @@ class Bandpass:
 
         if preserve_zp:
             return Bandpass(self._orig_tp, self.wave_type, blue_limit, red_limit,
-                            _wave_list=wave_list, _tp=self._tp, zeropoint=self.zeropoint)
+                            zeropoint=self.zeropoint, interpolant=self.interpolant,
+                            _wave_list=wave_list, _tp=self._tp)
         else:
             return Bandpass(self._orig_tp, self.wave_type, blue_limit, red_limit,
+                            interpolant=self.interpolant,
                             _wave_list=wave_list, _tp=self._tp)
 
     def thin(self, rel_err=1.e-4, trim_zeros=True, preserve_range=True, fast_search=True,
@@ -586,6 +591,8 @@ class Bandpass:
         if len(self.wave_list) > 0:
             x = self.wave_list
             f = self(x)
+            interpolant = (self.interpolant if not isinstance(self._tp, LookupTable)
+                           else self._tp.interpolant)
             newx, newf = utilities.thin_tabulated_values(x, f, rel_err=rel_err,
                                                          trim_zeros=trim_zeros,
                                                          preserve_range=preserve_range,
@@ -624,9 +631,9 @@ class Bandpass:
 
     def __repr__(self):
         return ('galsim.Bandpass(%r, wave_type=%r, blue_limit=%r, red_limit=%r, zeropoint=%r, '
-                                 '_wave_list=array(%r))')%(
-                self._orig_tp, self.wave_type, self.blue_limit, self.red_limit, self.zeropoint,
-                self.wave_list.tolist())
+                'interpolant=%r, _wave_list=array(%r))')%(
+                    self._orig_tp, self.wave_type, self.blue_limit, self.red_limit,
+                    self.zeropoint, self.interpolant, self.wave_list.tolist())
 
     def __str__(self):
         orig_tp = repr(self._orig_tp)

--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -1895,6 +1895,14 @@ class ChromaticTransformation(ChromaticObject):
             s += '.atRedshift(%s)'%(self._redshift)
         return s
 
+    def __getstate__(self):
+        d = self.__dict__.copy()
+        d.pop('sed',None)
+        return d
+
+    def __setstate__(self, d):
+        self.__dict__ = d
+
     def _getTransformations(self, wave):
         if hasattr(self._jac, '__call__'):
             jac = self._jac(wave)
@@ -2084,6 +2092,14 @@ class SimpleChromaticTransformation(ChromaticTransformation):
     def __str__(self):
         return str(self.original) + ' * ' + str(self.sed)
 
+    def __getstate__(self):
+        d = self.__dict__.copy()
+        d.pop('sed',None)
+        return d
+
+    def __setstate__(self, d):
+        self.__dict__ = d
+
     def _getTransformations(self, wave):
         flux_ratio = self._flux_ratio(wave)
         return self._jac, self._offset, flux_ratio
@@ -2268,6 +2284,14 @@ class ChromaticSum(ChromaticObject):
     def __str__(self):
         str_list = [ str(obj) for obj in self.obj_list ]
         return 'galsim.ChromaticSum([%s])'%', '.join(str_list)
+
+    def __getstate__(self):
+        d = self.__dict__.copy()
+        d.pop('sed',None)
+        return d
+
+    def __setstate__(self, d):
+        self.__dict__ = d
 
     def evaluateAtWavelength(self, wave):
         """Evaluate this chromatic object at a particular wavelength ``wave``.
@@ -2579,6 +2603,14 @@ class ChromaticConvolution(ChromaticObject):
     def __str__(self):
         str_list = [ str(obj) for obj in self.obj_list ]
         return 'galsim.ChromaticConvolution([%s])'%', '.join(str_list)
+
+    def __getstate__(self):
+        d = self.__dict__.copy()
+        d.pop('sed',None)
+        return d
+
+    def __setstate__(self, d):
+        self.__dict__ = d
 
     def _approxWavelength(self, wave):
         # If any of the components prefer a different wavelength, use that for all.
@@ -2985,6 +3017,14 @@ class ChromaticAutoConvolution(ChromaticObject):
     def __str__(self):
         return 'galsim.ChromaticAutoConvolution(%s)'%self._obj
 
+    def __getstate__(self):
+        d = self.__dict__.copy()
+        d.pop('sed',None)
+        return d
+
+    def __setstate__(self, d):
+        self.__dict__ = d
+
     def evaluateAtWavelength(self, wave):
         """Evaluate this chromatic object at a particular wavelength ``wave``.
 
@@ -3081,6 +3121,14 @@ class ChromaticAutoCorrelation(ChromaticObject):
 
     def __str__(self):
         return 'galsim.ChromaticAutoCorrelation(%s)'%self._obj
+
+    def __getstate__(self):
+        d = self.__dict__.copy()
+        d.pop('sed',None)
+        return d
+
+    def __setstate__(self, d):
+        self.__dict__ = d
 
     def evaluateAtWavelength(self, wave):
         """Evaluate this chromatic object at a particular wavelength ``wave``.

--- a/galsim/random.py
+++ b/galsim/random.py
@@ -825,7 +825,7 @@ class DistDeviate(BaseDeviate):
                     "Cannot provide an interpolant with a callable function argument",
                     interpolant=interpolant, function=function)
             if isinstance(function, LookupTable):
-                if x_min or x_max:
+                if (x_min not in (None, function.x_min)) or (x_max not in (None, function.x_max)):
                     raise GalSimIncompatibleValuesError(
                         "Cannot provide x_min or x_max with a LookupTable function",
                         function=function, x_min=x_min, x_max=x_max)

--- a/galsim/real.py
+++ b/galsim/real.py
@@ -28,7 +28,7 @@ from .gsobject import GSObject
 from .gsparams import GSParams
 from .position import PositionD
 from .bounds import BoundsI
-from .utilities import lazy_property, doc_inherit, convert_interpolant
+from .utilities import lazy_property, doc_inherit, convert_interpolant, merge_sorted
 from .interpolant import Quintic
 from .interpolatedimage import InterpolatedImage, _InterpolatedKImage
 from .convolve import Convolve, Deconvolve
@@ -1291,7 +1291,7 @@ class ChromaticRealGalaxy(ChromaticSum):
         # Use polynomial SEDs by default; up to the number of bands provided.
         waves = []
         for bp in bands:
-            waves = np.union1d(waves, bp.wave_list)
+            waves = merge_sorted([waves, bp.wave_list])
         SEDs = []
         for i in range(len(bands)):
             SEDs.append(

--- a/galsim/sed.py
+++ b/galsim/sed.py
@@ -891,12 +891,13 @@ class SED:
             spec_native = self._spec(rest_wave_native)
 
             # Note that this is thinning in native units, not nm and photons/nm.
-            newx, newf = utilities.thin_tabulated_values(
-                    rest_wave_native, spec_native, rel_err=rel_err,
-                    trim_zeros=trim_zeros, preserve_range=preserve_range, fast_search=fast_search)
-
             interpolant = (self.interpolant if not isinstance(self._spec, LookupTable)
                            else self._spec.interpolant)
+            newx, newf = utilities.thin_tabulated_values(
+                    rest_wave_native, spec_native, rel_err=rel_err,
+                    trim_zeros=trim_zeros, preserve_range=preserve_range,
+                    fast_search=fast_search, interpolant=interpolant)
+
             newspec = _LookupTable(newx, newf, interpolant=interpolant)
             return SED(newspec, self.wave_type, self.flux_type, redshift=self.redshift,
                        fast=self.fast)

--- a/galsim/sed.py
+++ b/galsim/sed.py
@@ -1139,9 +1139,13 @@ class EmissionLine(SED):
         _, wave_factor = SED._parse_wave_type(wave_type)
         assert max_wave > wavelength + fwhm
 
+        w = wavelength
+        # Some operations can turn a 0 into 1.e-15, which can lead to large errors
+        # when integrating from w+fwhm to max_wave.  So add a second set of 0's at
+        # w +- 2*fwhm to make sure it's exactly 0 for most of the range.
         spec = LookupTable(
-            [0.0, wavelength-fwhm, wavelength, wavelength+fwhm, max_wave*wave_factor],
-            [0, 0, flux/fwhm, 0, 0],
+            [0.0, w-2*fwhm, w-fwhm, w, w+fwhm, w+2*fwhm, max_wave*wave_factor],
+            [0, 0, 0, flux/fwhm, 0, 0, 0],
             interpolant='linear'
         )
         super().__init__(

--- a/galsim/sed.py
+++ b/galsim/sed.py
@@ -109,14 +109,15 @@ class SED:
     in this case.
 
     Parameters:
-        spec:        Function defining the z=0 spectrum at each wavelength.  See above for
-                     valid options for this parameter.
-        wave_type:   String or astropy.unit specifying units for wavelength input to ``spec``.
-        flux_type:   String or astropy.unit specifying what type of spectral density or
-                     dimensionless normalization ``spec`` represents.  See above for valid options
-                     for this parameter.
-        redshift:    Optionally shift the spectrum to the given redshift. [default: 0]
-        fast:        Convert units on initialization instead of on __call__. [default: True]
+        spec:           Function defining the z=0 spectrum at each wavelength.  See above for
+                        valid options for this parameter.
+        wave_type:      String or astropy.unit specifying units for wavelength input to ``spec``.
+        flux_type:      String or astropy.unit specifying what type of spectral density or
+                        dimensionless normalization ``spec`` represents.  See above for valid
+                        options for this parameter.
+        redshift:       Optionally shift the spectrum to the given redshift. [default: 0]
+        fast:           Convert units on initialization instead of on __call__. [default: True]
+        interpolant:    If reading from a file, what interpolant to use. [default: 'linear']
     """
     # We'll use these multiple times below, and they are ridiculously slow to construct,
     # so just make them once at the class level.
@@ -131,9 +132,10 @@ class SED:
     _dimensionless = units.dimensionless_unscaled
     _bolo_max_wave = 1.e30  # What we use as "infinity" for bolometric flux calculations.
 
-    def __init__(self, spec, wave_type, flux_type, redshift=0., fast=True,
+    def __init__(self, spec, wave_type, flux_type, redshift=0., fast=True, interpolant='linear',
                  _blue_limit=0.0, _red_limit=np.inf, _wave_list=None):
         self._flux_type = flux_type  # Need to save the original for repr
+        self.interpolant = interpolant
 
         # Parse the various options for wave_type
         self.wave_type, self.wave_factor = self._parse_wave_type(wave_type)
@@ -322,7 +324,7 @@ class SED:
         elif isinstance(self._orig_spec, basestring):
             isfile, filename = utilities.check_share_file(self._orig_spec, 'SEDs')
             if isfile:
-                self._spec = LookupTable.from_file(filename, interpolant='linear')
+                self._spec = LookupTable.from_file(filename, interpolant=self.interpolant)
             else:
                 # If a constant function is input as a string (e.g. '1'), then we want to
                 # make sure it is flagged as a const SED.
@@ -1082,10 +1084,10 @@ class SED:
         return self._hash
 
     def __repr__(self):
-        outstr = ('galsim.SED(%r, wave_type=%r, flux_type=%r, redshift=%r, fast=%r,'
-                  ' _wave_list=%r, _blue_limit=%r, _red_limit=%s)')%(
+        outstr = ('galsim.SED(%r, wave_type=%r, flux_type=%r, redshift=%r, fast=%r, '
+                  'interpolant=%r, _wave_list=%r, _blue_limit=%r, _red_limit=%s)')%(
                       self._orig_spec, self.wave_type, self._flux_type, self.redshift, self.fast,
-                      self.wave_list, self.blue_limit,
+                      self.interpolant, self.wave_list, self.blue_limit,
                       "float('inf')" if self.red_limit == np.inf else repr(self.red_limit))
         return outstr
 

--- a/galsim/sed.py
+++ b/galsim/sed.py
@@ -824,7 +824,9 @@ class SED:
                     # points, so this can be slightly inaccurate if the waves are too far apart.
                     # Add in 100 uniformly spaced points to achieve relative accurace ~few e-6.
                     w = utilities.merge_sorted([w, np.linspace(w[0], w[-1], 100)])
-                return _LookupTable(w,bandpass(w),'linear').integrate_product(self)
+                interpolant = (bandpass._tp.interpolant if hasattr(bandpass._tp, 'interpolant')
+                                else 'linear')
+                return _LookupTable(w, bandpass(w), interpolant).integrate_product(self)
         else:
             return integ.int1d(lambda w: bandpass(w)*self(w),
                                bandpass.blue_limit, bandpass.red_limit)
@@ -944,7 +946,9 @@ class SED:
         flux = self.calculateFlux(bandpass)
         if len(self.wave_list) > 0 or len(bandpass.wave_list) > 0:
             w, _, _ = utilities.combine_wave_list(self, bandpass)
-            bp = _LookupTable(w,bandpass(w),'linear')
+            interpolant = (bandpass._tp.interpolant if hasattr(bandpass._tp, 'interpolant')
+                            else 'linear')
+            bp = _LookupTable(w, bandpass(w), interpolant)
             R = lambda w: dcr.get_refraction(w, zenith_angle, **kwargs)
             Rbar = bp.integrate_product(lambda w: self(w) * R(w)) / flux
             V = bp.integrate_product(lambda w: self(w) * (R(w)-Rbar)**2) / flux
@@ -992,7 +996,9 @@ class SED:
             # errors of order ~few e-6.
             w, _, _ = utilities.combine_wave_list([self, bandpass])
             w = utilities.merge_sorted([w, np.linspace(w[0], w[-1], 100)])
-            bp = _LookupTable(w,bandpass(w),'linear')
+            interpolant = (bandpass._tp.interpolant if hasattr(bandpass._tp, 'interpolant')
+                            else 'linear')
+            bp = _LookupTable(w, bandpass(w), interpolant)
             return bp.integrate_product(lambda w: self(w) * (w/base_wavelength)**(2*alpha)) / flux
         else:
             weight = lambda w: bandpass(w) * self(w)

--- a/galsim/sed.py
+++ b/galsim/sed.py
@@ -819,7 +819,7 @@ class SED:
                     # When not fast, the SED definition is not linear between the wave_list
                     # points, so this can be slightly inaccurate if the waves are too far apart.
                     # Add in 100 uniformly spaced points to achieve relative accurace ~few e-6.
-                    w = np.union1d(w, np.linspace(w[0], w[-1], 100))
+                    w = utilities.merge_sorted([w, np.linspace(w[0], w[-1], 100)])
                 return _LookupTable(w,bandpass(w),'linear').integrate_product(self)
         else:
             return integ.int1d(lambda w: bandpass(w)*self(w),
@@ -985,7 +985,7 @@ class SED:
             # bandpass points. The error goes like dx**3, so 100 points should give relative
             # errors of order ~few e-6.
             w, _, _ = utilities.combine_wave_list([self, bandpass])
-            w = np.union1d(w, np.linspace(w[0], w[-1], 100))
+            w = utilities.merge_sorted([w, np.linspace(w[0], w[-1], 100)])
             bp = _LookupTable(w,bandpass(w),'linear')
             return bp.integrate_product(lambda w: self(w) * (w/base_wavelength)**(2*alpha)) / flux
         else:

--- a/galsim/sed.py
+++ b/galsim/sed.py
@@ -1023,13 +1023,10 @@ class SED:
             else:
                 sed = self._mul_bandpass(bandpass)
 
-            if isinstance(sed._fast_spec, LookupTable):
-                dev = DistDeviate(function=sed._fast_spec, npoints=npoints)
-            else:
-                xmin = sed.blue_limit / (1.+self.redshift)
-                xmax = sed.red_limit / (1.+self.redshift)
-                dev = DistDeviate(function=sed._fast_spec, x_min=xmin, x_max=xmax,
-                                  npoints=npoints)
+            xmin = sed.blue_limit / (1.+self.redshift)
+            xmax = sed.red_limit / (1.+self.redshift)
+            dev = DistDeviate(function=sed._fast_spec, x_min=xmin, x_max=xmax,
+                              npoints=npoints, clip_neg=True)
             self._cache_deviate[key] = dev
 
         # Reset the deviate explicitly

--- a/galsim/sed.py
+++ b/galsim/sed.py
@@ -1137,6 +1137,8 @@ class EmissionLine(SED):
         self.fwhm = fwhm
         self.flux = flux
         _, wave_factor = SED._parse_wave_type(wave_type)
+        if wave_factor is None:
+            raise GalSimValueError("wave_type must be a distance unit", wave_type)
         assert max_wave > wavelength + fwhm
 
         w = wavelength

--- a/galsim/sed.py
+++ b/galsim/sed.py
@@ -1164,10 +1164,9 @@ class EmissionLine(SED):
             return self
         if redshift <= -1:
             raise GalSimRangeError("Invalid redshift", redshift, -1.)
-        zfactor = (1.0 + redshift) / (1.0 + self.redshift)
         return EmissionLine(
-            self.wavelength * zfactor,
-            self.fwhm * zfactor,
+            self.wavelength,
+            self.fwhm,
             flux=self.flux,
             wave_type=self.wave_type,
             flux_type=self.flux_type,

--- a/galsim/sed.py
+++ b/galsim/sed.py
@@ -421,7 +421,7 @@ class SED:
                     f = self._rest_nm_to_photons(x)
                 else:
                     f = self._rest_nm_to_dimensionless(x)
-                interp = self._spec.interpolant if isinstance(self._spec, LookupTable) else 'spline'
+                interp = self._spec.interpolant if isinstance(self._spec, LookupTable) else 'linear'
                 return _LookupTable(x, f, interpolant=interp)
 
     def _call_fast(self, wave):

--- a/galsim/table.py
+++ b/galsim/table.py
@@ -344,6 +344,7 @@ class LookupTable:
         Returns:
             an estimate of the integral
         """
+        from .utilities import merge_sorted
         if self.x_log:
             raise GalSimNotImplementedError("log x spacing not implemented yet.")
         if self.f_log:
@@ -372,7 +373,7 @@ class LookupTable:
         else:
             gx = self.x / x_factor
             gx = gx[(gx >= x_min) & (gx <= x_max)]
-            gx = np.union1d(gx, [x_min, x_max])
+            gx = merge_sorted([gx, [x_min, x_max]])
             # Let this raise an appropriate error if g is not a valid function over this domain.
             gf = g(gx)
             # If g is a constant function (like lambda wave: 1), then this doesn't return

--- a/galsim/table.py
+++ b/galsim/table.py
@@ -553,21 +553,23 @@ def _LookupTable(x, f, interpolant='spline', x_log=False, f_log=False):
     return ret
 
 
-def trapz(f, x):
+def trapz(f, x, interpolant='linear'):
     """Integrate f(x) using the trapezoidal rule.
 
     Equivalent to np.trapz(f,x) for 1d array inputs.  Intended as a drop-in replacement,
     which is usually faster.
 
     Parameters:
-        f:      The ordinates of the function to integrate.
-        x:      The abscissae of the function to integrate.
+        f:              The ordinates of the function to integrate.
+        x:              The abscissae of the function to integrate.
+        interpolant:    The interpolant to use between the tabulated points.  [default: 'linear',
+                        which matches the behavior of np.trapz]
 
     Returns:
         Estimate of the integral.
     """
     if len(x) >= 2:
-        return _LookupTable(x,f,'linear').integrate()
+        return _LookupTable(x, f, interpolant=interpolant).integrate()
     else:
         return 0.
 

--- a/galsim/table.py
+++ b/galsim/table.py
@@ -391,11 +391,13 @@ class LookupTable:
     def _check_range(self, x):
         slop = (self.x_max - self.x_min) * 1.e-6
         if np.min(x,initial=self.x_min) < self.x_min - slop:
+            xx = np.array(x)
             raise GalSimRangeError("x value(s) below the range of the LookupTable.",
-                                   x, self.x_min, self.x_max)
+                                   xx[xx<self.x_min], self.x_min, self.x_max) from None
         if np.max(x,initial=self.x_max) > self.x_max + slop:  # pragma: no branch
+            xx = np.array(x)
             raise GalSimRangeError("x value(s) above the range of the LookupTable.",
-                                   x, self.x_min, self.x_max)
+                                   xx[xx>self.x_max], self.x_min, self.x_max) from None
 
     def getArgs(self):
         return self.x

--- a/tests/test_bandpass.py
+++ b/tests/test_bandpass.py
@@ -269,6 +269,12 @@ def test_Bandpass_wave_type():
                                    err_msg="Bandpass.effective_wavelength doesn't respect"
                                            +" wave_type")
 
+    # Spline interpolation changes the effective wavelength slightly, but not much.
+    a2 = galsim.Bandpass('LSST_r.dat', wave_type='nm', interpolant='spline')
+    np.testing.assert_equal(a2.red_limit, a0.red_limit)
+    np.testing.assert_equal(a2.blue_limit, a0.blue_limit)
+    np.testing.assert_allclose(a2.effective_wavelength, a0.effective_wavelength, rtol=1.e-3)
+
     b0 = galsim.Bandpass(galsim.LookupTable([1,2,3,4,5], [1,2,3,4,5]), wave_type='nm')
     b1 = galsim.Bandpass(galsim.LookupTable([10,20,30,40,50], [1,2,3,4,5]), wave_type='ang')
     np.testing.assert_approx_equal(b0.red_limit, b1.red_limit,

--- a/tests/test_bandpass.py
+++ b/tests/test_bandpass.py
@@ -319,28 +319,32 @@ def test_ne():
 def test_thin():
     """Test that bandpass thinning works with the requested accuracy."""
     s = galsim.SED('1', wave_type='nm', flux_type='fphotons')
-    bp = galsim.Bandpass(os.path.join(datapath, 'LSST_r.dat'), 'nm')
-    flux = s.calculateFlux(bp)
-    print("Original number of bandpass samples = ",len(bp.wave_list))
-    for err in [1.e-2, 1.e-3, 1.e-4, 1.e-5]:
-        print("Test err = ",err)
-        thin_bp = bp.thin(rel_err=err, preserve_range=True, fast_search=False)
-        thin_flux = s.calculateFlux(thin_bp)
-        thin_err = (flux-thin_flux)/flux
-        print("num samples with preserve_range = True, fast_search = False: ",len(thin_bp.wave_list))
-        print("realized error = ",(flux-thin_flux)/flux)
-        thin_bp = bp.thin(rel_err=err, preserve_range=True)
-        thin_flux = s.calculateFlux(thin_bp)
-        thin_err = (flux-thin_flux)/flux
-        print("num samples with preserve_range = True: ",len(thin_bp.wave_list))
-        print("realized error = ",(flux-thin_flux)/flux)
-        assert np.abs(thin_err) < err, "Thinned bandpass failed accuracy goal, preserving range."
-        thin_bp = bp.thin(rel_err=err, preserve_range=False)
-        thin_flux = s.calculateFlux(thin_bp)
-        thin_err = (flux-thin_flux)/flux
-        print("num samples with preserve_range = False: ",len(thin_bp.wave_list))
-        print("realized error = ",(flux-thin_flux)/flux)
-        assert np.abs(thin_err) < err, "Thinned bandpass failed accuracy goal, w/ range shrinkage."
+    bp1 = galsim.Bandpass(os.path.join(datapath, 'LSST_r.dat'), 'nm')
+    bp2 = galsim.Bandpass(os.path.join(datapath, 'LSST_r.dat'), 'nm', interpolant='spline')
+
+    for bp in [bp1, bp2]:
+        flux = s.calculateFlux(bp)
+        print("Original number of bandpass samples = ",len(bp.wave_list))
+        for err in [1.e-2, 1.e-3, 1.e-4, 1.e-5]:
+            print("Test err = ",err)
+            thin_bp = bp.thin(rel_err=err, preserve_range=True, fast_search=False)
+            thin_flux = s.calculateFlux(thin_bp)
+            thin_err = (flux-thin_flux)/flux
+            print("num samples with preserve_range = True, fast_search = False: ",
+                  len(thin_bp.wave_list))
+            print("realized error = ",(flux-thin_flux)/flux)
+            thin_bp = bp.thin(rel_err=err, preserve_range=True)
+            thin_flux = s.calculateFlux(thin_bp)
+            thin_err = (flux-thin_flux)/flux
+            print("num samples with preserve_range = True: ",len(thin_bp.wave_list))
+            print("realized error = ",(flux-thin_flux)/flux)
+            assert np.abs(thin_err) < err, "Thinned bandpass failed accuracy goal, preserving range."
+            thin_bp = bp.thin(rel_err=err, preserve_range=False)
+            thin_flux = s.calculateFlux(thin_bp)
+            thin_err = (flux-thin_flux)/flux
+            print("num samples with preserve_range = False: ",len(thin_bp.wave_list))
+            print("realized error = ",(flux-thin_flux)/flux)
+            assert np.abs(thin_err) < err, "Thinned bandpass failed accuracy goal, w/ range shrinkage."
 
 
 @timer

--- a/tests/test_chromatic.py
+++ b/tests/test_chromatic.py
@@ -2617,7 +2617,7 @@ def test_chromatic_invariant():
     assert isinstance(chrom, galsim.ChromaticTransformation)
     assert not isinstance(chrom, galsim.SimpleChromaticTransformation)
     check_chromatic_invariant(chrom)
-    np.testing.assert_allclose(chrom.sed(waves), flux * bulge_SED(waves) * waves**1.03)
+    np.testing.assert_allclose(chrom.sed(waves), flux * bulge_SED(waves) * waves**1.03, rtol=1.e-4)
     # Not picklable, but run str, repr
     str(chrom)
     repr(chrom)
@@ -3199,7 +3199,7 @@ def test_shoot_transformation():
     img = obj.drawImage(bandpass, nx=25, ny=25, scale=0.2, method='phot', rng=rng,
                         poisson_flux=False)
     print(img.added_flux)
-    np.testing.assert_allclose(img.added_flux, flux)
+    np.testing.assert_allclose(img.added_flux, flux, rtol=1.e-6)
     img = obj.drawImage(bandpass, nx=25, ny=25, scale=0.2, method='phot', rng=rng)
     print(img.added_flux)
     assert abs(img.added_flux - flux) > 0.1

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -20,6 +20,7 @@ import numpy as np
 import os
 import sys
 import math
+import warnings
 
 import galsim
 from galsim_test_helpers import *
@@ -1756,6 +1757,32 @@ def test_distLookupTable():
     np.testing.assert_array_almost_equal(
             test_array, np.array(dLookupTableResult), precision,
             err_msg='Wrong DistDeviate random number sequence from generate.')
+
+    # Test clip_neg
+    # Same values as d, but with some negative values, where it had zeros.
+    x = [0.0, 1.0, 1.000000001, 1.5, 2, 2.5, 2.999999999, 3.0, 4.0]
+    f = [0.1, 0.1, 0.0, -0.2, -0.3, -0.2, 0.0    , 0.1, 0.1]
+    tab2 = galsim.LookupTable(x=x, f=f, interpolant='linear')
+    d2 = galsim.DistDeviate(testseed, function=tab2, clip_neg=True)
+    test_array2 = np.empty(3)
+    d2.generate(test_array2)
+    np.testing.assert_array_almost_equal(test_array2, test_array)
+
+    # Without clip_neg, it raises an error
+    with assert_raises(galsim.GalSimValueError):
+        galsim.DistDeviate(testseed, function=tab2)
+    with assert_raises(galsim.GalSimValueError):
+        galsim.DistDeviate(testseed, function=tab2, clip_neg=False)
+
+    # Also works to cleanup NaN values
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=RuntimeWarning)
+        f = [0.1, 0.1, 0.0, -0.2, np.sqrt(-0.3), -0.2, 0.0    , 0.1, 0.1]
+    tab3 = galsim.LookupTable(x=x, f=f, interpolant='linear')
+    d3 = galsim.DistDeviate(testseed, function=tab3, clip_neg=True)
+    test_array3 = np.empty(3)
+    d3.generate(test_array3)
+    np.testing.assert_array_almost_equal(test_array3, test_array)
 
     # Test filling an image
     d.seed(testseed)

--- a/tests/test_sed.py
+++ b/tests/test_sed.py
@@ -287,9 +287,12 @@ def test_SED_mul():
         f = a*e
         np.testing.assert_almost_equal(f(x), a(x) * e(x), 10,
                                        err_msg="Found wrong value in SED.__mul__")
-        f = e*a
-        np.testing.assert_almost_equal(f(x), e(x) * a(x), 10,
+        f2 = e*a
+        np.testing.assert_almost_equal(f2(x), e(x) * a(x), 10,
                                        err_msg="Found wrong value in SED.__mul__")
+        if sed is sed0:
+            check_pickle(f)
+            check_pickle(f2)
 
         # SED multiplied by dimensionless, non-constant SED
         g = galsim.SED('wave', 'nm', '1')
@@ -299,6 +302,9 @@ def test_SED_mul():
         h2 = g*a
         np.testing.assert_almost_equal(h2(x), g(x) * a(x), 10,
                                        err_msg="Found wrong value in SED.__mul__")
+        if sed is sed0:
+            check_pickle(h)
+            check_pickle(h2)
 
         assert_raises(TypeError, a.__mul__, 'invalid')
 

--- a/tests/test_sed.py
+++ b/tests/test_sed.py
@@ -1180,8 +1180,12 @@ def test_emission_line():
             with np.testing.assert_raises(galsim.GalSimSEDError):
                 spectral / sed
 
-            sed = sed.atRedshift(1.1)
-            assert sed is sed.atRedshift(1.1)
+            z = 1.1
+            sed = sed.atRedshift(z)
+            assert sed is sed.atRedshift(z)
+            np.testing.assert_allclose(sed.calculateFlux(None), (1+z))
+            np.testing.assert_allclose(sed(wavelength*(1+z)), 1/fwhm)
+
             with np.testing.assert_raises(galsim.GalSimRangeError):
                 sed.atRedshift(-2.0)
 

--- a/tests/test_sed.py
+++ b/tests/test_sed.py
@@ -1190,6 +1190,8 @@ def test_emission_line():
 
             with np.testing.assert_raises(galsim.GalSimRangeError):
                 sed.atRedshift(-2.0)
+        with np.testing.assert_raises(galsim.GalSimValueError):
+            galsim.EmissionLine(wavelength, fwhm, wave_type=units.Hz),
 
 
 @timer

--- a/tests/test_sed.py
+++ b/tests/test_sed.py
@@ -513,8 +513,9 @@ def test_SED_withFlux():
     for z in [0, 0.2, 0.4]:
         for fast in [True, False]:
             for sed in [
-                galsim.SED(os.path.join(sedpath, 'CWW_E_ext.sed'), wave_type='ang',
-                           flux_type='flambda', fast=fast),
+                galsim.SED('CWW_E_ext.sed', wave_type='ang', flux_type='flambda', fast=fast),
+                galsim.SED('CWW_E_ext.sed', wave_type='ang', flux_type='flambda', fast=fast,
+                           interpolant='spline'),
                 galsim.SED('wave', wave_type='nm', flux_type='fphotons'),
                 galsim.EmissionLine(620.0, 1.0) + 2*galsim.EmissionLine(450.0, 0.5)
             ]:
@@ -573,8 +574,7 @@ def test_SED_withFluxDensity():
     """ Check that setting the flux density works.
     """
 
-    a0 = galsim.SED(os.path.join(sedpath, 'CWW_E_ext.sed'), wave_type='ang',
-                    flux_type='flambda')
+    a0 = galsim.SED('CWW_E_ext.sed', wave_type='ang', flux_type='flambda')
     for z in [0, 0.2, 0.4]:
         a = a0.atRedshift(z)
         a = a.withFluxDensity(1.0, 500)
@@ -723,6 +723,21 @@ def test_redshift_calculateFlux():
     # Regression tests
     np.testing.assert_allclose(flux0, 2.993792e+15, rtol=1.e-4)
     np.testing.assert_allclose(flux1, 4.395954e+14, rtol=1.e-4)
+
+    # With spline, it's almost the same, but slightly different of course.
+    sed = galsim.SED('CWW_Sbc_ext.sed', 'nm', 'flambda', interpolant='spline')
+    bp = galsim.Bandpass('ACS_wfc_F606W.dat', 'nm', interpolant='spline')
+    t0 = time.time()
+    flux0 = sed.calculateFlux(bp)
+    t1 = time.time()
+    flux1 = sed.atRedshift(1).calculateFlux(bp)
+    t2 = time.time()
+    print('z=0 disk in HST V band: flux = ',flux0, t1-t0)
+    print('z=1 disk in HST V band: flux = ',flux1, t2-t1)
+
+    # Regression tests
+    np.testing.assert_allclose(flux0, 3.023368e+15, rtol=1.e-4)
+    np.testing.assert_allclose(flux1, 4.303569e+14, rtol=1.e-4)
 
 
 @timer

--- a/tests/test_sed.py
+++ b/tests/test_sed.py
@@ -849,7 +849,7 @@ def test_SED_sampleWavelength():
     np.testing.assert_equal(len(sed._cache_deviate),2,"Creating new SED deviate failed.")
 
     test1 = np.array([ 4.16227593,  4.6166918 ,  2.95075946])
-    np.testing.assert_array_almost_equal(out,test1,8,"Unexpected SED sample values.")
+    np.testing.assert_array_almost_equal(out,test1,5,"Unexpected SED sample values.")
 
     out = sed.sampleWavelength(1e3,bandpass,rng=seed,npoints=256)
     np.testing.assert_equal(len(sed._cache_deviate),2,"Unexpected number of SED deviates.")

--- a/tests/test_sed.py
+++ b/tests/test_sed.py
@@ -1155,8 +1155,10 @@ def test_emission_line():
     ]:
         for sed in [
             galsim.EmissionLine(wavelength, fwhm),
-            galsim.EmissionLine(wavelength*10, fwhm*10, wave_type='ang')
+            galsim.EmissionLine(wavelength*10, fwhm*10, wave_type='ang'),
+            galsim.EmissionLine(wavelength*1.e-9, fwhm*1.e-9, wave_type=units.m),
         ]:
+            print(sed)
             np.testing.assert_allclose(sed.calculateFlux(None), 1.0)
             np.testing.assert_allclose((sed*2).calculateFlux(None), 2.0)
             np.testing.assert_allclose((3*sed).calculateFlux(None), 3.0)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1086,6 +1086,8 @@ def test_integrate():
     t6 = time.time()
     ans7 = np.trapz(y,x)
     t7 = time.time()
+    ans8 = galsim.trapz(y,x, interpolant='spline')
+    t8 = time.time()
     # Amazingly, LookupTable(linear) is more than 2x faster than np.trapz, and equally accurate.
     # Spline is a bit slower, but about 2x more accurate.
     # Floor and ceil are slightly faster still, but not nearly as accurate.
@@ -1097,6 +1099,7 @@ def test_integrate():
     print('nearest        %.6f          %.6e'%(t5-t4,ans5-np.pi))
     print('trapz          %.6f          %.6e'%(t6-t5,ans6-np.pi))
     print('np.trapz       %.6f          %.6e'%(t7-t6,ans7-np.pi))
+    print('trapz(spline)  %.6f          %.6e'%(t8-t7,ans8-np.pi))
     np.testing.assert_allclose(ans1, np.pi, atol=2.e-9)
     np.testing.assert_allclose(ans2, np.pi, atol=1.e-9)
     np.testing.assert_allclose(ans3, np.pi, atol=3.e-6)
@@ -1104,6 +1107,7 @@ def test_integrate():
     np.testing.assert_allclose(ans5, np.pi, atol=2.e-9)
     np.testing.assert_allclose(ans6, np.pi, atol=2.e-9)
     np.testing.assert_allclose(ans7, np.pi, atol=2.e-9)
+    np.testing.assert_allclose(ans8, np.pi, atol=1.e-9)
 
     # Check errors
     with assert_raises(NotImplementedError):


### PR DESCRIPTION
This PR addresses a number of things that have turned up in various imsim/roman_sim runs related to the SED classes.  The initial impetus for this work was to let the SEDs we get from skyCatalogs to be picklable, so image.nproc would work correctly, and other use cases as well would not be quite so finicky about pickling.

* The main solution for this problem was to have mul_sed try to return a tabulated sed if possible.  I.e. when either (or both) of them uses a lookup table.
* Another thing that helps for some cases is to not try to pickle the derived SEDs in chromatic objects that have the SED as a lazy_property.  It's not very inefficient to remove them from the dictionary before pickling and remake them if needed.  (Indeed it might be usually more efficient, since there is less serialization and communication involved.)
* While I was at it I addressed issue #1187, making it generally fine to use spline interpolation for Bandpass and SED objects.  The default in these classes is still linear (e.g. when reading from a file), but now it's not inefficient to build an SED with a regular LookupTable using the default interpolant='spline'.
* Given the above, I added an `interpolant` option to these classes so if you want to read from a file using spline interpolation, it is now possible.
* I added a clip_neg option to DistDeviate to clip any negative values in the probability distribution to 0.  This is now used in sampleWavelengths, since spline interpolations can lead to slightly negative values in some cases.  Rather than try to avoid it in the SED class, it seems more sensible to just allow DistDeviate to gracefully ignore those negative values.  The default behavior of DistDeviate is unchanged -- with the default clip_neg=False, it raises an error if there are any negative probabilities.
* The hardest thing for getting spline to work well was to get the thin() algorithm to work correctly with a spline table.  I couldn't find an O(N) algorithm for that, so it uses the slower algorithm, but I think it's basically working now.
* Along the way I found two bugs in the new EmissionLine class, which I fixed.  First, the `atRedshift` function was wrong.  It both set the redshift value and changed the wavelength of the line.  The nominal wavelength shouldn't change, since the given spectrum is supposed to define the rest-frame SED, not the observed SED.  
* Also, in some use cases, the 0 at the edge of the emission line could turn into a 1.e-16 kind of number.  When integrating from there to "infinity", that could lead to crazy bolometric fluxes.  My fix for this was to add a second 0 another fwhm away on either size to really force it to zero when not near the line.
* Related to that, I changed out definition of infinity in bolometric fluxes from 1.e100 to 1.e30 (nm).  That's still 1.e21 meters, which is way past any conceivable radio wave wavelength.  But it allows functions of wave with some modest power like wave**3 to not blow up.
* Finally, I added an interpolant option to our trapz function to make it easier do the integral in the thin_tabulated function using the specified interpolant.  I didn't end up using it in as many places as I originally expected to, but still, I think it's a useful enough feature, so I kept it.