### PR TITLE
Remove setuptools<72 pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
 
                 # Do these three first to clarify potential conflicts
                 pip install -U numpy
-                pip install -U "setuptools<72"
+                pip install -U setuptools
                 pip install -U wheel
 
                 # Standard dependencies
@@ -217,16 +217,6 @@ jobs:
                 test -d build/shared_clib
                 ls build/shared_clib
                 ls build/shared_clib/libgalsim.*
-
-                # For now, use `python setup.py test` to test linking to the shared library.
-                # We run some C++ tests there, and we use the shared library for linking.
-                # Caveats:
-                #  1. The C++ tests are not very comprehensive, so it won't catch all errors.
-                #  2. Apparently setup.py test is deprecated.  I'm getting warnings when I run
-                #     it that indicate it may go away at some point.  So whenever that happens,
-                #     we'll have to revisit this test to find another way to build and run
-                #     the C++ tests.
-                GALSIM_TEST_PY=0 python setup.py test
 
             - name: Upload coverage to codecov
               if: matrix.py != 'pypy-3.7'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,14 @@ jobs:
                 pip install -U matplotlib
 
                 pip install -U astroplan
+
+            # Starlink doesn't seem to work anymore.  Even with numpy 1.x, I'm getting
+            # "ModuleNotFoundError: No module named 'numpy'" when building the wheel.
+            # This after already installing numpy, so it should be there.
+            # Revisit from time to time to see if they fix it.
+            - name: Install starlink
+              if: 0
+              run: |
                 pip install -U starlink-pyast
 
             - name: Install CPython-only dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
             matrix:
                 # First all python versions in basic linux
                 os: [ ubuntu-latest ]
