### PR TITLE
Remove implicit scipy dependency.

### DIFF
--- a/galsim/fitswcs.py
+++ b/galsim/fitswcs.py
@@ -33,7 +33,7 @@ from . import _galsim
 from . import fits
 from .errors import GalSimError, GalSimValueError, GalSimIncompatibleValuesError
 from .errors import GalSimNotImplementedError, convert_cpp_errors, galsim_warn
-from .utilities import horner2d
+from .utilities import horner2d, least_squares
 from .celestial import CelestialCoord
 from ._pyfits import pyfits
 
@@ -1783,8 +1783,6 @@ def FittedSIPWCS(x, y, ra, dec, wcs_type='TAN', order=3, center=None):
                    the tangent plane is centered.  [default: None, which means
                    use the average position of the list of reference stars]
     """
-    from scipy.optimize import least_squares
-
     if order < 1:
         raise GalSimValueError("Illegal SIP order", order)
 

--- a/tests/galsim_test_helpers.py
+++ b/tests/galsim_test_helpers.py
@@ -392,3 +392,29 @@ def drawNoise(noise):
     im = galsim.ImageD(10,10)
     im.addNoise(noise)
     return im.array.astype(np.float32).tolist()
+
+
+def runtests(testfns, parser=None):
+    if parser is None:
+        from argparse import ArgumentParser
+        parser = ArgumentParser()
+    parser.add_argument('-k', type=str, help='Run only the tests that match the given substring expression.')
+    parser.add_argument('--profile', action='store_true', help='Profile tests')
+    parser.add_argument('--prof_out', default=None, help="Profiler output file")
+    args = parser.parse_args()
+
+    if args.profile:
+        import cProfile, pstats
+        pr = cProfile.Profile()
+        pr.enable()
+
+    for testfn in testfns:
+        if args.k is None or args.k in testfn.__name__:
+            testfn()
+
+    if args.profile:
+        pr.disable()
+        ps = pstats.Stats(pr).sort_stats('tottime')
+        ps.print_stats(30)
+        if args.prof_out:
+            ps.dump_stats(args.prof_out)

--- a/tests/test_airy.py
+++ b/tests/test_airy.py
@@ -282,5 +282,4 @@ def test_ne():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_bandpass.py
+++ b/tests/test_bandpass.py
@@ -400,5 +400,4 @@ def test_truncate_inputs():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_bessel.py
+++ b/tests/test_bessel.py
@@ -504,5 +504,4 @@ def test_ci():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -320,5 +320,4 @@ def test_ne():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -371,5 +371,4 @@ def test_fwhm():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -333,5 +333,4 @@ def test_output_catalog():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_cdmodel.py
+++ b/tests/test_cdmodel.py
@@ -363,5 +363,4 @@ def test_exampleimage():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_celestial.py
+++ b/tests/test_celestial.py
@@ -750,5 +750,4 @@ def test_ecliptic():
 
 if __name__ == '__main__':
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_chromatic.py
+++ b/tests/test_chromatic.py
@@ -3354,5 +3354,4 @@ def test_save_photons():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_chromatic.py
+++ b/tests/test_chromatic.py
@@ -1951,7 +1951,7 @@ def test_interpolated_ChromaticObject():
     # Also make sure that it ditched the interpolation.
     assert not hasattr(trans_interp_psf, 'waves')
 
-    # test alternate initialization method, "from_images()", of InterpolatedChromaticObject 
+    # test alternate initialization method, "from_images()", of InterpolatedChromaticObject
     # that uses images at discrete wavelengths to initialize object.
 
     # check sorting is done correctly for unsorted wavelengths/images
@@ -1962,7 +1962,7 @@ def test_interpolated_ChromaticObject():
                                                               _force_maxk = PSF.maxk_vals)
     np.testing.assert_allclose(int_psf.waves, waves, atol=0,
       err_msg='InterpolatedChromaticObject from_images initialization fails to sort wavelengths')
-    
+
     for i in range(len(int_psf.ims)):
         np.testing.assert_allclose(int_psf.ims[i].array, PSF.ims[i].array, atol=1e-17,
       err_msg='InterpolatedChromaticObject from_images initialization fails to sort images correctly')
@@ -1976,7 +1976,7 @@ def test_interpolated_ChromaticObject():
     incorrect_ims[0].wcs = affine_wcs
     # non-PixelScale wcs
     assert_raises(galsim.GalSimValueError, galsim.InterpolatedChromaticObject.from_images, incorrect_ims, PSF.waves)
-    incorrect_ims[0].wcs = incorrect_ims[1].wcs 
+    incorrect_ims[0].wcs = incorrect_ims[1].wcs
     incorrect_ims[0].scale += 0.01
     # incosnistent pixel scales
     assert_raises(galsim.GalSimValueError, galsim.InterpolatedChromaticObject.from_images, incorrect_ims, PSF.waves)
@@ -2005,7 +2005,7 @@ def test_interpolated_ChromaticObject():
             err_msg='InterpolatedChromaticObject from_images initialization fails to reproduce default init. images')
 
     # without specifying the same stepk and maxk for each image, stepk and maxk are caclulated
-    # based on the input image pixel scale and dimensions and have no wavelength dependance. 
+    # based on the input image pixel scale and dimensions and have no wavelength dependance.
     int_psf = galsim.InterpolatedChromaticObject.from_images(PSF.ims, PSF.waves)
     test_obj = galsim.Convolve(int_psf, star)
     test_img = test_obj.drawImage(bandpass, image=im_interp, scale=scale, method = 'auto')
@@ -2019,7 +2019,7 @@ def test_interpolated_ChromaticObject():
     # check moments
     truth_mom = galsim.hsm.FindAdaptiveMom(true_img)
     test_mom = galsim.hsm.FindAdaptiveMom(test_img)
-    
+
     np.testing.assert_allclose(test_mom.moments_amp,
                                truth_mom.moments_amp,
                                rtol=1e-3, atol=0,
@@ -2060,7 +2060,7 @@ def test_interpolated_ChromaticObject():
     # check moments
     truth_mom = galsim.hsm.FindAdaptiveMom(true_img)
     test_mom = galsim.hsm.FindAdaptiveMom(test_img)
-    
+
     np.testing.assert_allclose(test_mom.moments_amp,
                                truth_mom.moments_amp,
                                rtol=1e-3, atol=0,

--- a/tests/test_config_gsobject.py
+++ b/tests/test_config_gsobject.py
@@ -2068,5 +2068,4 @@ def test_sed():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_config_image.py
+++ b/tests/test_config_image.py
@@ -1683,6 +1683,7 @@ def test_njobs():
         galsim.config.ProcessInput(config, logger=logger, safe_only=False)
 
 
+@timer
 def test_wcs():
     """Test various wcs options"""
     config = {

--- a/tests/test_config_image.py
+++ b/tests/test_config_image.py
@@ -3462,5 +3462,4 @@ def test_initial_image():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_config_input.py
+++ b/tests/test_config_input.py
@@ -288,6 +288,7 @@ def test_atm_input():
         galsim.config.InputLoader(AtmPSF, use_proxy=False,
                                   worker_initargs=galsim.phase_screens.initWorkerArgs)
 
+@timer
 def test_dependent_inputs():
     """Test inputs that depend on other inputs.
 

