### PR TITLE
Fixes for numpy 2

### DIFF
--- a/galsim/_utilities.py
+++ b/galsim/_utilities.py
@@ -19,6 +19,7 @@
 # This file is logically part of utilities.py, but to avoid circular imports, we
 # put a few things in here so files can import _utilties without triggering an ImportError.
 
+import numpy as np
 import os
 import functools
 import weakref
@@ -120,6 +121,20 @@ class doc_inherit:
             raise NameError("Can't find '%s' in parents"%self.name)
         func.__doc__ = source.__doc__
         return func
+
+
+# Numpy array constructor compatibility shim.
+if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
+    copy_if_needed = None
+elif np.lib.NumpyVersion(np.__version__) < "1.28.0":
+    copy_if_needed = False
+else:
+    # 2.0.0 dev versions, handle cases where copy may or may not exist
+    try:
+        np.array([1]).__array__(copy=None)
+        copy_if_needed = None
+    except TypeError:
+        copy_if_needed = False
 
 
 def isinteger(value):

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -1370,7 +1370,7 @@ class Image:
             y:      The y coordinate of the pixel to add to.
             value:  The value to add to this pixel.
         """
-        self._array[y-self.ymin, x-self.xmin] += value
+        self._array[y-self.ymin, x-self.xmin] += np.array(value).astype(self._array.dtype, casting="unsafe")
 
     def fill(self, value):
         """Set all pixel values to the given ``value``

--- a/galsim/table.py
+++ b/galsim/table.py
@@ -23,11 +23,12 @@ import numbers
 import warnings
 
 from . import _galsim
-from ._utilities import lazy_property, basestring
+from ._utilities import lazy_property, basestring, copy_if_needed
 from .bounds import BoundsD
 from .position import _PositionD
 from .errors import *
 from .interpolant import convert_interpolant
+
 
 def _str_array(a):
     # Used by both LookupTable.__str__ and LookupTable2D.__str__
@@ -889,8 +890,8 @@ class LookupTable2D:
             return f
 
     def _call_constant(self, x, y, grid=False):
-        x = np.array(x, dtype=float, copy=False)
-        y = np.array(y, dtype=float, copy=False)
+        x = np.array(x, dtype=float, copy=copy_if_needed)
+        y = np.array(y, dtype=float, copy=copy_if_needed)
         if grid:
             f = np.empty((len(y), len(x)), dtype=float)
             # Fill in interpolated values first, then go back and fill in
@@ -951,8 +952,9 @@ class LookupTable2D:
         Returns:
             a scalar value if x and y are scalar, or a numpy array if x and y are arrays.
         """
-        x1 = np.array(x, dtype=float, copy=self.edge_mode=='wrap')
-        y1 = np.array(y, dtype=float, copy=self.edge_mode=='wrap')
+        copy_flag = copy_if_needed if not self.edge_mode == 'wrap' else True
+        x1 = np.array(x, dtype=float, copy=copy_flag)
+        y1 = np.array(y, dtype=float, copy=copy_flag)
         x2 = np.ascontiguousarray(x1.ravel(), dtype=float)
         y2 = np.ascontiguousarray(y1.ravel(), dtype=float)
 
@@ -1011,8 +1013,8 @@ class LookupTable2D:
         return self._gradient_inbounds(x, y, grid)
 
     def _gradient_constant(self, x, y, grid=False):
-        x = np.array(x, dtype=float, copy=False)
-        y = np.array(y, dtype=float, copy=False)
+        x = np.array(x, dtype=float, copy=copy_if_needed)
+        y = np.array(y, dtype=float, copy=copy_if_needed)
         if grid:
             dfdx = np.empty((len(y), len(x)), dtype=float)
             dfdy = np.empty((len(y), len(x)), dtype=float)
@@ -1064,8 +1066,9 @@ class LookupTable2D:
             A tuple of (dfdx, dfdy) where dfdx, dfdy are single values (if x,y were single
             values) or numpy arrays.
         """
-        x1 = np.array(x, dtype=float, copy=self.edge_mode=='wrap')
-        y1 = np.array(y, dtype=float, copy=self.edge_mode=='wrap')
+        copy_flag = copy_if_needed if not self.edge_mode=='wrap' else True
+        x1 = np.array(x, dtype=float, copy=copy_flag)
+        y1 = np.array(y, dtype=float, copy=copy_flag)
         x2 = np.ascontiguousarray(x1.ravel(), dtype=float)
         y2 = np.ascontiguousarray(y1.ravel(), dtype=float)
 

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -55,6 +55,20 @@ from .position import parse_pos_args
 from ._utilities import *
 
 
