### PR TITLE
Updates to be compatible with numpy 2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
                       #py: pypy-3.7
                       #CC: gcc
                       #CXX: g++
+
         env:
             FFTW_DIR: ${{ matrix.FFTW_DIR }}
 
@@ -140,6 +141,13 @@ jobs:
                 if ! test -d $HOME/des_data || ! test -f $HOME/des_data/DECam_00154912_01.fits.fz; then wget --no-check-certificate http://www.sas.upenn.edu/~mjarvis/des_data.tar.gz; tar xfz des_data.tar.gz -C $HOME; fi
                 ln -s $HOME/des_data examples/des/
 
+            - name: Install numpy 2.0.0rc2
+              # Just on python 3.12, use the rc2 branch of numpy 2.0.0.
+              # XXX: Once the default numpy is >= 2.0, remove this.
+              if: matrix.py == 3.12
+              run: |
+                pip install numpy==2.0.0rc2
+
             - name: Install basic dependencies
               run: |
                 python -m pip install -U pip
@@ -155,7 +163,14 @@ jobs:
                 # Extra packages needed for testing
                 pip install -U -r test_requirements.txt
                 pip install -U nose coverage
-                pip install -U matplotlib astroplan
+
+                pip install -U matplotlib
+
+            - name: Install astroplan
+              # astroplan isn't yet numpy 2.0 compatible.  So don't install that on 3.12.
+              if: matrix.py != 3.12
+              run: |
+                pip install -U astroplan
 
             - name: Install CPython-only dependencies
               if: matrix.py != 'pypy-3.7'
@@ -171,7 +186,7 @@ jobs:
 
             - name: Build GalSim
               run: |
-                # The prefix is required for recen MacOS, because of System Integrity Protection.
+                # The prefix is required for recent MacOS, because of System Integrity Protection.
                 # It's not necessary on Linux, but is harmless enough.
                 FFTW_DIR=$FFTW_DIR pip install -vvv .
 

--- a/galsim/config/extra_psf.py
+++ b/galsim/config/extra_psf.py
@@ -77,7 +77,7 @@ def DrawPSFStamp(psf, config, base, bounds, offset, method, logger):
 
         sn_target = ParseValue(config, 'signal_to_noise', base, float)[0]
 
-        sn_meas = math.sqrt( np.sum(im.array**2, dtype=float) / noise_var )
+        sn_meas = np.sqrt( np.sum(im.array**2, dtype=float) / noise_var )
         flux = sn_target / sn_meas
         im *= flux
 

--- a/galsim/config/stamp.py
+++ b/galsim/config/stamp.py
@@ -1106,7 +1106,7 @@ class StampBuilder:
         # Then a few things cancel and we find that
         # S/N = sqrt( sum I(x,y)^2 / var )
 
-        sn_meas = math.sqrt( np.sum(image.array**2, dtype=float) / noise_var )
+        sn_meas = np.sqrt( np.sum(image.array**2, dtype=float) / noise_var )
         # Now we rescale the flux to get our desired S/N
         scale_factor = sn_target / sn_meas
         return scale_factor

--- a/galsim/deprecated/integ.py
+++ b/galsim/deprecated/integ.py
@@ -41,6 +41,7 @@ def trapz(func, min, max, points=10000):
         points:     If integer, the number of points to sample the integrand. If array-like, then
                     the points to sample the integrand at. [default: 1000].
     """
+    from ..table import trapz
     from . import depr
     depr('galsim.integ.trapz', 2.3, 'galsim.integ.int1d')
 
@@ -52,7 +53,7 @@ def trapz(func, min, max, points=10000):
     else:
         points = np.linspace(min, max, points)
 
-    return np.trapz(func(points),points)
+    return trapz(func(points),points)
 
 def midpt(fvals, x):
     """Midpoint rule for integration.

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -1790,7 +1790,7 @@ class Image:
 
     def __neg__(self):
         result = self.copy()
-        result *= -1
+        result *= np.int64(-1)
         return result
 
     # Define &, ^ and | only for integer-type images

--- a/galsim/lensing_ps.py
+++ b/galsim/lensing_ps.py
@@ -53,9 +53,9 @@ def theoryToObserved(gamma1, gamma2, kappa):
     Returns:
         the reduced shear and magnification as a tuple (g1, g2, mu)
     """
-    gamma1 = np.array(gamma1, copy=False, dtype=float)
-    gamma2 = np.array(gamma2, copy=False, dtype=float)
-    kappa = np.array(kappa, copy=False, dtype=float)
+    gamma1 = np.asarray(gamma1, dtype=float)
+    gamma2 = np.asarray(gamma2, dtype=float)
+    kappa = np.asarray(kappa, dtype=float)
 
     g1 = gamma1/(1.-kappa)
     g2 = gamma2/(1.-kappa)

--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -676,8 +676,8 @@ class AtmosphericScreen:
         Returns:
             Array of wavefront lag or lead in nanometers.
         """