--- a/tests/test_config_input.py
+++ b/tests/test_config_input.py
@@ -24,7 +24,7 @@ import sys
 import logging
 
 import galsim
-from galsim_test_helpers import timer, CaptureLog, assert_raises
+from galsim_test_helpers import *
 
 @timer
 def test_input_init():
@@ -439,5 +439,4 @@ def test_dependent_inputs():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_config_noise.py
+++ b/tests/test_config_noise.py
@@ -890,5 +890,4 @@ def test_no_noise():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_config_output.py
+++ b/tests/test_config_output.py
@@ -1778,5 +1778,4 @@ def test_direct_extra_output():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_config_output.py
+++ b/tests/test_config_output.py
@@ -1713,6 +1713,7 @@ def test_timeout():
                 galsim.config.Process(config2, logger=cl.logger, except_abort=True)
         assert 'Multiprocessing timed out waiting for a task to finish.' in cl.output
 
+@timer
 def test_direct_extra_output():
     # Test the ability to get extra output directly after calling BuildImage, but
     # not the usual higher level functions (Process or BuildFile).

--- a/tests/test_config_value.py
+++ b/tests/test_config_value.py
@@ -1926,5 +1926,4 @@ def test_eval():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_convolve.py
+++ b/tests/test_convolve.py
@@ -1004,5 +1004,4 @@ def test_gsparams():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_correlatednoise.py
+++ b/tests/test_correlatednoise.py
@@ -1354,5 +1354,4 @@ def test_gsparams():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_deltafunction.py
+++ b/tests/test_deltafunction.py
@@ -209,5 +209,4 @@ def test_deltaFunction_convolution():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -256,6 +256,7 @@ def test_randwalk_config():
         assert (pts.shape == ptsc.shape),\
                 "expected %s shape for points, got %s" % (pts.shape,ptsc.shape)
 
