### PR TITLE
fix: bug in maxk algorithm for interpolated images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,12 +201,11 @@ jobs:
 
             - name: Run unit tests
               run: |
-                # cd tests
-                pytest -vvsx -k test_interpolatedimage_maxk_python
-                # coverage run -m pytest -v
-                # pytest -v run_examples.py
-                # cd ..  # N.B. This seems to happen automatically if omitted.
-                #        # Less confusing to include it explicitly.
+                cd tests
+                coverage run -m pytest -v
+                pytest -v run_examples.py
+                cd ..  # N.B. This seems to happen automatically if omitted.
+                       # Less confusing to include it explicitly.
 
             - name: Check shared library
               if: matrix.py == 3.12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,11 +201,12 @@ jobs:
 
             - name: Run unit tests
               run: |
-                cd tests
-                coverage run -m pytest -v
-                pytest -v run_examples.py
-                cd ..  # N.B. This seems to happen automatically if omitted.
-                       # Less confusing to include it explicitly.
+                # cd tests
+                pytest -vvsx -k test_interpolatedimage_maxk_python
+                # coverage run -m pytest -v
+                # pytest -v run_examples.py
+                # cd ..  # N.B. This seems to happen automatically if omitted.
+                #        # Less confusing to include it explicitly.
 
             - name: Check shared library
               if: matrix.py == 3.12

