### PR TITLE
Update calculateFWHM to be insensitive to np.argsort algorithmic details 

### DIFF
--- a/galsim/image.py
+++ b/galsim/image.py
@@ -1590,13 +1590,18 @@ class Image:
 
         # Find the first value with I < 0.5 * Imax
         k = np.argmax(data < 0.5 * Imax)
-        Ik = data[k] / Imax
+        # If there are duplicate rsq values, argmax won't be deterministic across numpy versions.
+        # To achieve consistent results, we take the average of all data values with the same rsq.
+        k2 = np.searchsorted(rsqf, rsqf[k], side='right')
+        Ik = np.mean(data[k:k2]) / Imax
 
         # Interpolate (linearly) between this and the previous value.
         if k == 0:
             rsqhm = rsqf[0] * (0.5 / Ik)
         else:
-            Ikm1 = data[k-1] / Imax
+            # Similarly, use the mean data for all rsq equal to rsqf[k-1].
+            k1 = np.searchsorted(rsqf, rsqf[k-1], side='left')
+            Ikm1 = np.mean(data[k1:k]) / Imax
             rsqhm = (rsqf[k-1] * (Ik-0.5) + rsqf[k] * (0.5-Ikm1)) / (Ik-Ikm1)
 
         # This has all been done in pixels.  So normalize according to the pixel scale.

--- a/galsim/image.py
+++ b/galsim/image.py
@@ -1794,7 +1794,10 @@ class Image:
     def __ipow__(self, other):
         if not isinstance(other, int) and not isinstance(other, float):
             raise TypeError("Can only raise an image to a float or int power!")
-        self.array[:,:] **= other
+        if not self.isinteger or isinstance(other, int):
+            self.array[:,:] **= other
+        else:
+            self.array[:,:] = self._safe_cast(self.array ** other)
         return self
 
     def __neg__(self):


### PR DESCRIPTION
@welucas2 reported on #1336 that our `calculateFWHM` calculation could return different values for different numpy versions.  Specifically with different argsort algorithmic details.

The problem occurs when the profile is centered directly on a pixel center (or corner or some other special locations) such that there are repeated rsq values.  Argsort will report one of these to be the "first" one to be farther than the half max value, but different numpy versions could report different pixels to be this location.

If the profile is symmetric and drawn directly or with fft, then this still wasn't a problem, since all data at that rsq would have the same value, so it didn't matter which one was the "first" one.  But with photon shooting or asymmetric profiles, that's not the case.

This PR updates our FWHM algorithm to compute the mean data value of all pixels with the desired rsq if there are more than one.  This should be insensitive to the details of how argsort does its thing, and also probably produce a slightly more robust answer for photon shooting, since it will average over the noise somewhat.  When the profile is slightly off-center, this will produce the same result as GalSIm has calculated in the past.