### PR TITLE
Fix a bug where errors could happen in chromatic drawing when realized flux is 0.

### DIFF
--- a/galsim/gsobject.py
+++ b/galsim/gsobject.py
@@ -2152,6 +2152,7 @@ class GSObject:
 
         # Make n_photons an integer.
         iN = int(n_photons + 0.5)
+        g = g if iN > 0 else 1.  # g=0 can cause trouble in places, so avoid it.
 
         return iN, g
 

--- a/tests/test_chromatic.py
+++ b/tests/test_chromatic.py
@@ -2490,6 +2490,29 @@ def test_phot(run_slow):
     with assert_raises(galsim.GalSimRangeError):
         obj2.drawImage(bp2, image=im5, method='phot', rng=rng, n_photons=10)
 
+@timer
+def test_low_flux_phot():
+    """ Check that objects with 0 realized flux don't have problems.
+    """
+
+    bandpass = galsim.Bandpass("LSST_r.dat", wave_type="nm")
+    sed = galsim.SED('vega.txt', 'nm', 'flambda').thin(rel_err=1.e-2)
+    sed = sed.withFlux(1.e-5, bandpass)
+
+    base_psf = galsim.Gaussian(fwhm=0.7)
+    psf = galsim.ChromaticAtmosphere(
+        base_psf,
+        700,
+        alpha=-0.3,
+        zenith_angle=0 * galsim.degrees,
+        parallactic_angle=0 * galsim.degrees,
+    )
+
+    observed = galsim.Convolve(psf, sed * galsim.Exponential(half_light_radius=0.3))
+    rng = galsim.BaseDeviate(1234)
+    image = observed.drawImage(nx=53, ny=53, bandpass=bandpass, method="phot", rng=rng)
+    np.testing.assert_array_equal(image.array, 0.)
+
 
 @timer
 def test_chromatic_fiducial_wavelength():


### PR DESCRIPTION
@sidneymau reported a bug where very low flux objects being drawn with chromatic photon shooting could error rather than just not draw anything.

The bug stemmed from having both 0 photons and each photon having a flux of 0 (the g parameter returned by calculate_nphotons).  This is overkill and confused one of the calculations in the chromatic draw function.  In case there are other bits of code that similarly assume the raw flux is sensible even if nphotons=0, I changed the calculate_nphotons function to return g=1 when iN=0.