### PR TITLE
Multiple SED in ChromaticTransformation by absolute value of determinant

### DIFF
--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -1903,9 +1903,9 @@ class ChromaticTransformation(ChromaticObject):
             @np.vectorize
             def detjac(w):
                 return np.linalg.det(np.asarray(self._jac(w)).reshape(2,2))
-            sed *= detjac
+            sed *= np.abs(detjac)
         elif self._jac is not None:
-            sed *= np.linalg.det(np.asarray(self._jac).reshape(2,2))
+            sed *= np.abs(np.linalg.det(np.asarray(self._jac).reshape(2,2)))
 
         return sed
 

--- a/galsim/chromatic.py
+++ b/galsim/chromatic.py
@@ -1902,8 +1902,8 @@ class ChromaticTransformation(ChromaticObject):
         if hasattr(self._jac, '__call__'):
             @np.vectorize
             def detjac(w):
-                return np.linalg.det(np.asarray(self._jac(w)).reshape(2,2))
-            sed *= np.abs(detjac)
+                return np.abs(np.linalg.det(np.asarray(self._jac(w)).reshape(2,2)))
+            sed *= detjac
         elif self._jac is not None:
             sed *= np.abs(np.linalg.det(np.asarray(self._jac).reshape(2,2)))
 

--- a/tests/test_chromatic.py
+++ b/tests/test_chromatic.py
@@ -2844,6 +2844,11 @@ def test_chromatic_invariant():
     str(chrom)
     repr(chrom)
 
+    chrom = galsim.Transform(gsobj, jac = (0.5, 0.5, 1, -1), flux_ratio=bulge_SED)
+    expected_flux = flux*bulge_SED.calculateFlux(bandpass)
+    chromobj_flux = chrom.calculateFlux(bandpass)
+    np.testing.assert_allclose(expected_flux, chromobj_flux)
+
     # ChromaticOpticalPSF
     chrom_opt = galsim.ChromaticOpticalPSF(lam=500.0, diam=2.0, tip=2.0, tilt=3.0, defocus=0.2,
                                            scale_unit='arcmin')


### PR DESCRIPTION
As described in #1346 1346, the `sed()` function in the` ChromaticTransformation` class should multiply the SED by the absolute value of the determinant of the jacobian. It currently multiplies by the determinant, allowing for negative fluxes if the determinant is negative. The change here simply adds the absolute value when multiplying the SED.