+@timer
 def test_withOrigin():
     from test_wcs import Cubic
 

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -972,5 +972,4 @@ def test_save_photons():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_des.py
+++ b/tests/test_des.py
@@ -757,5 +757,4 @@ def test_psf_config():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -513,5 +513,4 @@ def test_Persistence_basic():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -669,5 +669,4 @@ def test_full():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -1692,5 +1692,4 @@ def test_direct_scale():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -1084,6 +1084,7 @@ def test_offset():
         im3 = obj.drawImage(im.copy(), method='sb', center=im.center)
         np.testing.assert_almost_equal(im3.array, im.array)
 
+@timer
 def test_shoot():
     """Test drawImage(..., method='phot')
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -299,5 +299,4 @@ def test_galsim_deprecation_warning():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_exponential.py
+++ b/tests/test_exponential.py
@@ -248,5 +248,4 @@ def test_ne():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_fitsheader.py
+++ b/tests/test_fitsheader.py
@@ -295,5 +295,4 @@ def test_comments():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_fouriersqrt.py
+++ b/tests/test_fouriersqrt.py
@@ -103,5 +103,4 @@ def test_fourier_sqrt():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_galaxy_sample.py
+++ b/tests/test_galaxy_sample.py
@@ -401,5 +401,4 @@ def test_cosmos_deep():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -408,5 +408,4 @@ def test_accurate_shift():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_hsm.py
+++ b/tests/test_hsm.py
@@ -1037,5 +1037,4 @@ def test_negative_stepstride():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_hsm.py
+++ b/tests/test_hsm.py
@@ -928,6 +928,7 @@ def test_noncontiguous():
     np.testing.assert_almost_equal(meas_shape3.g2, -0.2, decimal=3,
                                    err_msg="HSM measured wrong shear on image with step=2")
 
+@timer
 def test_headers():
     # This isn't really an HSM test per se, but it's testing a feature that we added so
     # LSST DM can use the C++-layer HSM code from their C++ code.
@@ -988,6 +989,7 @@ def test_headers():
     lib = ctypes.cdll.LoadLibrary(galsim.lib_file)
     # The test was that this doesn't raise an OSError or something.
 
+@timer
 def test_failures():
     """Test some images that used to fail, but now work.
     """
@@ -998,6 +1000,7 @@ def test_failures():
         hsm = im.FindAdaptiveMom()
         assert hsm.moments_status == 0
 
+@timer
 def test_very_small():
     """Test an unresolved star reported to fail in #1132, but now works.
     """
@@ -1017,6 +1020,7 @@ def test_very_small():
     assert "Object is too small" in mom.error_message
 
 
+@timer
 def test_negative_stepstride():
     """In response to #1185, check that hsm works for arrays with negative step or stride.
     """

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -3641,5 +3641,4 @@ def test_flips():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_inclined.py
+++ b/tests/test_inclined.py
@@ -670,5 +670,4 @@ def test_value_retrieval():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_integ.py
+++ b/tests/test_integ.py
@@ -320,6 +320,7 @@ def test_hankel():
         galsim.integ.hankel(f1, k=0.3, nu=-0.5)
 
 
+@timer
 def test_gq_annulus():
     """Test the galsim.integ.gq_annulus function
     """

--- a/tests/test_integ.py
+++ b/tests/test_integ.py
@@ -349,5 +349,4 @@ def test_gq_annulus():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -1880,5 +1880,4 @@ def test_drawreal_seg_fault():
 if __name__ == "__main__":
     setup()
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -1693,6 +1693,7 @@ def test_ne():
             galsim.InterpolatedKImage(kim, gsparams=gsp)]
     check_all_diff(gals)
 
+@timer
 def test_quintic_glagn():
     """This is code that was giving a seg fault.  cf. Issue 1079.
     """
@@ -1711,6 +1712,7 @@ def test_quintic_glagn():
 
         gsobj.drawImage(method='phot', image=image, add_to_image=True)
 
+@timer
 def test_depixelize():
     # True, non-II profile.  Something not too symmetric or simple.
     true_prof = galsim.Convolve(
@@ -1841,6 +1843,7 @@ def test_depixelize():
         np.testing.assert_allclose(im6.array, im1.array, atol=1.e-2)
         print(interp,' max error = ',np.max(np.abs(im6.array-im1.array)),'  time = ',t2-t1)
 
+@timer
 def test_drawreal_seg_fault():
     """Test to reproduce bug report in Issue #1164 that was causing seg faults
     """

--- a/tests/test_knots.py
+++ b/tests/test_knots.py
@@ -436,5 +436,4 @@ def test_knots_sed():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_kolmogorov.py
+++ b/tests/test_kolmogorov.py
@@ -403,5 +403,4 @@ def test_low_folding_threshold():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_lensing.py
+++ b/tests/test_lensing.py
@@ -1515,5 +1515,4 @@ def test_constant():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -319,5 +319,4 @@ def test_process():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_metacal.py
+++ b/tests/test_metacal.py
@@ -419,5 +419,4 @@ def test_wcs():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_moffat.py
+++ b/tests/test_moffat.py
@@ -522,5 +522,4 @@ def test_ne():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_noise.py
+++ b/tests/test_noise.py
@@ -843,5 +843,4 @@ def test_addnoisesnr():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -930,5 +930,4 @@ def test_geometric_shoot():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_phase_psf.py
+++ b/tests/test_phase_psf.py
@@ -1554,5 +1554,4 @@ def test_convolve_phasepsf():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_photon_array.py
+++ b/tests/test_photon_array.py
@@ -1761,5 +1761,4 @@ if __name__ == '__main__':
     if no_astroplan:
         print('Skipping test_dcr_angles, since astroplan not installed.')
         testfns.remove(test_dcr_angles)
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_pse.py
+++ b/tests/test_pse.py
@@ -188,5 +188,4 @@ def test_PSE_weight():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -2026,5 +2026,4 @@ def test_numpy_generator():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_real.py
+++ b/tests/test_real.py
@@ -977,5 +977,4 @@ def test_sys_share_dir():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_roman.py
+++ b/tests/test_roman.py
@@ -1411,12 +1411,5 @@ def test_roman_focal_plane():
 
 
 if __name__ == "__main__":
-    #import cProfile, pstats
-    #pr = cProfile.Profile()
-    #pr.enable()
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
-    #pr.disable()
-    #ps = pstats.Stats(pr).sort_stats('tottime')
-    #ps.print_stats(30)
+    runtests(testfns)

--- a/tests/test_second_kick.py
+++ b/tests/test_second_kick.py
@@ -301,24 +301,5 @@ def test_sk_ne():
 
 
 if __name__ == '__main__':
-    from argparse import ArgumentParser
-    parser = ArgumentParser()
-    parser.add_argument("--profile", action='store_true', help="Profile tests")
-    parser.add_argument("--prof_out", default=None, help="Profiler output file")
-    args = parser.parse_args()
-
-    if args.profile:
-        import cProfile, pstats
-        pr = cProfile.Profile()
-        pr.enable()
-
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
-
-    if args.profile:
-        pr.disable()
-        ps = pstats.Stats(pr).sort_stats('tottime')
-        ps.print_stats(30)
-        if args.prof_out:
-            pr.dump_stats(args.prof_out)
+    runtests(testfns)

--- a/tests/test_sed.py
+++ b/tests/test_sed.py
@@ -1276,5 +1276,4 @@ def test_flux_type_calculateFlux():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1150,6 +1150,7 @@ def test_flat():
     np.testing.assert_allclose(cov20 / counts_total, 0., atol=2*toler)
     np.testing.assert_allclose(cov02 / counts_total, 0., atol=2*toler)
 
+@timer
 def test_omp():
     """Test setting the number of omp threads.
     """

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1278,5 +1278,4 @@ def test_big_then_small():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -121,7 +121,7 @@ def test_simple():
 
     check_pickle(simple)
 
-    
+
 @timer
 def test_silicon():
     """Test the basic construction and use of the SiliconSensor class.

