### PR TITLE
Save photons from the component objects of a ChromaticSum

### DIFF
--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -1834,7 +1834,21 @@ class GSObject:
 
         image.added_flux = added_photons / flux_scale
         if save_photons:
-            image.photons = photons
+            # We need to check if image already contains photons from a previous call to drawImage,
+            # for example if doing a ChromaticSum.
+            if not hasattr(image, 'photons'):
+                # If not, then simply put the photons into the image.
+                image.photons = photons
+            else:
+                # If photons have already been saved, need to create a new larger array and copy
+                # in from both the original and new photon arrays.
+                n_orig_photons = image.photons.size()
+                n_new_photons = photons.size()
+                n_total_photons = n_orig_photons + n_new_photons
+                total_photons = pa.PhotonArray(n_total_photons)
+                total_photons.copyFrom(image.photons, slice(0, n_orig_photons))
+                total_photons.copyFrom(photons, slice(n_orig_photons, n_total_photons))
+                image.photons = total_photons
 
         return image
 


### PR DESCRIPTION
This commit addresses #1284 by checking whether `image` already has a `photons` attribute at the end of `GSObject.drawImage`. If not, it simply assigns it the newly created photon array as previously. If it does exist, a new array with the correct length is created, the extant `image.photons` copied in at the beginning and the new `photons` after, and the new array assigned to `image.photons`.

This fix corrects the example in #1284 and also fixes previously incorrect output from the imSim photon pooling pipeline noted in LSSTDESC/imSim#424.