### PR TITLE
Update wheel.yml to build ARM wheels and switch to trusted PyPi upload rather than using a token.

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -13,19 +13,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_BUILD: "*manylinux*"
           CIBW_ARCHS: auto64
-          CIBW_SKIP: cp36* pp*
+          CIBW_SKIP: cp36* cp37* pp*
           # I think yum might always work here.  But leave all options available.
-          CIBW_BEFORE_ALL_LINUX: yum install -y fftw-devel || apt-get install libfftw3-dev || apk add --upgrade fftw-dev
+          CIBW_BEFORE_ALL: yum install -y fftw-devel || apt-get install libfftw3-dev || apk add --upgrade fftw-dev
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v5
         with:
+          name: linux-wheels
           path: ./wheelhouse/*.whl
 
   build_musl_wheels:
@@ -34,39 +35,69 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_BUILD: "*musllinux*"
           CIBW_ARCHS: auto64
-          CIBW_SKIP: cp36* pp*
+          CIBW_SKIP: cp36* cp37* pp*
           # I think musl always uses apk, but keep all options available.
           CIBW_BEFORE_ALL: apk add --upgrade fftw-dev || apt-get install libfftw3-dev || yum install -y fftw-devel
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v5
         with:
+          name: musl-wheels
           path: ./wheelhouse/*.whl
 
-  build_macosx_wheels:
-    name: Build wheels on macosx
+  build_macosx_intel_wheels:
+    name: Build wheels on MacOS Intel
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_BUILD: "*macosx*"
           CIBW_ARCHS: auto64
-          CIBW_SKIP: cp36* pp*
-          CIBW_BEFORE_ALL_MACOS: brew install fftw || true
+          CIBW_SKIP: cp36* cp37* pp*
+          CIBW_BEFORE_ALL: brew install fftw || true
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v5
         with:
+          name: macos-wheels
+          path: ./wheelhouse/*.whl
+
+  build_macosx_arm_wheels:
+    name: Build wheels on MacOS ARM
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.16.5
+        env:
+          CIBW_BUILD: "*macosx*"
+          CIBW_ARCHS: arm64
+          CIBW_SKIP: cp36* cp37* pp*
+          CIBW_BEFORE_ALL: brew install llvm libomp fftw eigen
+          CIBW_ENVIRONMENT: >-
+            CC=/opt/homebrew/opt/llvm/bin/clang
+            CXX=/opt/homebrew/opt/llvm/bin/clang++
+            LDFLAGS="-L/opt/homebrew/opt/llvm/lib -Wl,-rpath,/opt/homebrew/opt/llvm/lib"
+            CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
+            PATH="/opt/homebrew/opt/llvm/bin:$PATH"
+            FFTW_DIR="/opt/homebrew"
+
+      - uses: actions/upload-artifact@v5
+        with:
+          name: arm-wheels
           path: ./wheelhouse/*.whl
 
   build_sdist:
@@ -78,7 +109,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
 
       - name: Install fftw
         run: |
@@ -106,9 +137,9 @@ jobs:
         run: |
           echo ls -l wheels
           ls -l wheels
-          echo ls -l wheels/artifact
-          ls -l wheels/artifact
-          cp wheels/artifact/*.whl dist
+          echo ls -l wheels/*
+          ls -l wheels/*
+          cp wheels/*/*.whl dist
           echo ls -l dist
           ls -l dist
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -53,7 +53,7 @@ jobs:
 
   build_macosx_intel_wheels:
     name: Build wheels on MacOS Intel
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
 
@@ -102,7 +102,7 @@ jobs:
 
   build_sdist:
     name: Build sdist and upload to PyPI
-    needs: [build_linux_wheels, build_musl_wheels, build_macosx_wheels]
+    needs: [build_linux_wheels, build_musl_wheels, build_macosx_intel_wheels, build_macosx_arm_wheels]
     # Just need to build sdist on a single machine
     runs-on: ubuntu-latest
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/upload-artifact@v5
         with:
-          name: linux-wheels
+          name: whl-linux
           path: ./wheelhouse/*.whl
 
   build_musl_wheels:
@@ -48,7 +48,7 @@ jobs:
 
       - uses: actions/upload-artifact@v5
         with:
-          name: musl-wheels
+          name: whl-musl
           path: ./wheelhouse/*.whl
 
   build_macosx_intel_wheels:
@@ -69,7 +69,7 @@ jobs:
 
       - uses: actions/upload-artifact@v5
         with:
-          name: macos-wheels
+          name: whl-macos
           path: ./wheelhouse/*.whl
 
   build_macosx_arm_wheels:
@@ -97,7 +97,7 @@ jobs:
 
       - uses: actions/upload-artifact@v5
         with:
-          name: arm-wheels
+          name: whl-arm
           path: ./wheelhouse/*.whl
 
   build_sdist:
@@ -105,6 +105,12 @@ jobs:
     needs: [build_linux_wheels, build_musl_wheels, build_macosx_wheels]
     # Just need to build sdist on a single machine
     runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/GalSim
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
 
     steps:
       - uses: actions/checkout@v4
@@ -123,9 +129,11 @@ jobs:
           pip install -U -r requirements.txt
 
       - name: Download wheels
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: ./wheels
+          pattern: whl-*
+          merge-multiple: true
 
       - name: Build sdist
         run: |
@@ -137,15 +145,11 @@ jobs:
         run: |
           echo ls -l wheels
           ls -l wheels
-          echo ls -l wheels/*
-          ls -l wheels/*
-          cp wheels/*/*.whl dist
+          cp wheels/*.whl dist
           echo ls -l dist
           ls -l dist
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-            user: __token__
-            password: ${{ secrets.PYPI_TOKEN }}
             verbose: true


### PR DESCRIPTION
In preparation for releasing version 2.5.3, I added arm wheels to our wheels.yaml script.
Also, PyPi now prefers using trusted publishing.  (cf. https://docs.pypi.org/trusted-publishers/adding-a-publisher/) So I switched to that as well.

This is hard to confirm before actually running the script, which will happen when we make the release tag v2.5.3.  But @jmeyers314 if you can look through it once to see if there are any errors that you can notice in advance, that would be appreciated.