-        u = np.array(u, dtype=float, copy=False)
-        v = np.array(v, dtype=float, copy=False)
+        u = np.asarray(u, dtype=float)
+        v = np.asarray(v, dtype=float)
         if u.shape != v.shape:
             raise GalSimIncompatibleValuesError("u.shape not equal to v.shape",u=u,v=v)
 
@@ -689,7 +689,7 @@ class AtmosphericScreen:
             tmp.fill(t)
             t = tmp
         else:
-            t = np.array(t, dtype=float, copy=False)
+            t = np.asarray(t, dtype=float)
             if t.shape != u.shape:
                 raise GalSimIncompatibleValuesError(
                     "t.shape must match u.shape if t is not a scalar", t=t, u=u)
@@ -743,8 +743,8 @@ class AtmosphericScreen:
         Returns:
             Arrays dWdu and dWdv of wavefront lag or lead gradient in nm/m.
         """
-        u = np.array(u, dtype=float, copy=False)
-        v = np.array(v, dtype=float, copy=False)
+        u = np.asarray(u, dtype=float)
+        v = np.asarray(v, dtype=float)
         if u.shape != v.shape:
             raise GalSimIncompatibleValuesError("u.shape not equal to v.shape", u=u, v=v)
 
@@ -753,7 +753,7 @@ class AtmosphericScreen:
             tmp.fill(t)
             t = tmp
         else:
-            t = np.array(t, dtype=float, copy=False)
+            t = np.asarray(t, dtype=float)
             if t.shape != u.shape:
                 raise GalSimIncompatibleValuesError(
                     "t.shape must match u.shape if t is not a scalar", t=t, u=u)
@@ -1108,8 +1108,8 @@ class OpticalScreen:
         Returns:
             Array of wavefront lag or lead in nanometers.
         """
-        u = np.array(u, dtype=float, copy=False)
-        v = np.array(v, dtype=float, copy=False)
+        u = np.asarray(u, dtype=float)
+        v = np.asarray(v, dtype=float)
         if u.shape != v.shape:
             raise GalSimIncompatibleValuesError("u.shape not equal to v.shape", u=u, v=v)
         return self._wavefront(u, v, t, theta)
@@ -1133,8 +1133,8 @@ class OpticalScreen:
         Returns:
             Arrays dWdu and dWdv of wavefront lag or lead gradient in nm/m.
         """
-        u = np.array(u, dtype=float, copy=False)
-        v = np.array(v, dtype=float, copy=False)
+        u = np.asarray(u, dtype=float)
+        v = np.asarray(v, dtype=float)
         if u.shape != v.shape:
             raise GalSimIncompatibleValuesError("u.shape not equal to v.shape", u=u, v=v)
         return self._wavefront_gradient(u, v, t, theta)

--- a/galsim/table.py
+++ b/galsim/table.py
@@ -889,8 +889,8 @@ class LookupTable2D:
             return f
 
     def _call_constant(self, x, y, grid=False):
-        x = np.array(x, dtype=float, copy=False)
-        y = np.array(y, dtype=float, copy=False)
+        x = np.asarray(x, dtype=float)
+        y = np.asarray(y, dtype=float)
         if grid:
             f = np.empty((len(y), len(x)), dtype=float)
             # Fill in interpolated values first, then go back and fill in
@@ -951,8 +951,15 @@ class LookupTable2D:
         Returns:
             a scalar value if x and y are scalar, or a numpy array if x and y are arrays.
         """
-        x1 = np.array(x, dtype=float, copy=self.edge_mode=='wrap')
-        y1 = np.array(y, dtype=float, copy=self.edge_mode=='wrap')
+        if np.__version__ >= "2.0":
+            # I'm not sure if there is a simpler way to do this in 2.0.
+            # We want a copy when edge_mode == wrap. Otherwise, only copy if dtype changes or
+            # x,y aren't already arrays. That used to be simple...
+            copy = True if self.edge_mode=='wrap' else None
+        else:
+            copy = self.edge_mode=='wrap'
+        x1 = np.array(x, dtype=float, copy=copy)
+        y1 = np.array(y, dtype=float, copy=copy)
         x2 = np.ascontiguousarray(x1.ravel(), dtype=float)
         y2 = np.ascontiguousarray(y1.ravel(), dtype=float)
 