--- a/src/SBInterpolatedImage.cpp
+++ b/src/SBInterpolatedImage.cpp
@@ -1174,9 +1174,11 @@ namespace galsim {
         for(int ix=0; ix<=max_ix; ++ix) {
             xdbg<<"Start search for ix = "<<ix<<std::endl;
             // Search along the two sides with either kx = ix or ky = ix.
+            double norm_kval = INFINITY; // something we know is above threshold
+
             for(int iy=0; iy<=ix; ++iy) {
                 // The bottom side of the square in the lower-right quadrant.
-                double norm_kval = fast_norm((*_kimage)(iy,-ix));
+                norm_kval = fast_norm((*_kimage)(iy,-ix));
                 xdbg<<"norm_kval at "<<iy<<','<<-ix<<" = "<<norm_kval<<std::endl;
                 if (norm_kval <= thresh && iy != ix && ix != No2) {
                     // The top side of the square in the upper-right quadrant.
@@ -1205,8 +1207,13 @@ namespace galsim {
                 }
             }
             xdbg<<"Done ix = "<<ix<<".  Current count = "<<n_below_thresh<<std::endl;
+            // we can get here either if the loop above finishes normally or if it hits
+            // the break statement. So we have to test the last value of norm_kval to
+            // see if the break statement was hit. If it was not, then we can increment
+            // the counter for the # below thresh.
+            if (norm_kval <= thresh) ++n_below_thresh;
             // If we get through 5 rows with nothing above the threshold, stop looking.
-            if (++n_below_thresh == 5) break;
+            if (n_below_thresh == 5) break;
         }
         xdbg<<"Finished.  maxk_ix = "<<maxk_ix<<std::endl;
         // Add 1 to get the first row that is below the threshold.

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -1890,98 +1890,55 @@ def test_drawreal_seg_fault():
     np.testing.assert_array_equal(image.array, 0)
 
 
-def _find_maxk(kim, thresh, count_thresh=True):
-    No2 = kim.xmax
-    dk = np.pi / No2
-
-    thresh *= thresh
-    max_ix = No2
-    n_below_thresh = 0
-    maxk_ix = 0
-
-    ix = 0
-    while ix <= max_ix:
-
-        iy = 0
-        while iy <= ix:
-            # The bottom side of the square in the lower-right quadrant.
-            norm_kval = kim(iy, -ix)
-            norm_kval = (norm_kval * norm_kval.conjugate()).real
-
-            if norm_kval <= thresh and iy != ix and ix != No2:
-                # The top side of the square in the upper-right quadrant.
-                norm_kval = kim(iy, ix)
-                norm_kval = (norm_kval * norm_kval.conjugate()).real
-
-            if norm_kval <= thresh and iy > 0:
-                # The right side of the square in the lower-right quadrant.
-                norm_kval = kim(ix, -iy)
-                norm_kval = (norm_kval * norm_kval.conjugate()).real
-
-            if norm_kval <= thresh and ix > 0 and iy != No2:
-                # The right side of the square in the upper-right quadrant.
-                norm_kval = kim(ix, iy)
-                norm_kval = (norm_kval * norm_kval.conjugate()).real
-
-            if norm_kval > thresh:
-                maxk_ix = ix
-                n_below_thresh = 0
-                break
-
-            iy += 1
-
-        if count_thresh:
-            if norm_kval <= thresh:
-                n_below_thresh += 1
-        else:
-            n_below_thresh += 1
-        if n_below_thresh == 5:
-            break
-
-        ix += 1
-
-    maxk_ix += 1
-    return maxk_ix * dk
-
-
 @timer
 def test_interpolatedimage_maxk_python():
     # this code makes an image where there is a gap in the fourier
-    # space image of 4 pixels where pixels go above and below the
-    # maxk threshold. Four pixels is exactly the gap needed to trigger
-    # the bug in the maxk code we are testing for.
+    # space image of a certain number pixels where pixels go above
+    # and below the maxk threshold. At five pixels, galsim should
+    # ignore the gap, but less than that it should increase maxk.
+
+    def _compute_maxk_cpp(xim, iim):
+        # this little function exists only to invoke the C++
+        # maxk code...
+        # we use copies to avoid side effects
+        ikim = xim.copy()
+        sbii = galsim._galsim.SBInterpolatedImage(
+            ikim._image,
+            ikim.bounds._b,
+            iim._pad_image.copy().bounds._b,
+            iim._x_interpolant._i,
+            iim._k_interpolant._i,
+            0,
+            0,
+            iim.gsparams._gsp,
+        )
+        sbii.calculateMaxK(0)  # this call is needed to invoke the C++ code
+        return sbii.maxK()
+
     im = galsim.Gaussian(fwhm=0.9 / 0.2).drawImage(scale=1)
-    iim = galsim.InterpolatedImage(im)
-    xim = iim._xim.copy()
-    kim = xim.calculate_fft()
-    kx, ky = kim.get_pixel_centers()
-    kx *= kim.scale
-    ky *= kim.scale
-    thresh = iim.gsparams.maxk_threshold * kim(0,0).real
-    maxk_py = _find_maxk(kim, thresh, count_thresh=True)
-    maxk_ix = np.floor(maxk_py / kim.scale).astype(int)
-    kim[maxk_ix, maxk_ix + 4] = kim[0, 0].real * 0.1
+    iim = galsim.InterpolatedImage(im, scale=1)
+    orig_maxk = _compute_maxk_cpp(iim._xim, iim)
 
-    new_im = kim.calculate_inverse_fft()
-    sbii = galsim._galsim.SBInterpolatedImage(
-        new_im._image,
-        new_im.bounds._b,
-        iim._pad_image.bounds._b,
-        iim._x_interpolant._i,
-        iim._k_interpolant._i,
-        0,
-        0,
-        iim.gsparams._gsp,
-    )
+    for offset in [3, 4, 5, 6, 7]:
+        kim = iim._xim.copy().calculate_fft()
+        kx, ky = kim.get_pixel_centers()
+        kx *= kim.scale
+        ky *= kim.scale
+        # maxk_ix is the last pixel above threshold
+        # we subtract 1 since galsim adds 1 in the C++ code
+        maxk_ix = np.floor(orig_maxk / kim.scale).astype(int) - 1
+        kim[maxk_ix, maxk_ix + offset] = kim[0, 0].real * 0.1
+        new_im = kim.calculate_inverse_fft()
+        new_maxk = _compute_maxk_cpp(new_im, iim)
 
-    maxk_py_false = _find_maxk(kim, thresh, count_thresh=False) / im.wcs._maxScale()
-    maxk_py_true = _find_maxk(kim, thresh, count_thresh=True) / im.wcs._maxScale()
-    sbii.calculateMaxK(0)
-    sbii_maxk = sbii.maxK()
+        print("offset|orig|new:", offset, orig_maxk, new_maxk)
 
-    print("galsim|pybuggy|pyfixed:", sbii_maxk, maxk_py_false, maxk_py_true)
-    assert np.abs(maxk_py_false - maxk_py_true) >= kim.scale
-    np.testing.assert_allclose(sbii_maxk, maxk_py_true, atol=1e-12, rtol=0)
+        if offset < 5:
+            # for offsets smaller than 5, we should get an offset of offset pixels
+            # in the location of maxk
+            np.testing.assert_allclose(new_maxk - orig_maxk, offset * kim.scale, atol=1e-12, rtol=0)
+        else:
+            np.testing.assert_allclose(new_maxk, orig_maxk, atol=1e-12, rtol=0)
 
 
 if __name__ == "__main__":

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -1923,12 +1923,12 @@ def _find_maxk(kim, thresh, count_thresh=True):
                 norm_kval = kim(ix, iy)
                 norm_kval = (norm_kval * norm_kval.conjugate()).real
 
-            iy += 1
-
             if norm_kval > thresh:
                 maxk_ix = ix
                 n_below_thresh = 0
                 break
+
+            iy += 1
 
         if count_thresh:
             if norm_kval <= thresh:
@@ -1950,12 +1950,10 @@ def test_interpolatedimage_maxk_python():
     # space image of 4 pixels where pixels go above and below the
     # maxk threshold. Four pixels is exactly the gap needed to trigger
     # the bug in the maxk code we are testing for.
-    im = galsim.Gaussian(fwhm=0.9).drawImage(scale=0.2)
+    im = galsim.Gaussian(fwhm=0.9 / 0.2).drawImage(scale=1)
     iim = galsim.InterpolatedImage(im)
-    orig_maxk = iim.maxk
-    kim = iim._xim.copy()
-    kim.wcs = galsim.PixelScale(1.0)
-    kim = kim.calculate_fft()
+    xim = iim._xim.copy()
+    kim = xim.calculate_fft()
     kx, ky = kim.get_pixel_centers()
     kx *= kim.scale
     ky *= kim.scale
@@ -1964,12 +1962,26 @@ def test_interpolatedimage_maxk_python():
     maxk_ix = np.floor(maxk_py / kim.scale).astype(int)
     kim[maxk_ix, maxk_ix + 4] = kim[0, 0].real * 0.1
 
+    new_im = kim.calculate_inverse_fft()
+    sbii = galsim._galsim.SBInterpolatedImage(
+        new_im._image,
+        new_im.bounds._b,
+        iim._pad_image.bounds._b,
+        iim._x_interpolant._i,
+        iim._k_interpolant._i,
+        0,
+        0,
+        iim.gsparams._gsp,
+    )
+
     maxk_py_false = _find_maxk(kim, thresh, count_thresh=False) / im.wcs._maxScale()
     maxk_py_true = _find_maxk(kim, thresh, count_thresh=True) / im.wcs._maxScale()
+    sbii.calculateMaxK(0)
+    sbii_maxk = sbii.maxK()
 
-    print("galsim|pybuggy|pyfixed:", orig_maxk, maxk_py_false, maxk_py_true)
-    assert maxk_py_false != maxk_py_true
-    assert orig_maxk == maxk_py_true
+    print("galsim|pybuggy|pyfixed:", sbii_maxk, maxk_py_false, maxk_py_true)
+    assert np.abs(maxk_py_false - maxk_py_true) >= kim.scale
+    np.testing.assert_allclose(sbii_maxk, maxk_py_true, atol=1e-12, rtol=0)
 
 
 if __name__ == "__main__":

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -1890,5 +1890,87 @@ def test_drawreal_seg_fault():
     np.testing.assert_array_equal(image.array, 0)
 
 
+def _find_maxk(kim, thresh, count_thresh=True):
+    No2 = kim.xmax
+    dk = np.pi / No2
+
+    thresh *= thresh
+    max_ix = No2
+    n_below_thresh = 0
+    maxk_ix = 0
+
+    ix = 0
+    while ix <= max_ix:
+
+        iy = 0
+        while iy <= ix:
+            # The bottom side of the square in the lower-right quadrant.
+            norm_kval = kim(iy, -ix)
+            norm_kval = (norm_kval * norm_kval.conjugate()).real
+
+            if norm_kval <= thresh and iy != ix and ix != No2:
+                # The top side of the square in the upper-right quadrant.
+                norm_kval = kim(iy, ix)
+                norm_kval = (norm_kval * norm_kval.conjugate()).real
+
+            if norm_kval <= thresh and iy > 0:
+                # The right side of the square in the lower-right quadrant.
+                norm_kval = kim(ix, -iy)
+                norm_kval = (norm_kval * norm_kval.conjugate()).real
+
+            if norm_kval <= thresh and ix > 0 and iy != No2:
+                # The right side of the square in the upper-right quadrant.
+                norm_kval = kim(ix, iy)
+                norm_kval = (norm_kval * norm_kval.conjugate()).real
+
+            iy += 1
+
+            if norm_kval > thresh:
+                maxk_ix = ix
+                n_below_thresh = 0
+                break
+
+        if count_thresh:
+            if norm_kval <= thresh:
+                n_below_thresh += 1
+        else:
+            n_below_thresh += 1
+        if n_below_thresh == 5:
+            break
+
+        ix += 1
+
+    maxk_ix += 1
+    return maxk_ix * dk
+
+
+@timer
+def test_interpolatedimage_maxk_python():
+    # this code makes an image where there is a gap in the fourier
+    # space image of 4 pixels where pixels go above and below the
+    # maxk threshold. Four pixels is exactly the gap needed to trigger
+    # the bug in the maxk code we are testing for.
+    im = galsim.Gaussian(fwhm=0.9).drawImage(scale=0.2)
+    iim = galsim.InterpolatedImage(im)
+    orig_maxk = iim.maxk
+    kim = iim._xim.copy()
+    kim.wcs = galsim.PixelScale(1.0)
+    kim = kim.calculate_fft()
+    kx, ky = kim.get_pixel_centers()
+    kx *= kim.scale
+    ky *= kim.scale
+    thresh = iim.gsparams.maxk_threshold * kim(0,0).real
+    maxk_py = _find_maxk(kim, thresh, count_thresh=True)
+    maxk_ix = np.floor(maxk_py / kim.scale).astype(int)
+    kim[maxk_ix, maxk_ix + 4] = kim[0, 0].real * 0.1
+
+    maxk_py_false = _find_maxk(kim, thresh, count_thresh=False) / im.wcs._maxScale()
+    maxk_py_true = _find_maxk(kim, thresh, count_thresh=True) / im.wcs._maxScale()
+
+    print("galsim|pybuggy|pyfixed:", orig_maxk, maxk_py_false, maxk_py_true)
+    assert maxk_py_false != maxk_py_true
+    assert orig_maxk == maxk_py_true
+
+
 if __name__ == "__main__":
     runtests(__file__)

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -1915,26 +1915,28 @@ def test_interpolatedimage_maxk_python():
         sbii.calculateMaxK(0)  # this call is needed to invoke the C++ code
         return sbii.maxK()
 
-    im = galsim.Gaussian(fwhm=0.9 / 0.2).drawImage(scale=1)
-    iim = galsim.InterpolatedImage(im, scale=1)
-    orig_maxk = _compute_maxk_cpp(iim._xim, iim)
-
+    print(" ")
     for offset in [3, 4, 5, 6, 7]:
+        im = galsim.Gaussian(fwhm=0.9 / 0.2).drawImage(scale=1)
+        iim = galsim.InterpolatedImage(im, scale=1)
+        orig_maxk = _compute_maxk_cpp(iim._xim, iim)
+
         kim = iim._xim.copy().calculate_fft()
         kx, ky = kim.get_pixel_centers()
         kx *= kim.scale
         ky *= kim.scale
-        # maxk_ix is the last pixel above threshold
-        # we subtract 1 since galsim adds 1 in the C++ code
+        # this is the last pixel above threshold. galsim adds 1
+        # to the last pixel it finds above threshold to compute orig_maxk
+        # and so we subtract 1
         maxk_ix = np.floor(orig_maxk / kim.scale).astype(int) - 1
-        kim[maxk_ix, maxk_ix + offset] = kim[0, 0].real * 0.1
+        kim[maxk_ix, maxk_ix + offset] = kim[0, 0].real
         new_im = kim.calculate_inverse_fft()
         new_maxk = _compute_maxk_cpp(new_im, iim)
 
         print("offset|orig|new:", offset, orig_maxk, new_maxk)
 
-        if offset < 5:
-            # for offsets smaller than 5, we should get an offset of offset pixels
+        if offset <= 5:
+            # for offsets <=5, we should get an offset of offset pixels
             # in the location of maxk
             np.testing.assert_allclose(new_maxk - orig_maxk, offset * kim.scale, atol=1e-12, rtol=0)
         else:

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -1894,7 +1894,7 @@ def test_drawreal_seg_fault():
 def test_interpolatedimage_maxk_kspace_pixel_gap():
     # this code makes an image where there is a gap in the fourier
     # space image of a certain number pixels where pixels go above
-    # and below the maxk threshold. At five pixels, galsim should
+    # and below the maxk threshold. At >five pixels, galsim should
     # ignore the gap, but less than that it should increase maxk.
 
     def _compute_maxk_cpp(xim, iim):

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -1891,7 +1891,7 @@ def test_drawreal_seg_fault():
 
 
 @timer
-def test_interpolatedimage_maxk_python():
+def test_interpolatedimage_maxk_kspace_pixel_gap():
     # this code makes an image where there is a gap in the fourier
     # space image of a certain number pixels where pixels go above
     # and below the maxk threshold. At five pixels, galsim should

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -1917,8 +1917,10 @@ def test_interpolatedimage_maxk_kspace_pixel_gap():
 
     print("\n| offset | orig       | new via direct C++ | new via galsim II |")
     print("|--------|------------|--------------------|-------------------|")
-    for offset in [3, 4, 5, 6, 7]:
+    for offset in [0, 3, 4, 5, 6, 7]:
         im = galsim.Gaussian(fwhm=0.9 / 0.2).drawImage(scale=1)
+        new_im = im.copy().calculate_fft().calculate_inverse_fft()
+        np.testing.assert_allclose(im.array, new_im[im.bounds].array, atol=1e-6, rtol=1e-6)
         iim = galsim.InterpolatedImage(im, scale=1)
         orig_maxk = iim.maxk
 
@@ -1930,15 +1932,19 @@ def test_interpolatedimage_maxk_kspace_pixel_gap():
         # to the last pixel it finds above threshold to compute orig_maxk
         # and so we subtract 1
         maxk_ix = np.floor(orig_maxk / kim.scale).astype(int) - 1
-        kim[maxk_ix, maxk_ix + offset] = kim[0, 0].real
+        if offset > 0:
+            kim[maxk_ix, maxk_ix + offset] = kim[0, 0].real * iim.gsparams.maxk_threshold * 2.0
         new_im = kim.calculate_inverse_fft()
         new_maxk = _compute_maxk_cpp(new_im, iim)
+
+        if offset == 0:
+            np.testing.assert_allclose(im.array, new_im[iim._image.bounds].array, atol=1e-6, rtol=1e-6)
 
         print("| % 6d | %10.6f | %18.6f | %17.6f |" % (
             offset,
             orig_maxk,
             new_maxk,
-            galsim.InterpolatedImage(new_im, scale=1).maxk),
+            galsim.InterpolatedImage(new_im[iim._image.bounds], scale=1).maxk),
         )
 
         if offset <= 5:

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -1900,7 +1900,7 @@ def test_interpolatedimage_maxk_kspace_pixel_gap():
     print("\n| offset | orig       | new                |")
     print("|--------|------------|--------------------|")
     for offset in [0, 3, 4, 5, 6, 7]:
-        im = galsim.Gaussian(fwhm=0.9 / 0.2).drawImage(scale=1)
+        im = galsim.Gaussian(fwhm=4.5).drawImage(scale=1)
         iim = galsim.InterpolatedImage(im, scale=1)
         orig_maxk = iim.maxk
 

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -1913,8 +1913,7 @@ def test_interpolatedimage_maxk_kspace_pixel_gap():
         # and so we subtract 1
         maxk_ix = np.floor(orig_maxk / kim.scale).astype(int) - 1
         if offset > 0:
-            val = kim[maxk_ix + offset, maxk_ix]
-            kim[maxk_ix + offset, maxk_ix] = val / np.abs(val) * kim[0, 0].real
+            kim[maxk_ix + offset, maxk_ix] = kim[0, 0].real
         new_im = kim.calculate_inverse_fft()
         new_maxk = galsim.InterpolatedImage(new_im, scale=1, pad_factor=1).maxk
 

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -1936,15 +1936,16 @@ def test_interpolatedimage_maxk_kspace_pixel_gap():
             kim[maxk_ix, maxk_ix + offset] = kim[0, 0].real
         new_im = kim.calculate_inverse_fft()
         new_maxk = _compute_maxk_cpp(new_im, iim)
+        new_im = new_im[iim._image.bounds]
 
         if offset == 0:
-            np.testing.assert_allclose(im.array, new_im[iim._image.bounds].array, atol=1e-6, rtol=1e-6)
+            np.testing.assert_allclose(im.array, new_im.array, atol=1e-6, rtol=1e-6)
 
         print("| % 6d | %10.6f | %18.6f | %17.6f |" % (
             offset,
             orig_maxk,
             new_maxk,
-            galsim.InterpolatedImage(new_im[iim._image.bounds], scale=1).maxk),
+            galsim.InterpolatedImage(new_im, scale=1).maxk),
         )
 
         if offset <= 5:

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -1933,7 +1933,7 @@ def test_interpolatedimage_maxk_kspace_pixel_gap():
         # and so we subtract 1
         maxk_ix = np.floor(orig_maxk / kim.scale).astype(int) - 1
         if offset > 0:
