### PR TITLE
Add 3.14 testing to CI and fix one 3.14 issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
             matrix:
                 # First all python versions in basic linux
                 os: [ ubuntu-latest ]
-                py: [ 3.8, 3.9, "3.10", 3.11, 3.12, 3.13 ]
+                py: [ 3.8, 3.9, "3.10", 3.11, 3.12, 3.13, 3.14 ]
                 CC: [ gcc ]
                 CXX: [ g++ ]
                 FFTW_DIR: [ "/usr/local/lib" ]

--- a/setup.py
+++ b/setup.py
@@ -1366,7 +1366,7 @@ else:
 print('GalSim version is %s'%(galsim_version))
 
 # Write a Version.h file that has this information for people using the C++ library.
-vi = re.split('\.|-',galsim_version)
+vi = re.split(r'\.|-',galsim_version)
 version_info = tuple([int(x) for x in vi if x.isdigit()])
 if len(version_info) == 2:
     version_info = version_info + (0,)


### PR DESCRIPTION
I was able to successfully run the python unit tests with python 3.14. I noticed one warning:
```
galsim/setup.py:1369: SyntaxWarning: "\." is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\."? A raw string is also an option.
  vi = re.split('\.|-',galsim_version)
```
This PR fixes the above invalid escape (https://github.com/GalSim-developers/GalSim/pull/1335 also fixes the same regex in the same way) and adds 3.14 to the CI.

Is `main` the correct branch to target for these changes?

Also if this warrants a changelog entry please let me know where to add one. Thanks!