### PR TITLE
test: fixes for precision and fragile tests from jax-galsim PR

### DIFF
--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -1097,22 +1097,22 @@ def test_shoot():
     # in exact arithmetic.  We had an assert there which blew up in a not very nice way.
     obj = galsim.Gaussian(sigma=0.2398318) + 0.1*galsim.Gaussian(sigma=0.47966352)
     obj = obj.withFlux(100001)
-    image1 = galsim.ImageF(32,32, init_value=100)
+    image1 = galsim.ImageD(32,32, init_value=100)
     rng = galsim.BaseDeviate(1234)
     obj.drawImage(image1, method='phot', poisson_flux=False, add_to_image=True, rng=rng,
                   maxN=100000)
 
     # The test here is really just that it doesn't crash.
     # But let's do something to check correctness.
-    image2 = galsim.ImageF(32,32)
+    image2 = galsim.ImageD(32,32)
     rng = galsim.BaseDeviate(1234)
     obj.drawImage(image2, method='phot', poisson_flux=False, add_to_image=False, rng=rng,
                   maxN=100000)
     image2 += 100
-    np.testing.assert_almost_equal(image2.array, image1.array, decimal=12)
+    np.testing.assert_almost_equal(image2.array, image1.array, decimal=10)
 
     # Also check that you get the same answer with a smaller maxN.
-    image3 = galsim.ImageF(32,32, init_value=100)
+    image3 = galsim.ImageD(32,32, init_value=100)
     rng = galsim.BaseDeviate(1234)
     obj.drawImage(image3, method='phot', poisson_flux=False, add_to_image=True, rng=rng, maxN=1000)
     # It's not exactly the same, since the rngs are realized in a different order.

--- a/tests/test_noise.py
+++ b/tests/test_noise.py
@@ -321,7 +321,7 @@ def test_variable_gaussian_noise():
     print('variance = ',var)
     print('getVar = ',big_vgn.var_image.array.mean())
     np.testing.assert_almost_equal(
-            var, big_vgn.var_image.array.mean(), 1,
+            var, big_vgn.var_image.array.mean(), 0,
             err_msg='Realized variance for VariableGaussianNoise did not match var_image')
 
     # Check realized variance in each mask
@@ -338,7 +338,7 @@ def test_variable_gaussian_noise():
     gal.withFlux(-1.e4).drawImage(image=big_im, add_to_image=True)
     var = np.var(big_im.array)
     np.testing.assert_almost_equal(
-            var, big_vgn.var_image.array.mean(), 1,
+            var, big_vgn.var_image.array.mean(), 0,
             err_msg='VariableGaussianNoise wrong when already an object drawn on the image')
 
     # Check picklability


### PR DESCRIPTION
This PR has suggested changes to the main galsim test suite from the JAX-GalSim changes PR (https://github.com/GalSim-developers/GalSim/pull/1252) that @rmjarvis reviewed for us a while back. 