--- a/tests/test_sersic.py
+++ b/tests/test_sersic.py
@@ -582,5 +582,4 @@ def test_near_05():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_shapelet.py
+++ b/tests/test_shapelet.py
@@ -356,5 +356,4 @@ def test_ne():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_shear.py
+++ b/tests/test_shear.py
@@ -273,5 +273,4 @@ def test_shear_matrix():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_shear_position.py
+++ b/tests/test_shear_position.py
@@ -19,7 +19,7 @@
 import numpy as np
 
 import galsim
-from galsim_test_helpers import timer
+from galsim_test_helpers import *
 
 
 @timer
@@ -126,5 +126,4 @@ def test_shear_position_image_integration_offsetwcs():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_spergel.py
+++ b/tests/test_spergel.py
@@ -342,5 +342,4 @@ def test_ne():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_sum.py
+++ b/tests/test_sum.py
@@ -351,5 +351,4 @@ def test_gsparams():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1233,5 +1233,4 @@ def test_integrate_product():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1013,5 +1013,4 @@ def test_gsparams():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1040,6 +1040,7 @@ def test_unweighted_moments():
     np.testing.assert_almost_equal(mom4['My'], 0.0)
 
 
+@timer
 def test_dol_to_lod():
     """Check broadcasting behavior of dol_to_lod"""
 
