### PR TITLE
Fix #1302

### DIFF
--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -450,6 +450,7 @@ class GSObject:
     def dimensionless(self): return True
     @property
     def wave_list(self): return np.array([], dtype=float)
+    def _fiducial_profile(self, bandpass): return bandpass.effective_wavelength, self
 
     # Also need these methods to duck-type as a ChromaticObject
     def evaluateAtWavelength(self, wave):


### PR DESCRIPTION
Fix an error found by @FedericoBerlfein that amounted to GSObjects missing a method needed to properly duck type as ChromaticObjects in some cases.  

Specifically, if an inseparable chromatic object is convolved with a GSObject (in Federico's case, a Pixel), then a bit of code tries to call `_fiducial_profile` on the separable components, which didn't work, since GSObject didn't have this method.  The fix is simply to add a trivial version of that method so the GSObject duck types properly in this context.