### PR TITLE
Implement ChromaticSum._shoot

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -97,3 +97,8 @@ Changes from v2.5.0 to v2.5.1
 - No longer pickle the SED of chromatic objects when the SED is a derived value. (#1257)
 - Added interpolant option to `utilities.trapz`. (#1257)
 - Added clip_neg option to `DistDeviate` class. (#1257)
+- Fix a bug in `SiliconSensor` if the image is outside the range where tree rings are defined.
+  (#1258)
+- Implemented missing `ChromaticSum._shoot` method, so `ChromaticSum` can be used as a
+  photon_op. (#1259)
+- Added `PhotonArray._copyFrom` method. (#1259)

--- a/galsim/photon_array.py
+++ b/galsim/photon_array.py
@@ -440,28 +440,51 @@ class PhotonArray:
 
     def assignAt(self, istart, rhs):
         """Assign the contents of another `PhotonArray` to this one starting at istart.
+
+        Parameters:
+            istart:     The first index at which to insert new values.
+            rhs:        The other `PhotonArray` from which to get the values.
         """
         if istart + rhs.size() > self.size():
             raise GalSimValueError(
                 "The given rhs does not fit into this array starting at %d"%istart, rhs)
         s = slice(istart, istart + rhs.size())
-        self.x[s] = rhs.x
-        self.y[s] = rhs.y
-        self.flux[s] = rhs.flux
+        self._copyFrom(rhs, s, slice(None))
+
+    def _copyFrom(self, rhs, s1, s2):
+        """Copy some contents of another `PhotonArray` to some elements of this one.
+
+        Specifically each element of rhs[s2] is mapped to self[s1].  The values s1 and s2
+        may be slices, list of indices or any other type that is a valid key for a
+        numpy array.
+
+        .. warning::
+
+            There are no checks that the given s1 and s2 are valid keys for the two
+            photon arrays.  It is up to the user to ensure these are valid.
+
+        Parameters:
+            rhs:        The `PhotonArray` from which to get values.
+            s1:         The indices at which to assign values in the current PhotonArray (self).
+            s2:         The indices from which to get values from the PhotonArray, ``rhs``.
+        """
+        self.x[s1] = rhs.x[s2]
+        self.y[s1] = rhs.y[s2]
+        self.flux[s1] = rhs.flux[s2]
         if rhs.hasAllocatedAngles():
             self.allocateAngles()
-            self.dxdz[s] = rhs.dxdz
-            self.dydz[s] = rhs.dydz
+            self.dxdz[s1] = rhs.dxdz[s2]
+            self.dydz[s1] = rhs.dydz[s2]
         if rhs.hasAllocatedWavelengths():
             self.allocateWavelengths()
-            self.wavelength[s] = rhs.wavelength
+            self.wavelength[s1] = rhs.wavelength[s2]
         if rhs.hasAllocatedPupil():
             self.allocatePupil()
-            self.pupil_u[s] = rhs.pupil_u
-            self.pupil_v[s] = rhs.pupil_v
+            self.pupil_u[s1] = rhs.pupil_u[s2]
+            self.pupil_v[s1] = rhs.pupil_v[s2]
         if rhs.hasAllocatedTimes():
             self.allocateTimes()
-            self.time[s] = rhs.time
+            self.time[s1] = rhs.time[s2]
 
     def convolve(self, rhs, rng=None):
         """Convolve this `PhotonArray` with another.

--- a/tests/test_chromatic.py
+++ b/tests/test_chromatic.py
@@ -2226,10 +2226,22 @@ def test_phot():
     # 7. InterpolatedChromaticObject
     psf7 = psf6.interpolate(waves=[500, 700, 1000])
 
-    for psf in [psf1, psf2, psf3, psf4, psf5, psf6, psf7]:
+    # 8. ChromaticSum
+    # Most useful as a way to linearly interpolate between two (or more) values, so do that.
+    ab1 = np.array([0,0,0,0, 0.008, -0.005, -0.005, -0.002])
+    ab2 = np.array([0,0,0,0, 0.003, 0.003, -0.007, -0.001])
+    psf8a = galsim.ChromaticOpticalPSF(lam=bandpass.effective_wavelength, diam=diam,
+                                       aberrations=ab1, obscuration=obscuration,
+                                       geometric_shooting=True)
+    psf8b = galsim.ChromaticOpticalPSF(lam=bandpass.effective_wavelength, diam=diam,
+                                       aberrations=ab2, obscuration=obscuration,
+                                       nstruts=6, geometric_shooting=True)
+    psf8 = 0.7 * psf8a + 0.3 * psf8b
+
+    for psf in [psf1, psf2, psf3, psf4, psf5, psf6, psf7, psf8]:
         print('psf = ',psf)
         atol = 4.e-4
-        if psf in [psf5, psf6, psf7]:
+        if psf in [psf5, psf6, psf7, psf8]:
             atol = 6e-4   # OpticalPSF doesn't match quite as well as the others.
         rng = galsim.BaseDeviate(1234)
 
@@ -2648,7 +2660,6 @@ def test_chromatic_invariant():
     repr(chrom_sum_noSED)
     str(chrom_sum_noSED)
     assert_raises(galsim.GalSimError, chrom_sum_noSED.applyTo, p1)
-    assert_raises(galsim.GalSimNotImplementedError, chrom_sum_noSED.applyTo, p2)
 
     chrom = gsobj * bulge_SED
     chrom_sum_SED = chrom + chrom  # used to be considered separable, but not anymore.
@@ -2665,7 +2676,6 @@ def test_chromatic_invariant():
     check_pickle(chrom_sum_SED2)
     assert not chrom_sum_SED2.separable
     assert_raises(galsim.GalSimError, chrom_sum_SED.applyTo, p1)
-    assert_raises(galsim.GalSimNotImplementedError, chrom_sum_SED.applyTo, p2)
 
     # ChromaticConvolution
     conv1 = galsim.Convolve(chrom, chrom_airy)  # SEDed


### PR DESCRIPTION
In PR #1100, I implemented the applyTo method for chromatic objects, so they can be used as photon_ops.  This is now the canonical way to do photon shooting with chromatic objects, since it can use each photon's specific wavelength to do wavelength-dependent things.

One that I skipped in that PR was ChromaticSum.  I suspect I thought that class would only be used for things like bulge + disk, where each object has a spectral SED.  These can't be used as photon_ops, so I didn't implement that functionality for them.

However, @matroxel wants to use ChromaticSum for the RomanPSF to smoothly interpolate across a sensor using a weighted sum of 4 PSFs, corresponding to the 4 corners of the sensor.  So this PR rectifies my oversight, and implements ChromaticSum._shoot, which is the back end function for all PSF applyTo calls.

Note: when implementing this, I added PhotonArray._copyFrom, which can copy portions of the data from one PhotonArray to another.  It copies all the allocated arrays, using an arbitrary mask in both the original and target PhotonArray.  Similar to `assignAt` but more flexible.  (And `assignAt` now uses `_copyFrom` for its implementation.)

I now use this all the places where we were doing this.  I think this is safer than what we were doing, since some PSFs may need things like the pupil positions or time and when generating the positions/fluxes, they may have generated such things.  So it's a little bit less efficient in most cases (but not much) in the interest of avoiding potentially subtle bugs that may turn up in various edge cases.  (We don't currently have any unit tests that care about such things.)