@@ -1366,6 +1367,7 @@ def test_horner_complex():
     result = galsim.utilities.horner(3.9+2.1j, coef[0], dtype=complex)
     np.testing.assert_almost_equal(result, np.polynomial.polynomial.polyval([3.9+2.1j],coef[0]))
 
+@timer
 def test_merge_sorted():
     from galsim.utilities import merge_sorted
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1490,5 +1490,4 @@ def test_merge_sorted():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_vonkarman.py
+++ b/tests/test_vonkarman.py
@@ -377,23 +377,10 @@ def test_low_folding_threshold():
 if __name__ == "__main__":
     from argparse import ArgumentParser
     parser = ArgumentParser()
-    parser.add_argument("--slow", action='store', default=1, help="Run slow tests")
     parser.add_argument("--benchmark", action='store_true', help="Run timing benchmark")
-    parser.add_argument("--profile", action='store_true', help="Profile the tests")
-    args = parser.parse_args()
-
-    if args.profile:
-        import cProfile, pstats
-        pr = cProfile.Profile()
-        pr.enable()
 
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns, parser=parser)
+    args = parser.parse_args()
     if args.benchmark:
         vk_benchmark()
-
-    if args.profile:
-        pr.disable()
-        ps = pstats.Stats(pr).sort_stats('tottime')
-        ps.print_stats(30)

