### PR TITLE
Add an actual global dbgout for compilers that don't fully optimize it away.

### DIFF
--- a/galsim/phase_screens.py
+++ b/galsim/phase_screens.py
@@ -386,7 +386,8 @@ class AtmosphericScreen:
         with acquire_lock(self._objDict['lock'], timeout=3) as acquired:
             # If this can't acquire the lock, just timeout and return -- don't hang.
             # (This seems to happen occasionally, but apparently only here in __del__.)
-            if not acquired: return
+            if not acquired:  # pragma: no cover
+                return
 
             self._objDict['refcount'].value -= 1
             # Normally, shareKey is present, but on final cleanup, we have no control over

--- a/src/SBProfile.cpp
+++ b/src/SBProfile.cpp
@@ -19,6 +19,7 @@
 
 //#define DEBUGLOGGING
 
+#include <fstream>
 #include "SBProfile.h"
 #include "SBTransform.h"
 #include "SBProfileImpl.h"
@@ -35,9 +36,21 @@
 // xdbg requires verbose_level >= 2
 // xxdbg requires verbose_level >= 3
 //
-// If DEBUGLOGGING is not defined, the all three becomes just `if (false) std::cerr`,
+// If DEBUGLOGGING is not defined, the all three becomes just `if (false) (*dbgout)`,
 // so the compiler parses the statement fine, but trivially optimizes the code away,
 // so there is no efficiency hit from leaving them in the code.
+
+#ifndef DEBUGLOGGING
+// Apparently not all compilers optimize away the if (false) (*dbgout) lines.
+// That can cause errors when linking.  cf. #1313.
+// This fixes the problem by providing an actual dbgout object that doesn't write anything.
+std::ostream* make_global_dbgout() {
+    static std::ofstream dbgout_ofstream;
+    dbgout_ofstream.setstate(std::ios_base::badbit);
+    return &dbgout_ofstream;
+}
+std::ostream* dbgout = make_global_dbgout();
+#endif
 
 namespace galsim {
 


### PR DESCRIPTION
Fixes #1313