-                py: [ 3.9, "3.10", 3.11, 3.12, 3.13 ]
+                py: [ 3.9, "3.10", 3.11, 3.12, 3.13, 3.14 ]
                 CC: [ gcc ]
                 CXX: [ g++ ]
                 FFTW_DIR: [ "/usr/local/lib" ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,12 +160,6 @@ jobs:
 
                 pip install -U matplotlib
 
-            - name: Install astroplan
-              # astroplan isn't yet numpy 2.0 compatible.  So don't install that on 3.9+.
-              # I'm also getting errors with starlink, which I think may be related to
-              # numpy 2.0.
-              if: (matrix.py == 3.8) || (matrix.py == 3.9)
-              run: |
                 pip install -U astroplan
                 pip install -U starlink-pyast
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
 
                 # Easier if eigen is installed with apt-get, but on at least one system, check that
                 # it gets downloaded and installed properly if it isn't installed.
-                if ${{ matrix.py != 3.8 }}; then sudo -H apt install -y libeigen3-dev; fi
+                if ${{ matrix.py != 3.12 }}; then sudo -H apt install -y libeigen3-dev; fi
 
                 # Need this for the mpeg tests
                 sudo -H apt install -y ffmpeg
@@ -189,7 +189,7 @@ jobs:
                 FFTW_DIR=$FFTW_DIR pip install -vvv .
 
             - name: Check download_cosmos only if it changed. (And only on 1 runner)
-              if: matrix.py == 3.8 && github.base_ref != ''
+              if: matrix.py == 3.12 && github.base_ref != ''
               run: |
                 git status
                 git --no-pager log --graph --pretty=oneline --abbrev-commit | head -50
@@ -206,9 +206,9 @@ jobs:
                        # Less confusing to include it explicitly.
 
             - name: Check shared library
-              if: matrix.py == 3.8
+              if: matrix.py == 3.12
               run: |
-                # On a few systems (arbitrarily py3.8, where we also check mac and clang),
+                # On a few systems (arbitrarily py3.12, where we also check mac and clang),
                 # check the shared library creation and link.
                 GALSIM_BUILD_SHARED=1 python setup.py build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
             matrix:
                 # First all python versions in basic linux
                 os: [ ubuntu-latest ]
-                py: [ 3.8, 3.9, "3.10", 3.11, 3.12, 3.13 ]
+                py: [ 3.9, "3.10", 3.11, 3.12, 3.13 ]
                 CC: [ gcc ]
                 CXX: [ g++ ]
                 FFTW_DIR: [ "/usr/local/lib" ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,13 +210,16 @@ jobs:
               run: |
                 # On a few systems (arbitrarily py3.8, where we also check mac and clang),
                 # check the shared library creation and link.
-                GALSIM_BUILD_SHARED=1 python setup.py install
+                GALSIM_BUILD_SHARED=1 python setup.py build
 
                 # These directories/files should now exist.
                 echo "Look for the shared library:"
                 test -d build/shared_clib
                 ls build/shared_clib
                 ls build/shared_clib/libgalsim.*
+
+                # Build and run the C++ test suite
+                GALSIM_RUN_TEST=1 python setup.py build
 
             - name: Upload coverage to codecov
               if: matrix.py != 'pypy-3.7'

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          pip install -U numpy "setuptools<72"
+          pip install -U numpy setuptools
           pip install -U -r requirements.txt
 
       - name: Download wheels

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -1,6 +1,6 @@
 # The requirements packages that can be installed with
 #    conda install -y -c conda-forge --file conda_requirements.txt
-setuptools>=38,<72
+setuptools>=38
 numpy>=1.17
 astropy>=2.0
 pybind11>=2.2

--- a/galsim/fitswcs.py
+++ b/galsim/fitswcs.py
@@ -307,7 +307,7 @@ class AstropyWCS(CelestialWCS):
         self._wcs = self._load_from_header(self.header)
 
 
-class PyAstWCS(CelestialWCS):
+class PyAstWCS(CelestialWCS): # pragma: no cover
     """This WCS uses PyAst (the python front end for the Starlink AST code) to read WCS
     information from a FITS file.  It requires the starlink.Ast python module to be installed.
 

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -1789,7 +1789,10 @@ class Image:
     def __ipow__(self, other):
         if not isinstance(other, int) and not isinstance(other, float):
             raise TypeError("Can only raise an image to a float or int power!")
-        self.array[:,:] **= other
+        if not self.isinteger or isinstance(other, int):
+            self.array[:,:] **= other
+        else:
+            self.array[:,:] = self._safe_cast(self.array ** other)
         return self
 
     def __neg__(self):

--- a/galsim/table.py
+++ b/galsim/table.py
@@ -951,7 +951,7 @@ class LookupTable2D:
         Returns:
             a scalar value if x and y are scalar, or a numpy array if x and y are arrays.
         """
-        if np.__version__ >= "2.0":
+        if np.__version__ >= "2.0":  # pragma: no branch
             # I'm not sure if there is a simpler way to do this in 2.0.
             # We want a copy when edge_mode == wrap. Otherwise, only copy if dtype changes or
             # x,y aren't already arrays. That used to be simple...
@@ -1071,7 +1071,7 @@ class LookupTable2D:
             A tuple of (dfdx, dfdy) where dfdx, dfdy are single values (if x,y were single
             values) or numpy arrays.
         """
-        if np.__version__ >= "2.0":
+        if np.__version__ >= "2.0":  # pragma: no branch
             copy = True if self.edge_mode=='wrap' else None
         else:
             copy = self.edge_mode=='wrap'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools>=38,<72", "wheel", "pybind11>=2.2"]
+requires = ["setuptools>=38", "wheel", "pybind11>=2.2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,7 @@
 [build-system]
 requires = ["setuptools>=38", "wheel", "pybind11>=2.2"]
+
+[tool.pytest.ini_options]
+testpaths = [
+    "tests",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 # These are in conda_requirements.txt.  If using that, you may prefer to do
 #   conda install -c conda-forge --file conda_requirements.txt
 # prior to running pip install -r requirements.txt
-setuptools>=38,<72
+setuptools>=38
 numpy>=1.17
 astropy>=2.0
 pybind11>=2.2

--- a/setup.py
+++ b/setup.py
@@ -1330,7 +1330,7 @@ else:
 print('GalSim version is %s'%(galsim_version))
 
 # Write a Version.h file that has this information for people using the C++ library.
-vi = re.split('\.|-',galsim_version)
+vi = re.split(r'\.|-',galsim_version)
 version_info = tuple([int(x) for x in vi if x.isdigit()])
 if len(version_info) == 2:
     version_info = version_info + (0,)

--- a/setup.py
+++ b/setup.py
@@ -102,10 +102,12 @@ lopt =  {
 }
 
 # If we build with debug, undefine NDEBUG flag
-# Note: setuptools stopped allowing --debug, so if we need this, we'll need to find another
-# mechanism.
+# Note: setuptools stopped allowing --debug, so edit this manually if you want debugging.
+# (The other debug variable is just for verbose output to debug this setup script.)
+full_debug = False
+
 undef_macros = []
-if "--debug" in sys.argv:
+if full_debug:
     undef_macros+=['NDEBUG']
     for name in copt.keys():
         if name != 'unknown':
@@ -118,7 +120,7 @@ else:
 
 # Verbose is the default for setuptools logging, but if it's on the command line, we take it
 # to mean that we should also be verbose.
-if "--debug" in sys.argv or "--verbose" in sys.argv:
+if full_debug or "--verbose" in sys.argv:
     debug = True
 
 local_tmp = 'tmp'

--- a/setup.py
+++ b/setup.py
@@ -1345,7 +1345,7 @@ ext=Extension("galsim._galsim",
               undef_macros = undef_macros,
               extra_link_args = ["-lfftw3"])
 
-build_dep = ['setuptools>=38,<72', 'pybind11>=2.2', 'numpy>=1.17']
+build_dep = ['setuptools>=38', 'pybind11>=2.2', 'numpy>=1.17']
 run_dep = ['astropy', 'LSSTDESC.Coord']
 test_dep = ['pytest', 'pytest-xdist', 'pytest-timeout', 'scipy', 'pyyaml']
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,11 @@
+import pytest
+
 def pytest_addoption(parser):
     parser.addoption(
         "--run_slow", action="store_true", default=False, help="Run slow tests"
     )
+
+# cf. https://stackoverflow.com/questions/62044541/change-pytest-working-directory-to-test-case-directory
+@pytest.fixture(autouse=True)
+def change_test_dir(request, monkeypatch):
+    monkeypatch.chdir(request.fspath.dirname)

--- a/tests/run_examples.py
+++ b/tests/run_examples.py
@@ -26,6 +26,7 @@ import os
 import sys
 import logging
 import shutil
+import pytest
 
 import galsim
 
@@ -65,8 +66,10 @@ def check_same(f1, f2):
 
 logging.basicConfig(format="%(message)s", stream=sys.stdout)
 
+@pytest.fixture(scope="module", autouse=True)
 @in_examples
 def setup():
+    print("Removing output dirs")
     remove_dir('output')
     remove_dir('output_yaml')
     remove_dir('output_json')

--- a/tests/test_fitsheader.py
+++ b/tests/test_fitsheader.py
@@ -75,6 +75,11 @@ def test_read():
     header = galsim.FitsHeader(file_name=file_name, dir=dir, hdu=0)
     check_tpv(header)
     check_pickle(header)
+    # Can also pass the hdu itself.
+    with pyfits.open(os.path.join(dir,file_name)) as hdu_list:
+        header = galsim.FitsHeader(hdu_list=hdu_list[0])
+    check_tpv(header)
+    check_pickle(header)
     # If you pass in a pyfits Header object, that should also work
     with pyfits.open(os.path.join(dir,file_name)) as hdu_list:
         header = galsim.FitsHeader(header=hdu_list[0].header)


### PR DESCRIPTION
This PR includes a number of fixes to our testing system, with the primary goal of not pinning setuptools<72 anymore.  There are a couple of security advisories about using an old setuptools version, so these should be resolved by removing the pin. ([1](https://github.com/GalSim-developers/GalSim/security/dependabot/1), [2](https://github.com/GalSim-developers/GalSim/security/dependabot/2))

* The most important change for removing the pin is that setuptools removed the test command, which we used for running the C++ tests.  So now we do that with an environment variable instead.  `GALSIM_RUN_TESTS=1 python setup.py build`
* Recent pytest versions have stopped running `setup()` before any tests in the module.  We only did this in run_examples.py, which was a holdover from when we used to use nosetests, where this was the right way to have a setup function.  It wasn't causing an error to have the setup() function, but it wasn't actually being run. Now declaring it as a pytest.fixture makes it run at the start of the module scope, which is what we want for this.
* Our test functions are all designed to be run from the tests directory, rather than the root directory.  If you run pytest from the root directory, the directory names didn't match up properly, so it gave a bunch of errors about missing files.  Another pytest fixture can be used to make sure all tests are run with tests as the working directory.  So now running pytest in the GalSim root directory works just fine.
* Fixed an error that started with numpy 2.3 related to the `**=` operator on numpy arrays.