### PR TITLE
Add max_sun_angle to the roman module global variables

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -105,3 +105,9 @@ Changes from v2.5.0 to v2.5.1
   necessary anymore. (#1259)
 - Deprecated `PhotonArray.assignAt` in favor of the more flexible `PhotonArray.copyFrom`
   method. (#1259)
+
+Changes from v2.5.1 to v2.5.2
+=============================
+
+- Added galsim.roman.max_sun_angle as a module-level named variable. (#1261)
+

--- a/galsim/roman/__init__.py
+++ b/galsim/roman/__init__.py
@@ -89,6 +89,9 @@ n_pix = 4088
 jitter_rms = 0.014
 charge_diffusion = 0.1
 
+# Maxinum allowed angle from the telecope solar panels to the sun in degrees.
+max_sun_angle = 36.
+
 from .roman_bandpass import getBandpasses
 from .roman_backgrounds import getSkyLevel
 from .roman_psfs import getPSF

--- a/galsim/roman/roman_wcs.py
+++ b/galsim/roman/roman_wcs.py
@@ -28,8 +28,7 @@ import os
 import coord
 import datetime
 
-from . import n_sca
-from . import n_pix
+from . import n_sca, n_pix, max_sun_angle
 from .. import meta_data
 from .. import GSFitsWCS, FitsHeader
 from .. import PositionD
@@ -606,9 +605,9 @@ def allowedPos(world_pos, date):
     angle_deg = abs(world_pos.distanceTo(sun)/coord.degrees)
 
     # Check if it's within tolerance.
-    min_ang = 90. - 36.
-    max_ang = 90. + 36.
-    return angle_deg >= min_ang and angle_deg <= max_ang
+    min_ang = 90. - max_sun_angle
+    max_ang = 90. + max_sun_angle
+    return min_ang <= angle_deg <= max_ang
 
 def bestPA(world_pos, date):
     """


### PR DESCRIPTION
For the upcoming Rubin-Roman sims, the time delay group (the TDS PIT) wants to be able to pretend that the ELAIS field is in the Roman continuous viewing zone so the transient light curves don't end up getting split up into discrete seasons.  

I think the least-intrusive way to allow this, without overly encouraging people to just ignore the sun position in Roman observations, is to make the maximum angle between the solar panels and the sun be a galsim.roman module variable, rather than hard-coded.  This is good programming practice anyway (it's currently written as just 36, rather than even named in the function).  And it would allow the roman_imsim package to add an option to edit it to something larger, which would let GalSim still calculate reasonable roll angles and just pretend that the solar panels could handle larger incidence angles.

I.e. `galsim.roman.max_sun_angle = 36`, but is potentially settable by user code.