### PR TITLE
Fix bug in using eval with templates not at top level

### DIFF
--- a/galsim/config/process.py
+++ b/galsim/config/process.py
@@ -265,7 +265,7 @@ def Process(config, logger=None, njobs=1, job=1, new_params=None, except_abort=F
                  json.dumps(config, default=lambda o: repr(o), indent=4))
 
     # Warn about any unexpected fields.
-    unexpected = [ k for k in config if k not in top_level_fields ]
+    unexpected = [ k for k in config if k not in top_level_fields and k[0] != '_' ]
     if len(unexpected) > 0 and logger:
         logger.warning("Warning: config dict contains the following unexpected fields: %s.",
                        unexpected)

--- a/galsim/config/process.py
+++ b/galsim/config/process.py
@@ -202,7 +202,7 @@ def ProcessAllTemplates(config, logger=None, base=None):
     """
     if base is None: base = config
     ProcessTemplate(config, base, logger)
-    for (key, field) in config.items():
+    for (key, field) in list(config.items()):
         if isinstance(field, dict):
             ProcessAllTemplates(field, logger, base)
         elif isinstance(field, list):

--- a/galsim/config/value_eval.py
+++ b/galsim/config/value_eval.py
@@ -86,7 +86,7 @@ def _GenerateFromEval(config, base, value_type):
 
         # These will be the variables to use for evaluating the eval statement.
         # Start with the current locals and globals, and add extra items to them.
-        if 'eval_gdict' not in base:
+        if '_eval_gdict' not in base:
             gdict = globals().copy()
             # We allow the following modules to be used in the eval string:
             exec('import galsim', gdict)
@@ -95,9 +95,9 @@ def _GenerateFromEval(config, base, value_type):
             exec('import numpy as np', gdict)
             exec('import os', gdict)
             ImportModules(base, gdict)
-            base['eval_gdict'] = gdict
+            base['_eval_gdict'] = gdict
         else:
-            gdict = base['eval_gdict']
+            gdict = base['_eval_gdict']
 
         if 'str' not in config:
             raise GalSimConfigError(

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
 pyyaml>=3.12
-pytest>=3.4
+pytest<8
 pytest-xdist>=1.19
 pytest-timeout>=1.2
 scipy>=1.0

--- a/tests/test_config_image.py
+++ b/tests/test_config_image.py
@@ -2547,6 +2547,21 @@ def test_template():
     config8['psf']['items'][2] = config4['image']['noise']
     assert config9 == config8
 
+    # Make sure evals work correltly for template string when not at top level.
+    # (This used to give an error about the config dict changing size during iteration.)
+    config10 = {
+        "eval_variables" : {
+            "iabc": 123,
+            "ddict": {
+                "template": "$os.path.join('config_input','dict.yaml')"
+            }
+        }
+    }
+    galsim.config.ProcessAllTemplates(config10)
+    assert config10['eval_variables']['ddict']['b'] == False
+    assert config10['eval_variables']['ddict']['s'] == "Brian"
+    assert config10['eval_variables']['ddict']['noise']['models'][0]['variance'] == 0.12
+
 
 @timer
 def test_variable_cat_size():


### PR DESCRIPTION
I was trying to craft a graceful solution to ImSim Issue [#452](https://github.com/LSSTDESC/imSim/issues/452), and I think I did, but I ran into a bug in GalSim, which this PR fixes.

Basically, if there is a template embedded in one of the fields of the config dict, and that template uses an eval, then Python doesn't like it, since you end up changing the size of the overall config dict due to the eval_gdict item.  Using `list(config.items())` fixes this issue.