@@ -1011,8 +1018,8 @@ class LookupTable2D:
         return self._gradient_inbounds(x, y, grid)
 
     def _gradient_constant(self, x, y, grid=False):
-        x = np.array(x, dtype=float, copy=False)
-        y = np.array(y, dtype=float, copy=False)
+        x = np.asarray(x, dtype=float)
+        y = np.asarray(y, dtype=float)
         if grid:
             dfdx = np.empty((len(y), len(x)), dtype=float)
             dfdy = np.empty((len(y), len(x)), dtype=float)
@@ -1064,8 +1071,12 @@ class LookupTable2D:
             A tuple of (dfdx, dfdy) where dfdx, dfdy are single values (if x,y were single
             values) or numpy arrays.
         """
-        x1 = np.array(x, dtype=float, copy=self.edge_mode=='wrap')
-        y1 = np.array(y, dtype=float, copy=self.edge_mode=='wrap')
+        if np.__version__ >= "2.0":
+            copy = True if self.edge_mode=='wrap' else None
+        else:
+            copy = self.edge_mode=='wrap'
+        x1 = np.array(x, dtype=float, copy=copy)
+        y1 = np.array(y, dtype=float, copy=copy)
         x2 = np.ascontiguousarray(x1.ravel(), dtype=float)
         y2 = np.ascontiguousarray(y1.ravel(), dtype=float)
 

--- a/galsim/utilities.py
+++ b/galsim/utilities.py
@@ -567,8 +567,8 @@ def horner(x, coef, dtype=None):
         x = np.ascontiguousarray(x, dtype=float)
         coef = np.ascontiguousarray(coef, dtype=float)
     else:
-        x = np.array(x, copy=False)
-        coef = np.array(coef, copy=False)
+        x = np.asarray(x)
+        coef = np.asarray(coef)
     if len(coef.shape) != 1:
         raise GalSimValueError("coef must be 1-dimensional", coef)
     _horner(x, coef, result)
@@ -626,9 +626,9 @@ def horner2d(x, y, coefs, dtype=None, triangle=False):
         y = np.ascontiguousarray(y, dtype=float)
         coefs = np.ascontiguousarray(coefs, dtype=float)
     else:
-        x = np.array(x, copy=False)
-        y = np.array(y, copy=False)
-        coefs = np.array(coefs, copy=False)
+        x = np.asarray(x)
+        y = np.asarray(y)
+        coefs = np.asarray(coefs)
 
     if x.shape != y.shape:
         raise GalSimIncompatibleValuesError("x and y are not the same shape", x=x, y=y)

--- a/tests/test_config_noise.py
+++ b/tests/test_config_noise.py
@@ -68,12 +68,12 @@ def test_gaussian():
     var = sigma**2
     var1 = galsim.config.CalculateNoiseVariance(config)
     np.testing.assert_equal(var1, var)
-    var2 = galsim.Image(3,3)
+    var2 = galsim.Image(3,3, dtype=float)
     galsim.config.AddNoiseVariance(config, var2)
     np.testing.assert_almost_equal(var2.array, var)
 
     # Check include_obj_var=True, which shouldn't do anything different in this case
-    var3 = galsim.Image(32,32)
+    var3 = galsim.Image(32,32, dtype=float)
     galsim.config.AddNoiseVariance(config, var3, include_obj_var=True)
     np.testing.assert_almost_equal(var3.array, var)
 

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -294,7 +294,7 @@ def test_quantize():
 def test_IPC_basic():
     # Make an image with non-trivially interesting scale.
     g = galsim.Gaussian(sigma=3.7)
-    im = g.drawImage(scale=0.25)
+    im = g.drawImage(scale=0.25, dtype=float)
     im_save = im.copy()
 
     # Check for no IPC

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -239,8 +239,8 @@ def test_Image_basic():
                 assert im2_cview.imag(x,y) == 0
 
                 value3 = 10*x + y
-                im1.addValue(x,y, value3-value2)
-                im2_view[x,y] += value3-value2
+                im1.addValue(x,y, np.int64(value3-value2))
+                im2_view[x,y] += np.int64(value3-value2)
                 assert im1[galsim.PositionI(x,y)] == value3
                 assert im1.view()[x,y] == value3
                 assert im1.view(make_const=True)[galsim.PositionI(x,y)] == value3

--- a/tests/test_sed.py
+++ b/tests/test_sed.py
@@ -25,6 +25,7 @@ import time
 
 import galsim
 from galsim_test_helpers import *
+from galsim import trapz
 
 
 bppath = os.path.join(galsim.meta_data.share_dir, "bandpasses")
@@ -695,7 +696,7 @@ def test_redshift_calculateFlux():
                 print('z = {} flux = {}, {}'.format(z, flux1, flux2))
                 wave = np.linspace(bp1.blue_limit, bp1.red_limit, 10000)
                 f = sedz(wave) * bp1(wave)
-                flux3 = np.trapz(f, wave)
+                flux3 = trapz(f, wave)
                 np.testing.assert_allclose(flux1, flux3)
                 np.testing.assert_allclose(flux2, flux3)
 
@@ -768,14 +769,14 @@ def test_SED_calculateDCRMomentShifts():
     # where sed is in units of photons/nm (which is the default)
     waves = np.linspace(bandpass.blue_limit, bandpass.red_limit, 1000)
     R = galsim.dcr.get_refraction(waves, 45.*galsim.degrees)
-    Rnum = np.trapz(sed(waves) * bandpass(waves) * R, waves)
-    den = np.trapz(sed(waves) * bandpass(waves), waves)
+    Rnum = trapz(sed(waves) * bandpass(waves) * R, waves)
+    den = trapz(sed(waves) * bandpass(waves), waves)
     rad2arcsec = galsim.radians / galsim.arcsec
 
     np.testing.assert_almost_equal(Rnum/den*rad2arcsec, Rbar[1]*rad2arcsec, 4)
     # and for the second moment, V, the numerator is:
     # \int{sed(\lambda) * bandpass(\lambda) * (R(\lambda) - Rbar)^2 d\lambda}
-    Vnum = np.trapz(sed(waves) * bandpass(waves) * (R - Rnum/den)**2, waves)
+    Vnum = trapz(sed(waves) * bandpass(waves) * (R - Rnum/den)**2, waves)
     np.testing.assert_almost_equal(Vnum/den, V[1,1], 5)
 
     # Repeat with a function sed and bandpass, since different path in code
@@ -791,10 +792,10 @@ def test_SED_calculateDCRMomentShifts():
     np.testing.assert_almost_equal(Rbar[0], Rbar3[1], 15)
     np.testing.assert_almost_equal(V[1,1], V3[0,0], 25)
     R = galsim.dcr.get_refraction(waves, 45.*galsim.degrees)
-    Rnum = np.trapz(sed2(waves) * R, waves)
-    den = np.trapz(sed2(waves), waves)
+    Rnum = trapz(sed2(waves) * R, waves)
+    den = trapz(sed2(waves), waves)
     np.testing.assert_almost_equal(Rnum/den, Rbar[1], 4)
-    Vnum = np.trapz(sed2(waves) * (R - Rnum/den)**2, waves)
+    Vnum = trapz(sed2(waves) * (R - Rnum/den)**2, waves)
     np.testing.assert_almost_equal(Vnum/den, V[1,1], 5)
 
     dim = galsim.SED('200', 'nm', '1')
@@ -821,16 +822,16 @@ def test_SED_calculateSeeingMomentRatio():
     # \Delta r^2/r^2 = \frac{\int{sed(\lambda) * bandpass(\lambda) * (\lambda/500)^-0.4 d\lambda}}
     #                       {\int{sed(\lambda) * bandpass(\lambda) d\lambda}}
     waves = np.linspace(bandpass.blue_limit, bandpass.red_limit, 1000)
-    num = np.trapz(sed(waves) * bandpass(waves) * (waves/500.0)**(-0.4), waves)
-    den = np.trapz(sed(waves) * bandpass(waves), waves)
+    num = trapz(sed(waves) * bandpass(waves) * (waves/500.0)**(-0.4), waves)
+    den = trapz(sed(waves) * bandpass(waves), waves)
     np.testing.assert_almost_equal(relative_size, num/den, 5)
 
     # Repeat with a function sed and bandpass, since different path in code
     sed2 = galsim.SED(spec=lambda x: 20.+5.*np.sin(x/400), flux_type='flambda', wave_type='nm')
     bp2 = galsim.Bandpass('1', 'nm', blue_limit=bandpass.blue_limit, red_limit=bandpass.red_limit)
     relative_size = sed2.calculateSeeingMomentRatio(bp2)
-    num = np.trapz(sed2(waves) * (waves/500.0)**(-0.4), waves)
-    den = np.trapz(sed2(waves), waves)
+    num = trapz(sed2(waves) * (waves/500.0)**(-0.4), waves)
+    den = trapz(sed2(waves), waves)
     np.testing.assert_almost_equal(relative_size, num/den, 4)
 
     # Invalid for dimensionless SED
@@ -1260,7 +1261,7 @@ def test_flux_type_calculateFlux():
         print('flux = {}, {}, {}'.format(flux1, flux2, flux3))
         wave = np.linspace(bp.blue_limit, bp.red_limit, 10000)
         f = sed(wave) * bp(wave)
-        flux5 = np.trapz(f, wave)
+        flux5 = trapz(f, wave)
         np.testing.assert_allclose(flux1, flux2)
         np.testing.assert_allclose(flux1, flux3)
         np.testing.assert_allclose(flux1, flux4)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1010,6 +1010,11 @@ def test_ne():
 
 @timer
 def test_integrate():
+    if np.__version__ >= '2.0':
+        np_trapz = np.trapezoid
+    else:
+        np_trapz = np.trapz
+
     functions = [
         galsim.LookupTable([0,1,2,3,4], [1,5,5,8,1], interpolant='linear'),
         galsim.LookupTable([0,4], [1,8], interpolant='linear'),
@@ -1046,7 +1051,7 @@ def test_integrate():
                     xmax = x_max
                 x = np.linspace(xmin, xmax, 10000)
                 f = func(x)
-                np_ans = np.trapz(f,x)
+                np_ans = np_trapz(f,x)
                 print('integrate range %s..%s = %s  %s'%(xmin,xmax,func_ans,np_ans))
                 if func.interpolant in ['linear', 'spline']:
                     rtol = 1.e-7
@@ -1084,7 +1089,7 @@ def test_integrate():
     t5 = time.time()
     ans6 = galsim.trapz(y,x)
     t6 = time.time()
-    ans7 = np.trapz(y,x)
+    ans7 = np_trapz(y,x)
     t7 = time.time()
     ans8 = galsim.trapz(y,x, interpolant='spline')
     t8 = time.time()
@@ -1126,6 +1131,11 @@ def test_integrate():
 
 @timer
 def test_integrate_product():
+    if np.__version__ >= '2.0':
+        np_trapz = np.trapezoid
+    else:
+        np_trapz = np.trapz
+
     functions = [
         galsim.LookupTable([0,1,2,3,4], [1,5,5,8,1], interpolant='linear'),
         galsim.LookupTable([0,4], [1,8], interpolant='linear'),
@@ -1186,7 +1196,7 @@ def test_integrate_product():
                         # Do the integral using trapz with fine x spacing.
                         x = np.linspace(xmin, xmax, 10000)
                         fg = func(x*xfact) * g2(x)
-                        np_ans = np.trapz(fg,x)
+                        np_ans = np_trapz(fg,x)
                         #print('integrate range %s..%s = %s  %s'%(xmin,xmax,func_ans,np_ans))
                         if func.interpolant in ['linear', 'spline']:
                             rtol = 1.e-7


### PR DESCRIPTION
Numpy made a few changes to their API with version 2.0.  This PR addresses the places where they impact GalSim code.

1. np.array(a, copy=False) is now an error if a copy is required for the dtype.  Using `copy=None` now does the equivalent to what `copy=False` used to do.  But in most cases, it's better to just use `np.asarray(a)`, which is equivalent in both versions.
2. There is one case where we have a more complicated decision about whether to copy, so in that case we need to use an explicit version check to get the right kwarg.
3. They changed the implicit dtype conversion for values in e.g. += and similar operations.  For GalSim purposes, this mostly just required changing test expectations.  E.g. using `Image(..., dtype=float)` when we want to test accuracy at double precision.
4. One other gotcha is that Python int cannot be implicitly assigned to np.uint types.  This feels like a bug to me, since np.int types do work.  Just not a regular Python int.  cf. numpy issue https://github.com/numpy/numpy/issues/26483  However, it is likely that in most cases where this would show up in user code, it is likely some kind of user error.  So I think it's best to not work around it, but rather just let the exception be raised.  We explicitly avoid it by using np.int types in tests where it would otherwise be a problem.
5. Related to the above, `Image.__neg__` now uses np.int64(-1), rather than just -1, so it will continue to work the same way it used to for unsigned dtypes.
6. Finally, np.trapz is deprecated.  The new name is `np.trapezoid`. We mostly don't use it, since our own implementation is faster, but there were a few places in the tests that needed to be updated.