### PR TITLE
Zernike enhancements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
             matrix:
                 # First all python versions in basic linux
                 os: [ ubuntu-latest ]
-                py: [ 3.7, 3.8, 3.9, "3.10", 3.11, 3.12 ]
+                py: [ 3.8, 3.9, "3.10", 3.11, 3.12 ]
                 CC: [ gcc ]
                 CXX: [ g++ ]
                 FFTW_DIR: [ "/usr/local/lib" ]
@@ -107,7 +107,7 @@ jobs:
 
                 # Easier if eigen is installed with apt-get, but on at least one system, check that
                 # it gets downloaded and installed properly if it isn't installed.
-                if ${{ matrix.py != 3.7 }}; then sudo -H apt install -y libeigen3-dev; fi
+                if ${{ matrix.py != 3.8 }}; then sudo -H apt install -y libeigen3-dev; fi
 
                 # Need this for the mpeg tests
                 sudo -H apt install -y ffmpeg
@@ -189,7 +189,7 @@ jobs:
                 FFTW_DIR=$FFTW_DIR pip install -vvv .
 
             - name: Check download_cosmos only if it changed. (And only on 1 runner)
-              if: matrix.py == 3.7 && github.base_ref != ''
+              if: matrix.py == 3.8 && github.base_ref != ''
               run: |
                 git status
                 git --no-pager log --graph --pretty=oneline --abbrev-commit | head -50

--- a/galsim/zernike.py
+++ b/galsim/zernike.py
@@ -1215,6 +1215,20 @@ class DoubleZernike:
                     assert np.shape(x) == np.shape(u)
                     return horner4d(u, v, x, y, self._coef_array_uvxy)
 
+    def xycoef(self, u, v):
+        """Return the xy Zernike coefficients for a given uv point or points.
+
+        Parameters:
+            u, v: float or array.  UV point(s).
+
+        Returns:
+            [npoint, jmax] array.  Zernike coefficients for the given UV point(s).
+        """
+        uu, vv = np.broadcast_arrays(u, v)
+        out = np.array([z(uu, vv) for z in self._xy_series]).T
+        out[..., 0] = 0.0  # Zero out piston term
+        return out
+
     def __neg__(self):
         """Negate a DoubleZernike."""
         if 'coef' in self.__dict__:

--- a/galsim/zernike.py
+++ b/galsim/zernike.py
@@ -387,7 +387,7 @@ def __annular_zern_rho_coefs(n, m, eps):
             if i % 2 == 1: continue
             j = i // 2
             more_coefs = (norm**j) * binomial(-eps**2, 1, j)
-            out[0:i+1:2] += coef*more_coefs
+            out[0:i+1:2] += float(coef)*more_coefs
     elif m == n:  # Equation (25)
         norm = 1./np.sqrt(np.sum((eps**2)**np.arange(n+1)))
         out[n] = norm

--- a/tests/test_zernike.py
+++ b/tests/test_zernike.py
@@ -1596,9 +1596,10 @@ def test_large_j(run_slow):
 
     print()
     for n, tol in test_vals:
-        j = np.sum(np.arange(n+2))
-        n, m = galsim.zernike.noll_to_zern(j)
-        print(f"Z{j} => (n, m) = ({n}, {n})")
+        j = (n+1)*(n+2)//2
+        _, m = galsim.zernike.noll_to_zern(j)
+        print(f"Z{j} => (n, m) = ({n}, {m})")
+        assert n == abs(m)
         coefs = np.zeros(j+1)
         coefs[j] = 1.0
         zk = Zernike(coefs, R_outer=R_outer, R_inner=R_inner)

--- a/tests/test_zernike.py
+++ b/tests/test_zernike.py
@@ -876,6 +876,21 @@ def test_dz_val():
                 atol=2e-13, rtol=0
             )
 
+        zk_coefs = dz.xycoef(*uv_vector)
+        for zk, c in zip(zk_list, zk_coefs):
+            # Zk may have trailing zeros...
+            ncoef = len(c)
+            np.testing.assert_allclose(
+                zk.coef[:ncoef],
+                c,
+                atol=2e-13, rtol=0
+            )
+        for i, (u, v) in enumerate(zip(*uv_vector)):
+            np.testing.assert_equal(
+                zk_coefs[i],
+                dz.xycoef(u, v)
+            )
+
         # Check asserts
         with assert_raises(AssertionError):
             dz(0.0, [1.0])


### PR DESCRIPTION
Two tweaks to the Zernike library:

• Adds a DoubleZernike.xycoef() method to directly get the pupil coefficient array at a given field position of a double zernike, without going through a galsim.Zernike object.
• Enables large jmax for annular Zernikes.  Addresses #1326 .

I found a closed-form for a certain subset of annular Zernikes where the radial and azimuthal orders are equal, so used that as a test of annular Zernikes Z66, Z231, Z861, Z1891, and Z3321.  GalSim's annular Zernike library reproduces these to tolerances of part per 10^12, 10^12, 10^9, 10^6, and 10^3 respectively.  I also tried Z5151.  This value of j is apparently well beyond the accuracy of the library though and yields errors in the ~factor of 10 range.

These were all for R_inner/R_outer = 0.5; I'd guess the accuracies probably improve as this ratio goes to 0 (annular Zernikes go to circular Zernikes), but didn't explicitly check.