### PR TITLE
Make PhotonDCR work correctly with both sky_pos and zenith_angle

### DIFF
--- a/galsim/dcr.py
+++ b/galsim/dcr.py
@@ -131,6 +131,7 @@ def parse_dcr_angles(**kwargs):
     if 'zenith_angle' in kwargs:
         zenith_angle = kwargs.pop('zenith_angle')
         parallactic_angle = kwargs.pop('parallactic_angle', 0.0*degrees)
+        kwargs.pop('obj_coord', None)  # Ok if present, but want to make sure we remove it.
         if not isinstance(zenith_angle, Angle):
             raise TypeError("zenith_angle must be a galsim.Angle.")
         if not isinstance(parallactic_angle, Angle):

--- a/tests/test_photon_array.py
+++ b/tests/test_photon_array.py
@@ -710,6 +710,12 @@ def test_dcr():
     im2c = galsim.config.BuildImage(config)
     assert im2c == im2
 
+    # Make sure it's ok if sky_pos is set.  (This used to be a bug.)
+    config['sky_pos'] = galsim.CelestialCoord(15 * galsim.degrees, -25 * galsim.degrees)
+    galsim.config.RemoveCurrent(config)
+    im2d = galsim.config.BuildImage(config)
+    assert im2c == im2
+
     # Should work with fft, but not quite match (because of inexact photon locations).
     im3 = galsim.ImageF(50, 50, scale=pixel_scale)
     achrom.drawImage(image=im3, method='fft', rng=rng, photon_ops=photon_ops)

--- a/tests/test_photon_array.py
+++ b/tests/test_photon_array.py
@@ -714,7 +714,7 @@ def test_dcr():
     config['sky_pos'] = galsim.CelestialCoord(15 * galsim.degrees, -25 * galsim.degrees)
     galsim.config.RemoveCurrent(config)
     im2d = galsim.config.BuildImage(config)
-    assert im2c == im2
+    assert im2d == im2
 
     # Should work with fft, but not quite match (because of inexact photon locations).
     im3 = galsim.ImageF(50, 50, scale=pixel_scale)


### PR DESCRIPTION
@vfbraga ran into a bug in the dcr angle parsing where both zenith_angle and obj_coord are set.  This can happen if zenith_angle is given explicitly, and there is a sky_pos being set in the config (which is relatively common).

The fix here is just to allow that combination.  So if zenith_angle is given, the dcr parsing function will pop off obj_coord from the rest of the kwargs that get returned.