-            kim[maxk_ix, maxk_ix + offset] = kim[0, 0].real * iim.gsparams.maxk_threshold * 2.0
+            kim[maxk_ix, maxk_ix + offset] = kim[0, 0].real
         new_im = kim.calculate_inverse_fft()
         new_maxk = _compute_maxk_cpp(new_im, iim)
 

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -1897,30 +1897,10 @@ def test_interpolatedimage_maxk_kspace_pixel_gap():
     # and below the maxk threshold. At >five pixels, galsim should
     # ignore the gap, but less than that it should increase maxk.
 
-    def _compute_maxk_cpp(xim, iim):
-        # this little function exists only to invoke the C++
-        # maxk code...
-        # we use copies to avoid side effects
-        ikim = xim.copy()
-        sbii = galsim._galsim.SBInterpolatedImage(
-            ikim._image,
-            ikim.bounds._b,
-            iim._pad_image.copy().bounds._b,
-            iim._x_interpolant._i,
-            iim._k_interpolant._i,
-            0,
-            0,
-            iim.gsparams._gsp,
-        )
-        sbii.calculateMaxK(0)  # this call is needed to invoke the C++ code
-        return sbii.maxK()
-
-    print("\n| offset | orig       | new via direct C++ | new via galsim II |")
-    print("|--------|------------|--------------------|-------------------|")
+    print("\n| offset | orig       | new                |")
+    print("|--------|------------|--------------------|")
     for offset in [0, 3, 4, 5, 6, 7]:
         im = galsim.Gaussian(fwhm=0.9 / 0.2).drawImage(scale=1)
