### PR TITLE
Define setter for Image.array to allow inplace operations

### DIFF
--- a/galsim/image.py
+++ b/galsim/image.py
@@ -450,9 +450,17 @@ class Image:
         self_array = self.array
         other_array = np.asarray(other)
         if other_array.shape != self_array.shape:
-            raise GalSimError("Other array shape is not equal to current array shape")
+            raise GalSimIncompatibleValuesError(
+                "Image array shapes are inconsistent",
+                arr1=self_array,
+                arr2=other_array
+            )
         if other_array.dtype != self_array.dtype:
-            raise GalSimError("Other array dtype is not equal to current array dtype")
+            raise GalSimIncompatibleValuesError(
+                "Image array dtypes are inconsistent",
+                arr1=self_array,
+                arr2=other_array
+            )
         self._array = other_array
     @property
     def nrow(self):

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -26,8 +26,9 @@ from . import _galsim
 from .position import PositionI, _PositionD, parse_pos_args
 from .bounds import BoundsI, BoundsD, _BoundsI
 from ._utilities import lazy_property
-from .errors import GalSimError, GalSimBoundsError, GalSimValueError, GalSimImmutableError, galsim_warn
-from .errors import GalSimUndefinedBoundsError, GalSimIncompatibleValuesError, convert_cpp_errors
+from .errors import GalSimError, GalSimBoundsError, GalSimValueError, GalSimImmutableError
+from .errors import GalSimUndefinedBoundsError, GalSimIncompatibleValuesError
+from .errors import convert_cpp_errors, galsim_warn
 
 # Sometimes (on 32-bit systems) there are two numpy.int32 types.  This can lead to some confusion
 # when doing arithmetic with images.  So just make sure both of them point to ImageViewI in the

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -443,6 +443,11 @@ class Image:
         """The underlying numpy array.
         """
         return self._array
+    @array.setter
+    def array(self, other):
+        """Set the numpy array in-place.
+        """
+        self._array[:] = other
     @property
     def nrow(self):
         """The number of rows in the image

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -26,7 +26,7 @@ from . import _galsim
 from .position import PositionI, _PositionD, parse_pos_args
 from .bounds import BoundsI, BoundsD, _BoundsI
 from ._utilities import lazy_property
-from .errors import GalSimError, GalSimBoundsError, GalSimValueError, GalSimImmutableError
+from .errors import GalSimError, GalSimBoundsError, GalSimValueError, GalSimImmutableError, galsim_warn
 from .errors import GalSimUndefinedBoundsError, GalSimIncompatibleValuesError, convert_cpp_errors
 
 # Sometimes (on 32-bit systems) there are two numpy.int32 types.  This can lead to some confusion
@@ -452,15 +452,11 @@ class Image:
         if other_array.shape != self_array.shape:
             raise GalSimIncompatibleValuesError(
                 "Image array shapes are inconsistent",
-                arr1=self_array,
-                arr2=other_array
+                shape1=self_array.shape,
+                shape2=other_array.shape
             )
-        if other_array.dtype != self_array.dtype:
-            raise GalSimIncompatibleValuesError(
-                "Image array dtypes are inconsistent",
-                arr1=self_array,
-                arr2=other_array
-            )
+        if other_array.ctypes.data % 16 != 0:
+            galsim_warn("Array may not be memory aligned")
         self._array = other_array
     @property
     def nrow(self):

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -447,7 +447,13 @@ class Image:
     def array(self, other):
         """Set the numpy array in-place.
         """
-        self._array[:] = other
+        self_array = self.array
+        other_array = np.asarray(other)
+        if other_array.shape != self_array.shape:
+            raise GalSimError("Other array shape is not equal to current array shape")
+        if other_array.dtype != self_array.dtype:
+            raise GalSimError("Other array dtype is not equal to current array dtype")
+        self._array = other_array
     @property
     def nrow(self):
         """The number of rows in the image

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1742,7 +1742,7 @@ def test_Image_inplace_setter():
             type_index = (i + j) % ntypes
             if type_index != i:
                 with assert_raises(galsim.GalSimError):
-                    image5 = galsim.Image(zeros_array)
+                    image5 = galsim.Image(ref_array.astype(types[i]))
                     image5.array = ref_array.astype(types[type_index])
 
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1719,7 +1719,11 @@ def test_Image_inplace_setter():
         # operations on the Image array
         internal_array = np.zeros_like(ref_array_view)
         image3 = galsim.Image(internal_array)
