### PR TITLE
Add Image.array setter (#1272)

### DIFF
--- a/galsim/image.py
+++ b/galsim/image.py
@@ -479,6 +479,10 @@ class Image:
         """
         return self._array.strides[1]//self._array.itemsize == 1
 
+    @array.setter
+    def array(self, other):
+        self._array[:] = self._safe_cast(other)
+
     @lazy_property
     def _image(self):
         cls = self._cpp_type[self.dtype]

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1734,6 +1734,19 @@ def test_Image_inplace_add():
                     err_msg="Inplace add in Image class does not match reference for dtypes = "
                     +str(types[i])+" and "+str(types[j]))
 
+        # Adding via array:
+        image4 = image2.copy()
+        image4.array += image2.array
+        np.testing.assert_allclose(image4.array, 2*image2.array)
+        image4.array[:] += image2.array
+        np.testing.assert_allclose(image4.array, 3*image2.array)
+        image4.array = image4.array + image2.array
+        np.testing.assert_allclose(image4.array, 4*image2.array)
+        with assert_raises(ValueError):
+            image4.array += image2.array[:2,:]
+        with assert_raises(ValueError):
+            image4.array = image4.array[:2,:] + image2.array[:2,:]
+
         with assert_raises(ValueError):
             image1 += image1.subImage(galsim.BoundsI(0,4,0,4))
 
@@ -1775,6 +1788,19 @@ def test_Image_inplace_subtract():
             np.testing.assert_array_equal(ref_array.astype(types[i]), image1.array,
                     err_msg="Inplace subtract in Image class does not match reference for dtypes = "
                     +str(types[i])+" and "+str(types[j]))
+
+        # Subtracting via array:
+        image4 = 5*image2
+        image4.array -= image2.array
+        np.testing.assert_allclose(image4.array, 4*image2.array)
+        image4.array[:] -= image2.array
+        np.testing.assert_allclose(image4.array, 3*image2.array)
+        image4.array = image4.array - image2.array
+        np.testing.assert_allclose(image4.array, 2*image2.array)
+        with assert_raises(ValueError):
+            image4.array -= image2.array[:2,:]
+        with assert_raises(ValueError):
+            image4.array = image4.array[:2,:] - image2.array[:2,:]
 
         with assert_raises(ValueError):
             image1 -= image1.subImage(galsim.BoundsI(0,4,0,4))
@@ -1907,6 +1933,17 @@ def test_Image_inplace_scalar_add():
                 err_msg="Inplace scalar add in Image class does not match reference for dtype = "
                 +str(types[i]))
 
+        # Adding via array:
+        image4 = image1.copy()
+        image4.array += 1
+        np.testing.assert_allclose(image4.array, image1.array + 1)
+        image4.array[:] += 1
+        np.testing.assert_allclose(image4.array, image1.array + 2)
+        image4.array = image4.array + 1
+        np.testing.assert_allclose(image4.array, image1.array + 3)
+        with assert_raises(ValueError):
+            image4.array = image4.array[:2,:] + 1
+
 
 @timer
 def test_Image_inplace_scalar_subtract():
@@ -1961,6 +1998,17 @@ def test_Image_inplace_scalar_multiply():
                 err_msg="Inplace scalar multiply in Image class does"
                 +" not match reference for dtype = "+str(types[i]))
 
+        # Multiplying via array:
+        image4 = image2.copy()
+        image4.array *= 2
+        np.testing.assert_allclose(image4.array, 2*image2.array)
+        image4.array[:] *= 2
+        np.testing.assert_allclose(image4.array, 4*image2.array)
+        image4.array = image4.array * 2
+        np.testing.assert_allclose(image4.array, 8*image2.array)
+        with assert_raises(ValueError):
+            image4.array = image4.array[:2,:] * 2
+
 
 @timer
 def test_Image_inplace_scalar_divide():
@@ -1987,6 +2035,36 @@ def test_Image_inplace_scalar_divide():
         np.testing.assert_array_equal(ref_array.astype(types[i]), image1.array,
                 err_msg="Inplace scalar divide in Image class does"
                 +" not match reference for dtype = "+str(types[i]))
+
+        # Dividing via array:
+        image4 = 16*image2
+        if simple_types[i] is int:
+            with assert_raises(TypeError):
+                image4.array /= 2
+            with assert_raises(TypeError):
+                image4.array[:] /= 2
+            np.testing.assert_array_equal(image4.array, 16*image2.array)  # unchanged yet
+            image4.array //= 2
+            np.testing.assert_array_equal(image4.array, 8*image2.array)
+            image4.array[:] //= 2
+            np.testing.assert_array_equal(image4.array, 4*image2.array)
+            image4.array = image4.array // 2
+            np.testing.assert_array_equal(image4.array, 2*image2.array)
+            # The following works for integer by explicitly rounding and casting.
+            # The native numpy operation would use floor to cast to int, which is 1 smaller.
+            image4.array = (image4.array / 2.0001)
+            np.testing.assert_array_equal(image4.array, image2.array)
+            with assert_raises(ValueError):
+                image4.array = image4.array[:2,:] // 2
+        else:
+            image4.array /= 2
+            np.testing.assert_allclose(image4.array, 8*image2.array)
+            image4.array[:] /= 2
+            np.testing.assert_allclose(image4.array, 4*image2.array)
+            image4.array = image4.array / 2
+            np.testing.assert_allclose(image4.array, 2*image2.array)
+            with assert_raises(ValueError):
+                image4.array = image4.array[:2,:] / 2
 
 
 @timer


### PR DESCRIPTION
@sidneymau ran into a weird edge case in a Jupyter notebook when doing `im.array /= 10` raised an AttributeError (that array doesn't have a setter), but performed the operation nonetheless.  

This seems to be a bug in either Python or numpy.  Numpy overloads the inplace arithmetic operations so `ar /= 10` is allowed and works in place.  But Python seems to think that `im.array /= 10` would necessarily require a setter, so it raises an AttributeError.  This so far is fine, but then Python calls the numpy `__idiv__` operation anyway, so the operation succeeds along with an AttributeError being raised.  

It was at least confusing for Sid, since a Jupyter session doesn't die when that happens, so the state of the array seemed inconsistent with the error messaging.

Anyway, this PR adds a setter, which lets `im.array = blah` work the same way as `im.array[:] = blah`, with the slight exception that we are careful about rounding things to the nearest integer if we are assigning to integer arrays rather than truncating as numpy would want to do.  (This is consistent with how GalSim does other arithmetic on integer Images.)

Note, this replaces Sid's PR #1276, which I wasn't happy with.  This implementation never changes the underlying array object.  Just lets things be assigned to it as appropriate.