-        new_im = im.copy().calculate_fft().calculate_inverse_fft()
-        np.testing.assert_allclose(im.array, new_im[im.bounds].array, atol=1e-6, rtol=1e-6)
         iim = galsim.InterpolatedImage(im, scale=1)
         orig_maxk = iim.maxk
 
@@ -1933,19 +1913,15 @@ def test_interpolatedimage_maxk_kspace_pixel_gap():
         # and so we subtract 1
         maxk_ix = np.floor(orig_maxk / kim.scale).astype(int) - 1
         if offset > 0:
-            kim[maxk_ix, maxk_ix + offset] = kim[0, 0].real
+            val = kim[maxk_ix + offset, maxk_ix]
+            kim[maxk_ix + offset, maxk_ix] = val / np.abs(val) * kim[0, 0].real
         new_im = kim.calculate_inverse_fft()
-        new_maxk = _compute_maxk_cpp(new_im, iim)
-        new_im = new_im[iim._image.bounds]
+        new_maxk = galsim.InterpolatedImage(new_im, scale=1, pad_factor=1).maxk
 
-        if offset == 0:
-            np.testing.assert_allclose(im.array, new_im.array, atol=1e-6, rtol=1e-6)
-
-        print("| % 6d | %10.6f | %18.6f | %17.6f |" % (
+        print("| % 6d | %10.6f | %18.6f |" % (
             offset,
             orig_maxk,
-            new_maxk,
-            galsim.InterpolatedImage(new_im, scale=1).maxk),
+            new_maxk),
         )
 
         if offset <= 5:
@@ -1955,7 +1931,7 @@ def test_interpolatedimage_maxk_kspace_pixel_gap():
         else:
             np.testing.assert_allclose(new_maxk, orig_maxk, atol=1e-12, rtol=0)
 
-    print("|--------|------------|--------------------|-------------------|")
+    print("|--------|------------|--------------------|")
 
 
 if __name__ == "__main__":

--- a/tests/test_interpolatedimage.py
+++ b/tests/test_interpolatedimage.py
@@ -1915,11 +1915,12 @@ def test_interpolatedimage_maxk_kspace_pixel_gap():
         sbii.calculateMaxK(0)  # this call is needed to invoke the C++ code
         return sbii.maxK()
 
-    print(" ")
+    print("\n| offset | orig       | new via direct C++ | new via galsim II |")
+    print("|--------|------------|--------------------|-------------------|")
     for offset in [3, 4, 5, 6, 7]:
         im = galsim.Gaussian(fwhm=0.9 / 0.2).drawImage(scale=1)
         iim = galsim.InterpolatedImage(im, scale=1)
-        orig_maxk = _compute_maxk_cpp(iim._xim, iim)
+        orig_maxk = iim.maxk
 
         kim = iim._xim.copy().calculate_fft()
         kx, ky = kim.get_pixel_centers()
@@ -1933,7 +1934,12 @@ def test_interpolatedimage_maxk_kspace_pixel_gap():
         new_im = kim.calculate_inverse_fft()
         new_maxk = _compute_maxk_cpp(new_im, iim)
 
-        print("offset|orig|new:", offset, orig_maxk, new_maxk)
+        print("| % 6d | %10.6f | %18.6f | %17.6f |" % (
+            offset,
+            orig_maxk,
+            new_maxk,
+            galsim.InterpolatedImage(new_im, scale=1).maxk),
+        )
 
         if offset <= 5:
             # for offsets <=5, we should get an offset of offset pixels
@@ -1941,6 +1947,8 @@ def test_interpolatedimage_maxk_kspace_pixel_gap():
             np.testing.assert_allclose(new_maxk - orig_maxk, offset * kim.scale, atol=1e-12, rtol=0)
         else:
             np.testing.assert_allclose(new_maxk, orig_maxk, atol=1e-12, rtol=0)
+
+    print("|--------|------------|--------------------|-------------------|")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes a small algorithmic bug in computing maxk for interpolated images. 

I verified that the test failed without the bug fix.