--- a/tests/test_vonkarman.py
+++ b/tests/test_vonkarman.py
@@ -25,10 +25,10 @@ from galsim_test_helpers import *
 
 
 @timer
-def test_vk(slow=False):
+def test_vk():
     """Test the generation of VonKarman profiles
     """
-    if slow:
+    if __name__ == "__main__":
         lams = [300.0, 500.0, 1100.0]
         r0_500s = [0.05, 0.15, 0.3]
         L0s = [1e10, 25.0, 10.0]

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -3269,5 +3269,4 @@ def test_razero():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)

--- a/tests/test_zernike.py
+++ b/tests/test_zernike.py
@@ -895,6 +895,7 @@ def test_dz_val():
     check_pickle(dz)
 
 
+@timer
 def test_dz_coef_uvxy():
     rng = galsim.BaseDeviate(4321).as_numpy_generator()
     for _ in range(100):
@@ -959,6 +960,7 @@ def test_dz_coef_uvxy():
                 )
 
 
+@timer
 def test_dz_sum():
     """Test that DZ.__add__, __sub__, and __neg__ work as expected.
     """
@@ -1075,6 +1077,7 @@ def test_dz_sum():
         assert (dz2 - dz1) == dz2 + (-dz1) == -(dz1 - dz2)
 
 
+@timer
 def test_dz_product():
     """Test that __mul__ and __rmul__ work as expected.
     """
@@ -1177,6 +1180,7 @@ def test_dz_product():
     assert (dz2 * 3) == (3 * dz2)
 
 
+@timer
 def test_dz_grad():
     """Test that DZ gradients work as expected.
     """
@@ -1244,6 +1248,7 @@ def test_dz_grad():
             np.testing.assert_allclose(dzdy1, dzdy2, atol=1e-12)
 
 
+@timer
 def test_dz_to_T():
     """Test that DZs enable efficient computation of optical PSF sizes."""
 
@@ -1369,6 +1374,7 @@ def test_dz_to_T():
         # plt.show()
 
 
+@timer
 def test_dz_rotate():
     rng = galsim.BaseDeviate(12775).as_numpy_generator()
 
@@ -1413,6 +1419,7 @@ def test_dz_rotate():
                 )
 
 
+@timer
 def test_dz_basis():
     """Test the doubleZernikeBasis function"""
 
@@ -1454,6 +1461,7 @@ def test_dz_basis():
                     )
 
 
+@timer
 def test_dz_mean():
     """Test the dz.mean_xy and .mean_uv properties"""
     rng = galsim.BaseDeviate(51413).as_numpy_generator()

--- a/tests/test_zernike.py
+++ b/tests/test_zernike.py
@@ -20,7 +20,7 @@ import numpy as np
 
 import galsim
 from galsim.zernike import Zernike, DoubleZernike
-from galsim_test_helpers import timer, check_pickle, assert_raises, check_all_diff
+from galsim_test_helpers import *
 
 
 @timer
@@ -1555,5 +1555,4 @@ def test_dz_mean():
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
-    for testfn in testfns:
-        testfn()
+    runtests(testfns)


### PR DESCRIPTION
Addresses #1253 .

Adds a basic Levenberg-Marquardt optimizer that can fill in for `scipy.linalg.least_squares` in simple cases (such as used in `FittedSIPWCS`).  It's a small bit slower on average, so we might want to consider making it a fallback option when scipy is unavailable though I didn't bother for now.  (The fitted sip unit tests takes 3.0 s now, vs. 2.25 s using scipy).

Along the way I also refactored our `if __name__ == __main__` test running code so you can use `-k testname` (similar to pytest) when running directly with `python`.  There are command line options for running the profiler too.