### PR TITLE
Update random_seed behavior in config to be less confusing.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,10 +11,20 @@ Dependency Changes
 API Changes
 -----------
 
+- Changed the behavior of random_seed. (See below) For most use cases, this is essentially a bug
+  fix, but if users were relying on the old behavior, you may need to change your config file to
+  work with the new behavior.  See `Image Field Attributes` for more details about the new
+  behavior. (#1309)
+
 
 Config Updates
 --------------
 
+- Changed the behavior of random_seed to be less confusing.  Now the first random_seed is always
+  converted into a sequence based on obj_num, and later ones (if any) in a list are not.
+  If you want a non-standard seed sequence, you should now put it in a list somewhere after
+  the first item.  The first item will always evaluate as an integer value and create a sequence
+  based on that indexed by obj_num. (#1309)
 
 
 New Features

--- a/docs/config_image.rst
+++ b/docs/config_image.rst
@@ -17,17 +17,7 @@ Some attributes that are allowed for all image types are:
 * ``random_seed`` = *int_value* or *list* (optional) The random seed to use for random numbers in the simulation.
 
     * The typical use case is that this is a simple integer value. Then, internally we scramble this value in a deterministic way and use a sequence of seeds based on the scrambled value so that the output is deterministic even when using multiple processes to build each image.
-    * If ``random_seed`` is a string, then it is parsed as a integer and treated in the same way as above.  This allows you to do a simple calculation using the ``$`` Eval shorthand to e.g. compute the initial seed from some other kind of ID number you might have in the config file.  It also means you don't have to be careful in your YAML writing to not accidentally write e.g. ``'1234'`` rather than ``1234``.
-    * If ``random_seed`` is a dict, it should parse as an *int_value*, but in this case, GalSim will not convert it into a sequence based on a single value.  Rather, it will respect your specification and evaluate the seed for each object as you specifiy.  This let's you do advanced things like use a different cadence for your random numbers (e.g. potentially to repeat the same seed for multiple objects; cf. `Demo 7`).
-    * If ``random_seed`` is a list, then multiple random number generators will be available for each object according to the multiple seed specifications.  This is normally used to have one random number behave normally for noise and such, and another one repeat with some cadence (e.g. repeat for each image in an exposure to make sure you generate the same PSFs for multiple CCDs in an exposure).  Whenever you want to use an rng other than the first one, add ``rng_num`` to the field and set it to the number of the rng you want to use in this list.  Each item in the list is parsed as above.
-
-    .. warning::
-
-        Within this ``random_seed`` list, any items that are either an int or str will be
-        evaluated once and converted into a sequence in the normal way.  So if you want an item
-        to be some complex Eval operation, you should make it a dict with an explicit
-        ``type: Eval``, rather than use the ``$`` shorthand notation.
-
+    * If ``random_seed`` is a list, then the first one will be converted as described above, but the later ones will not. Rather, it will respect your specification and evaluate the seed for each object as you specifiy. This will create multiple random number generators, according to the multiple seed specifications. This is normally used to have one random number behave normally for noise and such, and another one (or more) repeat with some other cadence (e.g. repeat for each image in an exposure to make sure you generate the same PSFs for multiple CCDs in an exposure). See `Demo 7` and `Demo 13` for examples of this. Whenever you want to use an rng other than the first one, add ``rng_num`` to the field and set it to the number of the rng you want to use in this list.
     * The default behavior, if ``random_seed`` is not given, is to get a seed from the system (/dev/urandom if possible, otherwise based on the time).
 
 * ``nproc`` = *int_value*  (default = 1)  Specify the number of processors to use when drawing images. If nproc <= 0, then this means to try to automatically figure out the number of cpus and use that.

--- a/examples/demo7.yaml
+++ b/examples/demo7.yaml
@@ -42,6 +42,8 @@
 # - stamp : draw_method (fft or phot)
 # - stamp : gsparams
 # - output : file_name with .gz, .bz2 or .fz extension automatically uses compression.
+# - Multiple random seeds (particular so one can repeat the same values for multiple images)
+# - rng_num specification in various fields
 
 
 # Define the PSF profiles
@@ -135,6 +137,13 @@ gal :
         e : { type : Random , min : 0.0 , max : 0.8 }
         beta : { type : Random }
 
+    # This line tells GalSim to use the image_num-indexed rng for all the random parameters
+    # in this field of the config.  Specifying rng_num anywhere in the config dict will apply
+    # to all items in that field at that level or lower, unless overridden by another rng_num
+    # specification at a lower level. (See image.random_seed below for how we set the seed
+    # for this rng.)
+    rng_num: 1
+
 
 # Define some other information about the images
 image :
@@ -158,13 +167,23 @@ image :
     noise :
         sky_level : 1.e4  # ADU / arcsec^2
 
-    # This is pretty contrived.  It is really only relevant for this particular demo.
-    # The usual case is to just set a single number, which really means that each object
-    # gets a sequential value starting with this number.  In this case we want to use the
-    # same value for both the fft and phot images to get the same values for the random
-    # parameters. To implement this, we tell it to use the image_num for the sequencing key
-    # rather than the usual obj_num.
-    random_seed : { type : Sequence , first : 553728 , index_key : 'image_num' }
+    # The usual way we set the random_seed is to just set a single number, which really means that
+    # each object gets a sequential value starting with something based on this number.
+    # This is fine for the noise, but it wouldn't work for the galaxy parameters, which we want
+    # to be the same for both fft and photon-shooting images.
+    # To get an rng that gives the same values for both, we need a second one indexed by
+    # image_num, rather than obj_num.  This will repeat the seed values for the two galaxies
+    # in each image, which we want to have identical properties.
+    # Note: Starting in verson 2.6, GalSim always converts the first random_seed to a sequence
+    # indexed by obj_num, so each galaxy gets a new rng.  Any more complicated seed specifications
+    # need to be done in rng_num=1 or higher (i.e. any but the first item in the list).
+    random_seed :
+      # rng_num=0 is implicitly converted to a sequence indexed by obj_num.  Used for noise here.
+      - 553728
+
+      # rng_num=1 is the one we use for the galaxy parameters so they are the same for
+      # both fft and photon shooting images.  We set rng_num=1 in the galaxy field above.
+      - { type : Sequence , first : 553728 , index_key : 'image_num' }
 
 
 # Define some image properties that are specific to the stamp generation phase:

--- a/tests/test_config_output.py
+++ b/tests/test_config_output.py
@@ -1459,7 +1459,7 @@ def test_eval_full_word():
             # is basically the same.
             'random_seed' : [
                 # Used for noise and nobjects.
-                { 'type' : 'Sequence', 'index_key' : 'obj_num', 'first' : 1234 },
+                12345,
                 # Used for objects.  Repeats sequence for each image in file
                 {
                     'type' : 'Eval',
@@ -1561,12 +1561,14 @@ def test_eval_full_word():
     data0 = np.genfromtxt('output/test_eval_full_word_0.dat', names=True, deletechars='')
     data1 = np.genfromtxt('output/test_eval_full_word_1.dat', names=True, deletechars='')
 
-    assert len(data0) == 18 # 9 obj each for first two exposures
-    assert len(data1) == 24 # 12 obj each for next two exposures
-    data00 = data0[:9]
-    data01 = data0[9:]
-    data10 = data1[:12]
-    data11 = data1[12:]
+    n1 = 11  # 11 obj each for first two exposures
+    n2 = 14  # 14 obj each for next two exposures
+    assert len(data0) == 2*n1
+    assert len(data1) == 2*n2
+    data00 = data0[:n1]
+    data01 = data0[n1:]
+    data10 = data1[:n2]
+    data11 = data1[n2:]
 
     # Check exposure = image_num
     np.testing.assert_array_equal(data00['exposure'], 0)
@@ -1575,21 +1577,21 @@ def test_eval_full_word():
     np.testing.assert_array_equal(data11['exposure'], 3)
 
     # Check obj_num
-    np.testing.assert_array_equal(data00['num'], range(0,9))
-    np.testing.assert_array_equal(data01['num'], range(9,18))
-    np.testing.assert_array_equal(data10['num'], range(18,30))
-    np.testing.assert_array_equal(data11['num'], range(30,42))
+    np.testing.assert_array_equal(data00['num'], range(0,n1))
+    np.testing.assert_array_equal(data01['num'], range(n1,2*n1))
+    np.testing.assert_array_equal(data10['num'], range(2*n1,2*n1+n2))
+    np.testing.assert_array_equal(data11['num'], range(2*n1+n2,2*n1+2*n2))
 
     # Check that galaxy properties are identical within exposures, but different across exposures
     for key in ['pos.x', 'pos.y', 'ra.rad', 'dec.rad', 'flux', 'size']:
         np.testing.assert_array_equal(data00[key], data01[key])
         np.testing.assert_array_equal(data10[key], data11[key])
-        assert np.all(np.not_equal(data00[key], data10[key][:9]))
+        assert np.all(np.not_equal(data00[key], data10[key][:n1]))
 
     # PSFs should all be different, but only in the mean
     assert np.all(np.not_equal(data00['psf_fwhm'], data01['psf_fwhm']))
     assert np.all(np.not_equal(data10['psf_fwhm'], data11['psf_fwhm']))
-    assert np.all(np.not_equal(data00['psf_fwhm'], data10['psf_fwhm'][:9]))
+    assert np.all(np.not_equal(data00['psf_fwhm'], data10['psf_fwhm'][:n1]))
     np.testing.assert_array_almost_equal(data00['psf_fwhm'] - np.mean(data00['psf_fwhm']),
                                          data01['psf_fwhm'] - np.mean(data01['psf_fwhm']))
     np.testing.assert_array_almost_equal(data10['psf_fwhm'] - np.mean(data10['psf_fwhm']),
@@ -1599,13 +1601,13 @@ def test_eval_full_word():
     # be in the Gaussian noise.
     im00, im01 = galsim.fits.readMulti('output/test_eval_full_word_0.fits')
     assert np.all(np.not_equal(im00.array, im01.array))
-    assert abs(np.mean(im00.array - im01.array)) < 0.1
+    assert abs(np.mean(im00.array - im01.array)) < 0.5
     assert 13.5 < np.std(im00.array - im01.array) < 15  # should be ~10 * sqrt(2)
     assert np.max(np.abs(im00.array)) > 200  # Just verify that many values are quite large
 
     im10, im11 = galsim.fits.readMulti('output/test_eval_full_word_1.fits')
     assert np.all(np.not_equal(im10.array, im11.array))
-    assert abs(np.mean(im10.array - im11.array)) < 0.1
+    assert abs(np.mean(im10.array - im11.array)) < 0.5
     assert 13.5 < np.std(im10.array - im11.array) < 15
     assert np.max(np.abs(im10.array)) > 200
 


### PR DESCRIPTION
@kailicao discovered an error in the recent Roman image simulations where the random seed was not updating for each galaxy as expected.  This only affected Poisson noise on the flux values (the "realized flux"), since most values were from SkyCatalog, not generated from an rng.  But the statistics of the fluxes ended up messed up.

@matroxel and I tracked down the problem to the random_seed specification in the config file, which used a dict to evaluate a value based on the input file.  This was intended to be the initial seed, to be converted into a sequence as usual.  But the ([documented](http://galsim-developers.github.io/GalSim/_build/html/config_image.html#image-field-attributes)) behavior in that case is to take the user's dict specification as is, and not convert it.  This is confusing behavior, since most of the time evaluation like this is equivalent to setting a literal value.  

Troxel also noticed that imsim's example config has the same problem, although the config files used by @jchiang87 for the recent simulation runs didn't use that.  (It used a string eval value for the seed.)  So imsim users may also be getting wrong random values currently.

So I changed the behavior to always convert the first random_seed in the list (or only one if not a list) into the sequence in the usual way.  Any other items in the list are evaluated as the user specifies.  This is technically an API change, since it's possible that some users have been relying on the old behavior to leave dict specifications as is and convert int or str values.  However, (a) I think it's unlikely that anyone was using this feature other than to have the first item be normal and later items be dicts, and (b) we know of two accidental erroneous usages mentioned above, and it wouldn't surprise me if there were others.  So this is more like a bug fix than a feature change.  Anyway, I document it as an API change nonetheless to warn users who might be relying on the old behavior.