### PR TITLE
Add recalc=0 option to SiliconSensor

### DIFF
--- a/galsim/sensor.py
+++ b/galsim/sensor.py
@@ -359,7 +359,7 @@ class SiliconSensor(Sensor):
                 self._silicon.subtractDelta(image._image)
             else:
                 self._silicon.initialize(image._image, orig_center._p);
-            self._accum_flux_since_update = 0.
+                self._accum_flux_since_update = 0.
         elif resume:
             # Case 2
             # The number in this batch is the total per recalc minus the number of photons

--- a/galsim/sensor.py
+++ b/galsim/sensor.py
@@ -313,7 +313,7 @@ class SiliconSensor(Sensor):
                             accumulation to see what flux is already on the image, which can
                             be more efficient, especially when the number of pixels is large.
                             [default: False]
-            recalc:         Whether to force a recalculation at the pixel boundaries at the
+            recalc:         Whether to force a recalculation of the pixel boundaries at the
                             start. [default: False]
 
         Returns:


### PR DESCRIPTION
For some work on imsim that @welucas2 is doing, we realized that there is not really a good API for the user to fully control when pixel boundary recalculations happen in the SiliconSensor class.  This PR adds a mechanism to do that more easily.

Specifically, now nrecalc=0 means don't do any recalculations during a call to accumulate.  And a new recalc=True option to accumulate means do a manual update right at the start.

If resume=False then the sensor will be initialized the normal way, but then (aside from the tree rings) work equivalently to the simple sensor (no pixel boundary adjustments).

If resume=True and recalc=True, then the pixel boundaries will be updates at the start of the accumulate call, but then not afterwards.

If resume=True and recalc=False, then it continues with the current image, and no recalculation is done.  This option is for when we have more batches than we want recalculations.

I think these two options should effectively allow complete control over when the recalculations happen.  At least sufficient for what we need in the imsim refactorization.