+# Numpy array constructor compatibility shim.
+if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
+    copy_if_needed = None
+elif np.lib.NumpyVersion(np.__version__) < "1.28.0":
+    copy_if_needed = False
+else:
+    # 2.0.0 dev versions, handle cases where copy may or may not exist
+    try:
+        np.array([1]).__array__(copy=None)
+        copy_if_needed = None
+    except TypeError:
+        copy_if_needed = False
+
+
 def roll2d(image, shape):
     """Perform a 2D roll (circular shift) on a supplied 2D NumPy array, conveniently.
 

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -581,8 +581,8 @@ def horner(x, coef, dtype=None):
         x = np.ascontiguousarray(x, dtype=float)
         coef = np.ascontiguousarray(coef, dtype=float)
     else:
-        x = np.array(x, copy=False)
-        coef = np.array(coef, copy=False)
+        x = np.array(x, copy=copy_if_needed)
+        coef = np.array(coef, copy=copy_if_needed)
     if len(coef.shape) != 1:
         raise GalSimValueError("coef must be 1-dimensional", coef)
     _horner(x, coef, result)
@@ -640,9 +640,9 @@ def horner2d(x, y, coefs, dtype=None, triangle=False):
         y = np.ascontiguousarray(y, dtype=float)
         coefs = np.ascontiguousarray(coefs, dtype=float)
     else:
-        x = np.array(x, copy=False)
-        y = np.array(y, copy=False)
-        coefs = np.array(coefs, copy=False)
+        x = np.array(x, copy=copy_if_needed)
+        y = np.array(y, copy=copy_if_needed)
+        coefs = np.array(coefs, copy=copy_if_needed)
 
     if x.shape != y.shape:
         raise GalSimIncompatibleValuesError("x and y are not the same shape", x=x, y=y)

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -55,20 +55,6 @@ from .position import parse_pos_args
 from ._utilities import *
 
 
-# Numpy array constructor compatibility shim.
-if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
-    copy_if_needed = None
-elif np.lib.NumpyVersion(np.__version__) < "1.28.0":
-    copy_if_needed = False
-else:
-    # 2.0.0 dev versions, handle cases where copy may or may not exist
-    try:
-        np.array([1]).__array__(copy=None)
-        copy_if_needed = None
-    except TypeError:
-        copy_if_needed = False
-
-
 def roll2d(image, shape):
     """Perform a 2D roll (circular shift) on a supplied 2D NumPy array, conveniently.
 

--- a/tests/test_config_noise.py
+++ b/tests/test_config_noise.py
@@ -70,12 +70,12 @@ def test_gaussian():
     np.testing.assert_equal(var1, var)
     var2 = galsim.Image(3,3)
     galsim.config.AddNoiseVariance(config, var2)
-    np.testing.assert_almost_equal(var2.array, var)
+    np.testing.assert_almost_equal(var2.array, np.array(var).astype(var2.array.dtype))
 
     # Check include_obj_var=True, which shouldn't do anything different in this case
     var3 = galsim.Image(32,32)
     galsim.config.AddNoiseVariance(config, var3, include_obj_var=True)
-    np.testing.assert_almost_equal(var3.array, var)
+    np.testing.assert_almost_equal(var3.array, np.array(var).astype(var3.array.dtype))
 
     # Gaussian noise can also be given the variance directly, rather than sigma
     galsim.config.RemoveCurrent(config)

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -332,16 +332,16 @@ def test_IPC_basic():
         err_msg="Image is altered for no IPC with edge_treatment = 'crop' and with a fill_value" )
     # Check if the edges are filled with fill_value
     np.testing.assert_array_equal(
-        im_new.array[0,:], fill_value,
+        im_new.array[0,:], np.array(fill_value).astype(im_new.array.dtype),
         err_msg="Top edge is not filled with the correct value by applyIPC")
     np.testing.assert_array_equal(
-        im_new.array[-1,:], fill_value,
+        im_new.array[-1,:], np.array(fill_value).astype(im_new.array.dtype),
         err_msg="Bottom edge is not filled with the correct value by applyIPC")
     np.testing.assert_array_equal(
-        im_new.array[:,0], fill_value,
+        im_new.array[:,0], np.array(fill_value).astype(im_new.array.dtype),
         err_msg="Left edge is not filled with the correct value by applyIPC")
     np.testing.assert_array_equal(
-        im_new.array[:,-1], fill_value,
+        im_new.array[:,-1], np.array(fill_value).astype(im_new.array.dtype),
         err_msg="Left edge is not filled with the correct value by applyIPC")
 
     # Testing for flux conservation

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -240,7 +240,7 @@ def test_Image_basic():
 
                 value3 = 10*x + y
                 im1.addValue(x,y, value3-value2)
-                im2_view[x,y] += value3-value2
+                im2_view[x,y] += np.array(value3-value2).astype(im2_view.dtype, casting="unsafe")
                 assert im1[galsim.PositionI(x,y)] == value3
                 assert im1.view()[x,y] == value3
                 assert im1.view(make_const=True)[galsim.PositionI(x,y)] == value3

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1476,10 +1476,11 @@ def test_Image_binary_multiply():
 
         # Check unary -
         image1 = galsim.Image(ref_array.astype(types[i]))
-        image3 = -image1
-        np.testing.assert_array_equal(image3.array, (-1 * ref_array).astype(types[i]),
-                err_msg="Unary - in Image class (dictionary call) does"
-                +" not match reference for dtype = "+str(types[i]))
+        if not types[i] in (np.uint16, np.uint32,):
+            image3 = -image1
+            np.testing.assert_array_equal(image3.array, (-1 * ref_array).astype(types[i]),
+                                          err_msg="Unary - in Image class (dictionary call) does"
+                                          +" not match reference for dtype = "+str(types[i]))
 
         for j in range(ntypes):
             image2_init_func = eval("galsim.Image"+tchar[j])


### PR DESCRIPTION
This should work with numpy 2 now (tested locally with numpy 2.0.0rc2 and python=3.12).  I based this off the 2.5 release branch, I don't know if that's the right thing to do.

One test -- checking the wfirst deprecation -- isn't working and I don't understand that or why it should be related to numpy2.  Maybe a py312 thing?
