### PR TITLE
Don't err if SiliconSensor accumulates on image outside range of treering function

### DIFF
--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -100,7 +100,7 @@ def acquire_lock(lock, block=True, timeout=None):
     try:
         yield held
     finally:
-        if held:
+        if held:  # pragma: no branch
             lock.release()
 
 

--- a/src/Silicon.cpp
+++ b/src/Silicon.cpp
@@ -542,7 +542,6 @@ namespace galsim {
     void Silicon::calculateTreeRingDistortion(int i, int j, Position<int> orig_center,
                                               Polygon& poly) const
     {
-        double shift = 0.0;
         for (int n=0; n<_nv; n++) {
             xdbg<<"i,j,n = "<<i<<','<<j<<','<<n<<": x,y = "<<
                 poly[n].x <<"  "<< poly[n].y<<std::endl;
@@ -551,7 +550,7 @@ namespace galsim {
             xdbg<<"tx,ty = "<<tx<<','<<ty<<std::endl;
             double r = sqrt(tx * tx + ty * ty);
             if (r > 0 && r < _tr_radial_table.argMax()) {
-                shift = _tr_radial_table.lookup(r);
+                double shift = _tr_radial_table.lookup(r);
                 xdbg<<"r = "<<r<<", shift = "<<shift<<std::endl;
                 // Shifts are along the radial vector in direction of the doping gradient
                 double dx = shift * tx / r;
@@ -568,32 +567,34 @@ namespace galsim {
     void Silicon::calculateTreeRingDistortion(int i, int j, Position<int> orig_center,
                                               int nx, int ny, int i1, int j1)
     {
-        iteratePixelBoundary(i - i1, j - j1, nx, ny, [&](int n, Position<float>& pt, bool rhs, bool top) {
-                             Position<double> p = pt;
+        iteratePixelBoundary(
+            i-i1, j-j1, nx, ny, [&](int n, Position<float>& pt, bool rhs, bool top) {
+                Position<double> p = pt;
 
-                             // only do bottom and left points unless we're on top/right edge
-                             if ((rhs) && ((i - i1) < (nx - 1))) return;
-                             if ((top) && ((j - j1) < (ny - 1))) return;
+                // only do bottom and left points unless we're on top/right edge
+                if ((rhs) && ((i - i1) < (nx - 1))) return;
+                if ((top) && ((j - j1) < (ny - 1))) return;
 
-                             if (rhs) p.x += 1.0;
-                             if (top) p.y += 1.0;
-                             //xdbg<<"x,y = "<<p.x<<','<<p.y<<std::endl;
+                if (rhs) p.x += 1.0;
+                if (top) p.y += 1.0;
+                //xdbg<<"x,y = "<<p.x<<','<<p.y<<std::endl;
 
-                             double tx = (double)i + p.x - _treeRingCenter.x + (double)orig_center.x;
-                             double ty = (double)j + p.y - _treeRingCenter.y + (double)orig_center.y;
-                             //xdbg<<"tx,ty = "<<tx<<','<<ty<<std::endl;
-                             double r = sqrt(tx * tx + ty * ty);
-                             if (r > 0 && r < _tr_radial_table.argMax()) {
-                                double shift = _tr_radial_table.lookup(r);
-                                //xdbg<<"r = "<<r<<", shift = "<<shift<<std::endl;
-                                // Shifts are along the radial vector in direction of the doping gradient
-                                double dx = shift * tx / r;
-                                double dy = shift * ty / r;
-                                //xdbg<<"dx,dy = "<<dx<<','<<dy<<std::endl;
-                                pt.x += dx;
-                                pt.y += dy;
-                             }
-        });
+                double tx = (double)i + p.x - _treeRingCenter.x + (double)orig_center.x;
+                double ty = (double)j + p.y - _treeRingCenter.y + (double)orig_center.y;
+                //xdbg<<"tx,ty = "<<tx<<','<<ty<<std::endl;
+                double r = sqrt(tx * tx + ty * ty);
+                if (r > 0 && r < _tr_radial_table.argMax()) {
+                    double shift = _tr_radial_table.lookup(r);
+                    //xdbg<<"r = "<<r<<", shift = "<<shift<<std::endl;
+                    // Shifts are along the radial vector in direction of the doping gradient
+                    double dx = shift * tx / r;
+                    double dy = shift * ty / r;
+                    //xdbg<<"dx,dy = "<<dx<<','<<dy<<std::endl;
+                    pt.x += dx;
+                    pt.y += dy;
+                }
+            }
+        );
     }
 
     template <typename T>
@@ -645,13 +646,16 @@ namespace galsim {
     {
         result = emptypoly;
 
-        iteratePixelBoundary(i, j, nx, ny, [&](int n, const Position<float>& pt, bool rhs, bool top) {
-                             Position<double> p = pt;
-                             if (rhs) p.x += 1.0;
-                             if (top) p.y += 1.0;
-                             result[n].x += (p.x - emptypoly[n].x) * factor;
-                             result[n].y += (p.y - emptypoly[n].y) * factor;
-                             });
+        iteratePixelBoundary(
+            i, j, nx, ny,
+            [&](int n, const Position<float>& pt, bool rhs, bool top) {
+                Position<double> p = pt;
+                if (rhs) p.x += 1.0;
+                if (top) p.y += 1.0;
+                result[n].x += (p.x - emptypoly[n].x) * factor;
+                result[n].y += (p.y - emptypoly[n].y) * factor;
+            }
+        );
 
         result.updateBounds();
     }

--- a/src/Silicon.cpp
+++ b/src/Silicon.cpp
@@ -550,9 +550,9 @@ namespace galsim {
             double ty = (double)j + poly[n].y - _treeRingCenter.y + (double)orig_center.y;
             xdbg<<"tx,ty = "<<tx<<','<<ty<<std::endl;
             double r = sqrt(tx * tx + ty * ty);
-            shift = _tr_radial_table.lookup(r);
-            xdbg<<"r = "<<r<<", shift = "<<shift<<std::endl;
-            if (r > 0) {
+            if (r > 0 && r < _tr_radial_table.argMax()) {
+                shift = _tr_radial_table.lookup(r);
+                xdbg<<"r = "<<r<<", shift = "<<shift<<std::endl;
                 // Shifts are along the radial vector in direction of the doping gradient
                 double dx = shift * tx / r;
                 double dy = shift * ty / r;
@@ -583,7 +583,7 @@ namespace galsim {
                              double ty = (double)j + p.y - _treeRingCenter.y + (double)orig_center.y;
                              //xdbg<<"tx,ty = "<<tx<<','<<ty<<std::endl;
                              double r = sqrt(tx * tx + ty * ty);
-                             if (r > 0) {
+                             if (r > 0 && r < _tr_radial_table.argMax()) {
                                 double shift = _tr_radial_table.lookup(r);
                                 //xdbg<<"r = "<<r<<", shift = "<<shift<<std::endl;
                                 // Shifts are along the radial vector in direction of the doping gradient

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -887,6 +887,29 @@ def test_treerings():
     # Mostly checking that there aren't any nan's here from division by 0.
     assert np.min(areas8.array) > 0
 
+    # Also check that things behave sensibly if the stamp is outside the arg range of
+    # the treering function
+    # tr6 has a max radius of 2000.
+    im.setCenter(2000,2000)
+    obj.drawImage(im, method='phot', sensor=sensor6, rng=rng6)
+    print('im.sum = ',im.array.sum(), im.added_flux)
+
+    areas6a = sensor6.calculate_pixel_areas(im, use_flux=True)
+    assert np.min(areas6a.array) > 0
+    print('areas6a = ',areas6a.array)
+    areas6b = sensor6.calculate_pixel_areas(im, use_flux=False)
+    assert np.min(areas6b.array) > 0
+    # When the stamp is outside the range of the treering function, the areas will be
+    # identical for the use_flux=False case.
+    print('areas6b = ',areas6b.array)
+    print('min, max = ',areas6b.array.min(), areas6b.array.max())
+    assert np.all(areas6b.array == areas6b.array[0,0])
+    # But not when use_flux=True
+    assert not np.all(areas6a.array == areas6a.array[0,0])
+    print('mean, std when use_flux=True: ', np.mean(areas6a.array), np.std(areas6a.array))
+    np.testing.assert_allclose(np.mean(areas6a.array), np.mean(areas6b.array),
+                               rtol=np.std(areas6a.array)/np.sqrt(np.prod(areas6b.array.shape))*3)
+
 
 @timer
 def test_resume():

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -893,6 +893,8 @@ def test_treerings():
     im.setCenter(2000,2000)
     obj.drawImage(im, method='phot', sensor=sensor6, rng=rng6)
     print('im.sum = ',im.array.sum(), im.added_flux)
+    np.testing.assert_allclose(im.array.sum(), im.added_flux)
+    np.testing.assert_allclose(im.array.sum(), init_flux, rtol=1.e-2)
 
     areas6a = sensor6.calculate_pixel_areas(im, use_flux=True)
     assert np.min(areas6a.array) > 0


### PR DESCRIPTION
In ImSim, we sometimes make a stamp image that is large enough to extend past the allowed range of the treering function.  The treatment outside that range is irrelevant, since we just ignore the part that is outside the bounds of the main image, but the current code was raising an exception.

This PR changes it to just ignore tree rings on any pixels that are outside the range of the treering function.