### PR TITLE
Flip to WFI coords and document the flip

### DIFF
--- a/galsim/roman/roman_psfs.py
+++ b/galsim/roman/roman_psfs.py
@@ -290,6 +290,12 @@ def __make_aperture(SCA, pupil_plane_type, pupil_bin, wave, gsparams):
 
     pupil_plane_im = pupil_plane_im.bin(pupil_bin,pupil_bin)
 
+    #The project provides pupils in the exit frame orientation. To switch to WFI coords, we need to flip following:
+    #https://github.com/Roman-HLIS-Cosmology-PIT/PSFSim/blob/main/docs/coordinates.rst, which has the chirality
+    #looking in the telescope. Can be accomplished by flipping the vertical axis.  
+           
+    pupil_plane_im = pupil_plane_im[::-1, :]
+
     aper = Aperture(lam=wave, diam=diameter,
                     obscuration=obscuration,
                     pupil_plane_im=pupil_plane_im,

--- a/galsim/roman/roman_psfs.py
+++ b/galsim/roman/roman_psfs.py
@@ -294,7 +294,7 @@ def __make_aperture(SCA, pupil_plane_type, pupil_bin, wave, gsparams):
     #https://github.com/Roman-HLIS-Cosmology-PIT/PSFSim/blob/main/docs/coordinates.rst, which has the chirality
     #looking in the telescope. Can be accomplished by flipping the vertical axis.  
            
-    pupil_plane_im = pupil_plane_im[::-1, :]
+    pupil_plane_im = pupil_plane_im.flip_ud()
 
     aper = Aperture(lam=wave, diam=diameter,
                     obscuration=obscuration,


### PR DESCRIPTION
Flipped the coordinate system, and added some justification/documentation

The Roman PSF had been targeting the exit pupil coordinates before applying the telescope rotation and WCS.  However, that's not correct. We should be targeting WFI coordinates, which are not the same thing.  There is a flip involved, which Nihar tracked down is equivalent to just flipping the y-axis of the pupil plane image.