+        image3_array_id = id(image3.array)
         image3.array += ref_array_view
+
+        # Check that the id of the Image array attribute is unchanged
+        assert id(image3.array) == image3_array_id
 
         # NumPy arrays will return views with new IDs, so we must check if the
         # underlying data buffers are equal rather than just the IDs
@@ -1729,16 +1733,17 @@ def test_Image_inplace_setter():
 
         # Test that attempting to set an Image's array to an array of different
         # shape raises a ValueError
-        with assert_raises(ValueError):
+        with assert_raises(galsim.GalSimError):
             image4 = galsim.Image(zeros_array)
             image4.array = large_array
 
-        # Test that attempting to set an Image array from that of a real dtype
-        # to that of a complex dtype raises a TypeError
-        if np.isreal(types[i]):
-            with assert_raises(TypeError):
-                image4 = galsim.Image(zeros_array)
-                image4.array =  1j * ref_array_view
+        # Test that setting an Image array to a different dtype raises an error
+        for j in range(ntypes):
+            type_index = (i + j) % ntypes
+            if type_index != i:
+                with assert_raises(galsim.GalSimError):
+                    image5 = galsim.Image(zeros_array)
+                    image5.array = ref_array.astype(types[type_index])
 
 
 @timer

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1711,6 +1711,12 @@ def test_Image_inplace_add():
         image3 += (image2 / 17) * 17
         np.testing.assert_allclose(image3.array, image1.array)
 
+        # Check inplace operations on the underlying array
+        image1 = galsim.Image(ref_array.astype(types[i]))
+        image1.array += 1
+        image2 = galsim.Image(ref_array.astype(types[i]) + 1)
+        np.testing.assert_allclose(image1.array, image2.array)
+
         # Then try using the eval command to mimic use via ImageD, ImageF etc.
         image_init_func = eval("galsim.Image"+tchar[i])
         slice_array = large_array.copy().astype(types[i])[::3,::2]

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1758,11 +1758,11 @@ def test_Image_inplace_setter():
 def test_Image_setter_alignment():
     # Make an array that is _not_ memory aligned
     # c.f. https://stackoverflow.com/a/9895986
-    m = n = 1000
+    m = n = 2
     dtype = np.dtype(np.float64)
     nbytes = m * n * dtype.itemsize
     buf = np.empty(nbytes + 16, dtype=np.uint8)
-    start_index = -buf.ctypes.data % 13  # define an awkward index to unalign the array in memory
+    start_index = -buf.ctypes.data % 16 + 1  # offset by 1 to unalign
     unaligned_array = buf[start_index:start_index + nbytes].view(dtype).reshape(m, n)
     unaligned_array[:] = 1
     assert unaligned_array.ctypes.data % 16 != 0

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1732,8 +1732,8 @@ def test_Image_inplace_setter():
         # Now we attempt verboten operations;
 
         # Test that attempting to set an Image's array to an array of different
-        # shape raises a ValueError
-        with assert_raises(galsim.GalSimError):
+        # shape raises an error
+        with assert_raises(galsim.GalSimIncompatibleValuesError):
             image4 = galsim.Image(zeros_array)
             image4.array = large_array
 
@@ -1741,7 +1741,7 @@ def test_Image_inplace_setter():
         for j in range(ntypes):
             type_index = (i + j) % ntypes
             if type_index != i:
-                with assert_raises(galsim.GalSimError):
+                with assert_raises(galsim.GalSimIncompatibleValuesError):
                     image5 = galsim.Image(ref_array.astype(types[i]))
                     image5.array = ref_array.astype(types[type_index])
 


### PR DESCRIPTION
(Duplicate of https://github.com/GalSim-developers/GalSim/pull/1273 due to rebasing/etc.)
This pull request addresses https://github.com/GalSim-developers/GalSim/issues/1272 by defining a setter for the Image.array attribute. This protects against any case where a user does an inplace operation on the image array attribute in an interactive environment: without the setter, this would raise an error while still performing the operation, leading to some confusion. This change also obviates the need to operate on a view of the underling array; e.g., instead of
```
image.array[:] += 1
```
we can now do
```
image.array += 1
```